### PR TITLE
Collapse first Streamlit block to remove top padding

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -218,12 +218,10 @@ st.markdown("""
   padding-top: 0 !important;
 }
 
-/* First rendered block (often a head-inject) — keep a small gap only */
+/* First rendered block (often a head-inject) — collapse fully */
 [data-testid="stAppViewContainer"] .main .block-container > div:first-child {
-  margin-top: 0 !important;
-  margin-bottom: 8px !important;   /* was 24px */
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
 }
 
 /* If that first block is an iframe, collapse it completely */


### PR DESCRIPTION
## Summary
- Collapse initial Streamlit block to eliminate top margin/padding so login page content sits flush with viewport top

## Testing
- `pytest` *(fails: RecursionError in cookie manager)*
- `streamlit run a1sprechen.py --server.headless true --server.port 8501` *(login page visual check attempted; browser tools unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b084736e7883218873920d227dc4a2