### PR TITLE
feat: make test cookie manager mapping

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -6,21 +6,48 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from threading import Lock
 from typing import Any, Callable, Optional
+from collections.abc import MutableMapping
 
 
 @dataclass
-class SimpleCookieManager:
+class SimpleCookieManager(MutableMapping[str, Any]):
     """Minimal in-memory cookie store used for tests.
 
     The real application uses the ``streamlit_cookies_manager`` package to
     persist cookies in the browser. For unit tests we only need a tiny subset
-    of the interface, so this class stores cookie values in memory.
+    of the interface, so this class stores cookie values in memory while
+    behaving like a :class:`MutableMapping`.
     """
+
     store: dict[str, dict[str, Any]] = field(default_factory=dict)
 
+    # -- Mapping protocol -------------------------------------------------
+    def __getitem__(self, key: str) -> Any:  # pragma: no cover - trivial
+        return self.store[key]["value"]
+
+    def __setitem__(self, key: str, value: Any) -> None:  # pragma: no cover - trivial
+        self.store[key] = {"value": value, "kwargs": {}}
+
+    def __delitem__(self, key: str) -> None:  # pragma: no cover - trivial
+        self.store.pop(key, None)
+
+    def __iter__(self):  # pragma: no cover - trivial
+        return iter(self.store)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.store)
+
+    # --------------------------------------------------------------------
+    def pop(self, key: str, default: Any | None = None) -> Any | None:  # pragma: no cover -
+        item = self.store.pop(key, None)
+        if item is None:
+            return default
+        return item.get("value")
+
     def set(self, key: str, value: Any, **kwargs: Any) -> None:  # pragma: no cover -
-        """Store ``value`` and any options under ``key``."""
-        self.store[key] = {"value": value, "kwargs": kwargs}
+        """Backwards-compatible setter storing ``value`` and options."""
+        self[key] = value
+        self.store[key]["kwargs"] = kwargs
 
     def get(self, key: str, default: Any | None = None) -> Any | None:  # pragma: no cover -
         """Return the stored value for ``key`` or ``default`` if missing."""
@@ -31,7 +58,10 @@ class SimpleCookieManager:
 
     def delete(self, key: str) -> None:  # pragma: no cover -
         """Remove ``key`` from the store if present."""
-        self.store.pop(key, None)
+        self.pop(key, None)
+
+    def clear(self) -> None:  # pragma: no cover - trivial
+        self.store.clear()
 
     def save(self) -> None:  # pragma: no cover -
         """Persist cookies (no-op for tests)."""
@@ -43,34 +73,43 @@ def create_cookie_manager() -> SimpleCookieManager:
     return SimpleCookieManager()
 
 
-def set_student_code_cookie(cm: SimpleCookieManager, code: str, **kwargs: Any) -> None:
+def set_student_code_cookie(cm: MutableMapping[str, Any], code: str, **kwargs: Any) -> None:
     """Store the student code in a cookie and persist the change."""
     cookie_args = {"httponly": True, "secure": True, "samesite": "Strict"}
     cookie_args.update(kwargs)
-    cm.set("student_code", code, **cookie_args)
+    cm["student_code"] = code
+    # ``SimpleCookieManager`` tracks cookie options for test assertions.
+    if hasattr(cm, "store"):
+        store = getattr(cm, "store", {})
+        if isinstance(store, dict) and "student_code" in store:
+            store["student_code"]["kwargs"] = cookie_args
     try:  # pragma: no cover - save rarely fails but we defend against it
-        cm.save()
+        cm.save()  # type: ignore[attr-defined]
     except Exception:
         logging.error("Failed to save student code cookie", exc_info=True)
 
 
-def set_session_token_cookie(cm: SimpleCookieManager, token: str, **kwargs: Any) -> None:
+def set_session_token_cookie(cm: MutableMapping[str, Any], token: str, **kwargs: Any) -> None:
     """Store the session token in a cookie and persist the change."""
     cookie_args = {"httponly": True, "secure": True, "samesite": "Strict"}
     cookie_args.update(kwargs)
-    cm.set("session_token", token, **cookie_args)
+    cm["session_token"] = token
+    if hasattr(cm, "store"):
+        store = getattr(cm, "store", {})
+        if isinstance(store, dict) and "session_token" in store:
+            store["session_token"]["kwargs"] = cookie_args
     try:  # pragma: no cover - save rarely fails but we defend against it
-        cm.save()
+        cm.save()  # type: ignore[attr-defined]
     except Exception:
         logging.exception("Failed to save session token cookie")
 
 
-def clear_session(cm: SimpleCookieManager) -> None:
+def clear_session(cm: MutableMapping[str, Any]) -> None:
     """Remove session-related cookies and persist the change."""
-    cm.delete("student_code")
-    cm.delete("session_token")
+    cm.pop("student_code", None)
+    cm.pop("session_token", None)
     try:  # persist cookie deletions
