### PR TITLE
Remove deprecated Streamlit ui config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -5,6 +5,3 @@ backgroundColor = "#f3f7fb"
 secondaryBackgroundColor = "#eef3fc"
 textColor = "#1a2340"
 font = "sans serif"
-
-[ui]
-customTheme = false   # enables the user theme switcher


### PR DESCRIPTION
## Summary
- remove unsupported [ui] section from Streamlit config

## Testing
- `streamlit run a1sprechen.py --server.headless true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0759609f083218e425c8ccbd6fbaa