### PR TITLE
Fix EncryptedCookieManager import path

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -28,7 +28,7 @@ import requests
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 import streamlit.components.v1 as components
-from streamlit_cookies_manager import EncryptedCookieManager
+from streamlit_cookies_manager.encrypted_cookie_manager import EncryptedCookieManager
 from docx import Document
 from google.cloud.firestore_v1 import FieldFilter
 from google.api_core.exceptions import GoogleAPICallError


### PR DESCRIPTION
## Summary
- fix EncryptedCookieManager import path for streamlit_cookies_manager

## Testing
- `python - <<'PY'
from streamlit_cookies_manager.encrypted_cookie_manager import EncryptedCookieManager
cm = EncryptedCookieManager(password='abc', prefix='falowen')
print('initialized:', isinstance(cm, EncryptedCookieManager))
PY`
- `pytest -q` *(fails: RecursionError: maximum recursion depth exceeded in tests/test_auth_cookie_logging.py::test_set_student_code_cookie_logs_error, tests/test_auth_cookie_logging.py::test_set_session_token_cookie_logs_error, tests/test_session_restore.py::test_cookies_keep_user_logged_in_after_reload, tests/test_session_restore.py::test_session_not_restored_if_contract_expired, tests/test_session_restore.py::test_session_not_restored_when_student_code_mismatch, tests/test_session_restore.py::test_session_rejected_when_user_agent_hash_mismatch, tests/test_session_restore.py::test_logout_clears_cookies_and_revokes_token, tests/test_session_restore.py::test_relogin_replaces_session_and_clears_old_token, tests/test_session_restore.py::test_clear_session_persists_cookie_deletion, tests/test_session_restore.py::test_set_cookie_functions_persist_changes, tests/test_session_restore.py::test_cookie_functions_apply_defaults_and_allow_override, tests/test_session_restore.py::test_multiple_cookie_managers_are_isolated)*

------
https://chatgpt.com/codex/tasks/task_e_68b080ffdb8c8321b4a559570e770fb5