-        cm.save()
+        cm.save()  # type: ignore[attr-defined]
     except Exception as exc:  # pragma: no cover - defensive
         logging.warning("Failed to persist cleared cookies: %s", exc)
 

--- a/tests/test_session_restore.py
+++ b/tests/test_session_restore.py
@@ -31,8 +31,8 @@ def test_cookies_keep_user_logged_in_after_reload():
     cookie_manager.store.clear()
 
     # Pretend the user previously logged in and cookies were set
-    set_student_code_cookie(cookie_manager, "abc")
-    set_session_token_cookie(cookie_manager, "tok123")
+    cookie_manager["student_code"] = "abc"
+    cookie_manager["session_token"] = "tok123"
 
     # Stub ``validate_session_token`` to accept our token without needing
     # external services.
@@ -97,8 +97,8 @@ def test_session_not_restored_if_contract_expired():
     st.session_state.clear()
     cookie_manager.store.clear()
 
-    set_student_code_cookie(cookie_manager, "abc")
-    set_session_token_cookie(cookie_manager, "tok123")
+    cookie_manager["student_code"] = "abc"
+    cookie_manager["session_token"] = "tok123"
 
     stub_sessions = types.SimpleNamespace(
         validate_session_token=lambda token, ua_hash="": {"student_code": "abc"}
@@ -134,8 +134,8 @@ def test_session_not_restored_when_student_code_mismatch():
     cookie_manager.store.clear()
 
     # Cookies indicate a previous login
-    set_student_code_cookie(cookie_manager, "abc")
-    set_session_token_cookie(cookie_manager, "tok123")
+    cookie_manager["student_code"] = "abc"
+    cookie_manager["session_token"] = "tok123"
 
     # Stub validation to return a *different* student code
     called: list[str] = []
@@ -168,8 +168,8 @@ def test_session_rejected_when_user_agent_hash_mismatch():
     cookie_manager.store.clear()
 
     # Cookies indicate a previous login
-    set_student_code_cookie(cookie_manager, "abc")
-    set_session_token_cookie(cookie_manager, "tok123")
+    cookie_manager["student_code"] = "abc"
+    cookie_manager["session_token"] = "tok123"
 
     # Stash an incorrect UA hash
     st.session_state["__ua_hash"] = "wrong_hash"
@@ -202,8 +202,8 @@ def test_logout_clears_cookies_and_revokes_token():
 
     # Simulate an active session
     st.session_state["session_token"] = "tok123"
-    set_student_code_cookie(cookie_manager, "abc")
-    set_session_token_cookie(cookie_manager, "tok123")
+    cookie_manager["student_code"] = "abc"
+    cookie_manager["session_token"] = "tok123"
 
     # Logout sequence
     destroy_session_token(st.session_state["session_token"])
@@ -231,15 +231,15 @@ def test_relogin_replaces_session_and_clears_old_token():
 
     # Existing login (old user)
     st.session_state["session_token"] = "tok_old"
-    set_student_code_cookie(cookie_manager, "old")
-    set_session_token_cookie(cookie_manager, "tok_old")
+    cookie_manager["student_code"] = "old"
+    cookie_manager["session_token"] = "tok_old"
 
     # User logs in as different student
     destroy_session_token(st.session_state.get("session_token"))
     clear_session(cookie_manager)
     st.session_state["session_token"] = "tok_new"
-    set_student_code_cookie(cookie_manager, "new")
-    set_session_token_cookie(cookie_manager, "tok_new")
+    cookie_manager["student_code"] = "new"
+    cookie_manager["session_token"] = "tok_new"
 
     assert destroyed == ["tok_old"]
     assert cookie_manager.get("student_code") == "new"
@@ -257,8 +257,8 @@ def test_clear_session_persists_cookie_deletion():
             self.saved = True
 
     cm = TrackingCookieManager()
-    set_student_code_cookie(cm, "abc")
-    set_session_token_cookie(cm, "tok123")
+    cm["student_code"] = "abc"
+    cm["session_token"] = "tok123"
     clear_session(cm)
 
     assert cm.get("student_code") is None
@@ -311,11 +311,11 @@ def test_multiple_cookie_managers_are_isolated():
     cm1 = create_cookie_manager()
     cm2 = create_cookie_manager()
 
-    set_student_code_cookie(cm1, "stuA")
-    set_session_token_cookie(cm1, "tokA")
+    cm1["student_code"] = "stuA"
+    cm1["session_token"] = "tokA"
 
-    set_student_code_cookie(cm2, "stuB")
-    set_session_token_cookie(cm2, "tokB")
+    cm2["student_code"] = "stuB"
+    cm2["session_token"] = "tokB"
 
     assert cm1.get("student_code") == "stuA"
     assert cm1.get("session_token") == "tokA"


### PR DESCRIPTION
## Summary
- make `SimpleCookieManager` act like a MutableMapping
- rewrite auth helpers to use mapping operations
- adjust session restore tests to manipulate cookies via mapping API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b079ef39248321af72bfc1b1c1882f