### PR TITLE
refactor: cache vocab stats data

### DIFF
--- a/src/stats.py
+++ b/src/stats.py
@@ -236,7 +236,6 @@ def get_vocab_stats(student_code: str):
         total_sessions = data.get("total_sessions")
         if total_sessions is None:
             total_sessions = len(history)
-        data = doc.to_dict() or {}
         return {
             "history": history,
             "last_practiced": data.get("last_practiced"),


### PR DESCRIPTION
## Summary
- avoid duplicated `doc.to_dict()` calls in `get_vocab_stats`

## Testing
- `PYTHONPATH=. pytest tests/test_stats.py`

------
https://chatgpt.com/codex/tasks/task_e_68b08b4e02dc8321a0b33d6bf8e6ef2e