### PR TITLE
Add fallback for cookie password and document deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-# Requires st.secrets["cookie_password"] for secure cookie management
+# Requires st.secrets["cookie_password"] or the COOKIE_PASSWORD env var for secure cookie management
 web: streamlit run a1sprechen.py --server.port=$PORT --server.address=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# A1Sprechen
+
+## Deployment
+
+Set the cookie encryption password either in Streamlit secrets or via an environment variable:
+
+```
+[secrets]
+cookie_password = "<strong-secret>"
+```
+
+or
+
+```
+export COOKIE_PASSWORD=<strong-secret>
+```
+
+This value is required for secure cookie management.

--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -140,7 +140,13 @@ SB_SESSION_TARGET = int(os.environ.get("SB_SESSION_TARGET", 5))
 
 cookie_password = st.secrets.get("cookie_password")
 if cookie_password is None:
-    raise RuntimeError("Missing 'cookie_password' in Streamlit secrets.")
+    cookie_password = os.environ.get("COOKIE_PASSWORD")
+if cookie_password is None:
+    st.error(
+        "Missing cookie password. Set `cookie_password` in `.streamlit/secrets.toml` "
+        "or define the `COOKIE_PASSWORD` environment variable."
+    )
+    st.stop()
 
 cookie_manager = bootstrap_cookie_manager(
     EncryptedCookieManager(


### PR DESCRIPTION
## Summary
- Fallback to `COOKIE_PASSWORD` env var when Streamlit secret is missing and show a helpful Streamlit error
- Clarify deployment instructions about the required cookie password

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0757024208321934805cd7351b26c