### PR TITLE
Use secret password for cookies

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,4 +1,4 @@
-
+cookie_password = "replace-with-strong-password"
 
 [firebase]
 type = "service_account"

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+# Requires st.secrets["cookie_password"] for secure cookie management
 web: streamlit run a1sprechen.py --server.port=$PORT --server.address=0.0.0.0

--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -140,7 +140,10 @@ SB_SESSION_TARGET = int(os.environ.get("SB_SESSION_TARGET", 5))
 
 
 cookie_manager = bootstrap_cookie_manager(
-    EncryptedCookieManager(prefix="falowen")
+    EncryptedCookieManager(
+        password=st.secrets["cookie_password"],
+        prefix="falowen",
+    )
 )
 
 if os.environ.get("RENDER"):


### PR DESCRIPTION
## Summary
- use `st.secrets["cookie_password"]` when initializing `EncryptedCookieManager`
- document required `cookie_password` in Streamlit deployment config
- note secret requirement in Procfile

## Testing
- `pytest -q`
- `STREAMLIT_SECRETS='{"cookie_password":"test"}' streamlit run a1sprechen.py --server.headless true --server.port=8501 --server.address=0.0.0.0`

------
https://chatgpt.com/codex/tasks/task_e_68b05f7d055c83218fd5f4b5c630c2a0