### PR TITLE
Refactor a1sprechen into modular components

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -1,0 +1,525 @@
+"""Assignment results and resources tab helpers."""
+
+from __future__ import annotations
+
+import base64 as _b64
+import io
+import re
+import tempfile
+from typing import Tuple
+
+import pandas as pd
+import requests
+import streamlit as st
+from fpdf import FPDF
+
+from .assignment import linkify_html, _clean_link, _is_http_url
+from .schedule import get_level_schedules as _get_level_schedules
+
+# ---------------------------------------------------------------------------
+# Data loaders
+# ---------------------------------------------------------------------------
+
+@st.cache_data(ttl=600)
+def _load_assignment_scores_cached() -> pd.DataFrame:
+    SHEET_ID = "1BRb8p3Rq0VpFCLSwL4eS9tSgXBo9hSWzfW_J_7W36NQ"
+    url = f"https://docs.google.com/spreadsheets/d/{SHEET_ID}/gviz/tq?tqx=out:csv&sheet=Sheet1"
+    df = pd.read_csv(url, dtype=str)
+    df.columns = df.columns.str.strip().str.lower()
+    for col in df.columns:
+        df[col] = df[col].astype(str).str.strip()
+    return df
+
+
+def load_assignment_scores() -> pd.DataFrame:
+    """Return assignment scores DataFrame cached in session state."""
+    if "assignment_scores_df" not in st.session_state:
+        st.session_state["assignment_scores_df"] = _load_assignment_scores_cached()
+    return st.session_state["assignment_scores_df"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers used by the Results & Resources tab
+# ---------------------------------------------------------------------------
+
+# Score labels are reused in the PDF export; keep logic in one place.
+def score_label_fmt(score, *, plain: bool = False) -> str:
+    try:
+        s = float(score)
+    except Exception:
+        return "" if not plain else "Needs Improvement"
+    if s >= 90:
+        return "Excellent 🌟" if not plain else "Excellent"
+    if s >= 75:
+        return "Good 👍" if not plain else "Good"
+    if s >= 60:
+        return "Sufficient ✔️" if not plain else "Sufficient"
+    return "Needs Improvement ❗" if not plain else "Needs Improvement"
+
+
+def clean_for_pdf(text: str) -> str:
+    import unicodedata as _ud
+
+    if not isinstance(text, str):
+        text = str(text)
+    text = _ud.normalize("NFKD", text)
+    text = "".join(c if 32 <= ord(c) <= 255 else "?" for c in text)
+    return text.replace("\n", " ").replace("\r", " ")
+
+
+def _results_csv_url() -> str:
+    try:
+        u = (
+            st.secrets.get("results", {}).get("csv_url", "")
+            if hasattr(st, "secrets")
+            else ""
+        ).strip()
+        if u:
+            return u
+    except Exception:
+        pass
+    return "https://docs.google.com/spreadsheets/d/1BRb8p3Rq0VpFCLSwL4eS9tSgXBo9hSWzfW_J_7W36NQ/gviz/tq?tqx=out:csv"
+
+
+@st.cache_data(ttl=600)
+def fetch_scores(csv_url: str) -> pd.DataFrame:
+    resp = requests.get(csv_url, timeout=8)
+    resp.raise_for_status()
+    df = pd.read_csv(io.StringIO(resp.text), engine="python")
+    df.columns = [
+        str(c).strip().lower().replace("studentcode", "student_code")
+        for c in df.columns
+    ]
+    aliases = {
+        "assignment/chapter": "assignment",
+        "chapter": "assignment",
+        "score (%)": "score",
+    }
+    for src, dst in aliases.items():
+        if src in df.columns and dst not in df.columns:
+            df = df.rename(columns={src: dst})
+    required = ["student_code", "name", "assignment", "score", "date", "level"]
+    if not set(required).issubset(df.columns):
+        return pd.DataFrame(columns=required)
+    df = df.dropna(subset=["student_code", "assignment", "score", "date", "level"])
+    return df
+
+
+def _get_current_student() -> Tuple[str, str, str]:
+    row = st.session_state.get("student_row") or {}
+    code = (
+        row.get("StudentCode")
+        or st.session_state.get("student_code", "")
+        or ""
+    ).strip()
+    name = (
+        row.get("Name") or st.session_state.get("student_name", "") or ""
+    ).strip()
+    level = (row.get("Level") or "").strip().upper()
+    return code, name, level
+
+
+# ---------------------------------------------------------------------------
+# Main renderer
+# ---------------------------------------------------------------------------
+
+def render_results_and_resources_tab() -> None:
+    """Render the "My Results & Resources" tab."""
+
+    st.markdown(
+        """
+        <div style="
+            padding: 8px 12px;
+            background: #17a2b8;
+            color: #fff;
+            border-radius: 6px;
+            text-align: center;
+            margin-bottom: 8px;
+            font-size: 1.3rem;
+        ">
+            📊 My Results & Resources
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+    st.divider()
+
+    GOOGLE_SHEET_CSV = _results_csv_url()
+
+    top_cols = st.columns([1, 1, 2])
+    with top_cols[0]:
+        if st.button("🔄 Refresh"):
+            st.cache_data.clear()
+            st.success("Cache cleared! Reloading…")
+            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+
+    df_scores = fetch_scores(GOOGLE_SHEET_CSV)
+    required_cols = {
+        "student_code",
+        "name",
+        "assignment",
+        "score",
+        "date",
+        "level",
+    }
+    if not required_cols.issubset(df_scores.columns):
+        st.error("Data format error. Please contact support.")
+        st.write("Columns found:", df_scores.columns.tolist())
+        st.stop()
+
+    student_code, student_name, _ = _get_current_student()
+    code_key = (student_code or "").lower().strip()
+
+    df_user = df_scores[
+        df_scores.student_code.astype(str).str.lower().str.strip() == code_key
+    ]
+    if df_user.empty:
+        st.info("No results yet. Complete an assignment to see your scores!")
+        st.stop()
+
+    df_user = df_user.copy()
+    df_user["level"] = df_user["level"].astype(str).str.upper().str.strip()
+    levels = sorted(df_user["level"].unique())
+    level = st.selectbox("Select level:", levels)
+    df_lvl = df_user[df_user.level == level].copy()
+    df_lvl["score"] = pd.to_numeric(df_lvl["score"], errors="coerce")
+
+    totals = {"A1": 18, "A2": 29, "B1": 28, "B2": 24, "C1": 24}
+    total = int(totals.get(level, 0))
+    completed = int(df_lvl["assignment"].nunique())
+    avg_score = float(df_lvl["score"].mean() or 0)
+    best_score = float(df_lvl["score"].max() or 0)
+
+    df_display = (
+        df_lvl.sort_values(["assignment", "score"], ascending=[True, False])
+        .reset_index(drop=True)
+    )
+    if "comments" not in df_display.columns:
+        df_display["comments"] = ""
+    if "link" not in df_display.columns:
+        df_display["link"] = ""
+
+    schedules_map = _get_level_schedules()
+    schedule = schedules_map.get(level, [])
+
+    if "rr_page" not in st.session_state:
+        st.session_state["rr_page"] = "Overview"
+    if "rr_prev_page" not in st.session_state:
+        st.session_state["rr_prev_page"] = st.session_state["rr_page"]
+
+    def on_rr_page_change() -> None:
+        st.session_state["rr_prev_page"] = st.session_state.get("rr_page")
+
+    rr_page = st.radio(
+        "Results & Resources section",
+        ["Overview", "My Scores", "Badges", "Missed & Next", "PDF", "Resources"],
+        horizontal=True,
+        key="rr_page",
+        on_change=on_rr_page_change,
+    )
+
+    if rr_page == "Overview":
+        st.subheader("Quick Overview")
+        c1, c2, c3, c4 = st.columns(4)
+        c1.metric("Total Assignments", total)
+        c2.metric("Completed", completed)
+        c3.metric("Average Score", f"{avg_score:.1f}")
+        c4.metric("Best Score", f"{best_score:.0f}")
+
+        st.markdown("---")
+        st.markdown("**Latest 5 results**")
+        latest = df_display.head(5)
+        for _, row in latest.iterrows():
+            perf = score_label_fmt(row["score"])
+            st.markdown(
+                f"""
+                <div style="margin-bottom: 12px;">
+                    <span style="font-size:1.05em;font-weight:600;">{row['assignment']}</span><br>
+                    Score: <b>{row['score']}</b> <span style='margin-left:12px;'>{perf}</span>
+                    | Date: {row['date']}
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
+        if len(df_display) > 5:
+            st.caption("See the **Assignments** tab for the full list and feedback.")
+
+    elif rr_page == "My Scores":
+        st.subheader("All Assignments & Feedback")
+        base_cols = ["assignment", "score", "date", "comments", "link"]
+        for _, row in df_display[base_cols].iterrows():
+            perf = score_label_fmt(row["score"])
+            comment_html = linkify_html(row["comments"])
+            ref_link = _clean_link(row.get("link"))
+            show_ref = bool(ref_link) and _is_http_url(ref_link) and pd.notna(
+                pd.to_numeric(row["score"], errors="coerce")
+            )
+
+            st.markdown(
+                f"""
+                <div style="margin-bottom: 18px;">
+                    <span style="font-size:1.05em;font-weight:600;">{row['assignment']}</span><br>
+                    Score: <b>{row['score']}</b> <span style='margin-left:12px;'>{perf}</span>
+                    | Date: {row['date']}<br>
+                    <div style='margin:8px 0; padding:10px 14px; background:#f2f8fa; border-left:5px solid #007bff; border-radius:7px; color:#333; font-size:1em;'>
+                        <b>Feedback:</b> {comment_html}
+                    </div>
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
+            if show_ref:
+                st.markdown(
+                    f'🔍 <a href="{ref_link}" target="_blank" rel="noopener">View answer reference (Lesen & Hören)</a>',
+                    unsafe_allow_html=True,
+                )
+            st.divider()
+
+    elif rr_page == "Badges":
+        st.subheader("Badges & Trophies")
+        with st.expander("What badges can you earn?", expanded=False):
+            st.markdown(
+                """
+                - 🏆 **Completion Trophy**: Finish all assignments for your level.
+                - 🥇 **Gold Badge**: Maintain an average score above 80.
+                - 🥈 **Silver Badge**: Average score above 70.
+                - 🥉 **Bronze Badge**: Average score above 60.
+                - 🌟 **Star Performer**: Score 85 or higher on any assignment.
+                """
+            )
+
+        badge_count = 0
+        if completed >= total and total > 0:
+            st.success("🏆 **Congratulations!** You have completed all assignments for this level!")
+            badge_count += 1
+        if avg_score >= 90:
+            st.info("🥇 **Gold Badge:** Average score above 90!")
+            badge_count += 1
+        elif avg_score >= 75:
+            st.info("🥈 **Silver Badge:** Average score above 75!")
+            badge_count += 1
+        elif avg_score >= 60:
+            st.info("🥉 **Bronze Badge:** Average score above 60!")
+            badge_count += 1
+        if best_score >= 95:
+            st.info("🌟 **Star Performer:** You scored 95 or above on an assignment!")
+            badge_count += 1
+        if badge_count == 0:
+            st.warning("No badges yet. Complete more assignments to earn badges!")
+
+    elif rr_page == "Missed & Next":
+        st.subheader("Missed Assignments & Next Recommendation")
+
+        def _extract_all_nums(chapter_str: str):
+            parts = re.split(r"[_\s,;]+", str(chapter_str))
+            nums = []
+            for part in parts:
+                m = re.search(r"\d+(?:\.\d+)?", part)
+                if m:
+                    nums.append(float(m.group()))
+            return nums
+
+        completed_nums = set()
+        for _, row in df_lvl.iterrows():
+            for num in _extract_all_nums(row["assignment"]):
+                completed_nums.add(num)
+        last_num = max(completed_nums) if completed_nums else 0.0
+
+        skipped_assignments = []
+        for lesson in schedule:
+            chapter_field = lesson.get("chapter", "")
+            lesson_nums = _extract_all_nums(chapter_field)
+            day = lesson.get("day", "")
+            has_assignment = lesson.get("assignment", False)
+            for chap_num in lesson_nums:
+                if has_assignment and chap_num < last_num and chap_num not in completed_nums:
+                    skipped_assignments.append(
+                        f"Day {day}: Chapter {chapter_field} – {lesson.get('topic','')}"
+                    )
+                    break
+
+        if skipped_assignments:
+            st.markdown(
+                f"""
+                <div style="
+                    background-color: #fff3cd;
+                    border-left: 6px solid #ffecb5;
+                    color: #7a6001;
+                    padding: 16px 18px;
+                    border-radius: 8px;
+                    margin: 12px 0;
+                    font-size: 1.05em;">
+                    <b>⚠️ You have skipped the following assignments.<br>
+                    Please complete them for full progress:</b><br>
+                    {"<br>".join(skipped_assignments)}
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
+        else:
+            st.success("No missed assignments detected. Great job!")
+
+        def _is_recommendable(lesson: dict) -> bool:
+            topic = str(lesson.get("topic", "")).lower()
+            return not ("schreiben" in topic and "sprechen" in topic)
+
+        def _extract_max_num(chapter: str):
+            nums = re.findall(r"\d+(?:\.\d+)?", str(chapter))
+            return max([float(n) for n in nums], default=None)
+
+        completed_chapters = []
+        for a in df_lvl["assignment"]:
+            n = _extract_max_num(a)
+            if n is not None:
+                completed_chapters.append(n)
+        last_num2 = max(completed_chapters) if completed_chapters else 0.0
+
+        next_assignment = None
+        for lesson in schedule:
+            chap_num = _extract_max_num(lesson.get("chapter", ""))
+            if not _is_recommendable(lesson):
+                continue
+            if chap_num and chap_num > last_num2:
+                next_assignment = lesson
+                break
+        if next_assignment:
+            st.info(
+                f"**Your next recommended assignment:**\n\n"
+                f"**Day {next_assignment.get('day','?')}: {next_assignment.get('chapter','?')} – {next_assignment.get('topic','')}**\n\n"
+                f"**Goal:** {next_assignment.get('goal','')}\n\n"
+                f"**Instruction:** {next_assignment.get('instruction','')}"
+            )
+        else:
+            st.success("🎉 You’re up to date!")
+
+    elif rr_page == "PDF":
+        st.subheader("Download PDF Summary")
+        COL_ASSN_W, COL_SCORE_W, COL_DATE_W = 45, 18, 30
+        PAGE_WIDTH, MARGIN = 210, 10
+        FEEDBACK_W = PAGE_WIDTH - 2 * MARGIN - (COL_ASSN_W + COL_SCORE_W + COL_DATE_W)
+        LOGO_URL = "https://i.imgur.com/iFiehrp.png"
+
+        @st.cache_data(ttl=3600)
+        def fetch_logo():
+            try:
+                r = requests.get(LOGO_URL, timeout=6)
+                r.raise_for_status()
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+                tmp.write(r.content)
+                tmp.flush()
+                return tmp.name
+            except Exception:
+                return None
+
+        class PDFReport(FPDF):
+            def header(self):
+                logo_path = fetch_logo()
+                if logo_path:
+                    try:
+                        self.image(logo_path, 10, 8, 30)
+                        self.ln(20)
+                    except Exception:
+                        self.ln(20)
+                else:
+                    self.ln(28)
+                self.set_font("Arial", "B", 16)
+                self.cell(0, 12, clean_for_pdf("Learn Language Education Academy"), ln=1, align="C")
+                self.ln(3)
+
+            def footer(self):
+                self.set_y(-15)
+                self.set_font("Arial", "I", 9)
+                self.set_text_color(120, 120, 120)
+                footer_text = clean_for_pdf(
+                    "Learn Language Education Academy — Results generated on "
+                ) + pd.Timestamp.now().strftime("%d.%m.%Y")
+                self.cell(0, 8, footer_text, 0, 0, "C")
+                self.set_text_color(0, 0, 0)
+                self.alias_nb_pages()
+
+        if st.button("⬇️ Create & Download PDF"):
+            pdf = PDFReport()
+            pdf.add_page()
+
+            pdf.set_font("Arial", "", 12)
+            try:
+                shown_name = df_user.name.iloc[0]
+            except Exception:
+                shown_name = student_name or "Student"
+            pdf.cell(0, 8, clean_for_pdf(f"Name: {shown_name}"), ln=1)
+            pdf.cell(0, 8, clean_for_pdf(f"Code: {code_key}     Level: {level}"), ln=1)
+            pdf.cell(0, 8, clean_for_pdf(f"Date: {pd.Timestamp.now():%Y-%m-%d %H:%M}"), ln=1)
+            pdf.ln(5)
+
+            pdf.set_font("Arial", "B", 13)
+            pdf.cell(0, 10, clean_for_pdf("Summary Metrics"), ln=1)
+            pdf.set_font("Arial", "", 11)
+            pdf.cell(
+                0,
+                8,
+                clean_for_pdf(
+                    f"Total: {total}   Completed: {completed}   Avg: {avg_score:.1f}   Best: {best_score:.0f}"
+                ),
+                ln=1,
+            )
+            pdf.ln(6)
+
+            pdf.set_font("Arial", "B", 11)
+            pdf.cell(COL_ASSN_W, 8, "Assignment", 1, 0, "C")
+            pdf.cell(COL_SCORE_W, 8, "Score", 1, 0, "C")
+            pdf.cell(COL_DATE_W, 8, "Date", 1, 0, "C")
+            pdf.cell(FEEDBACK_W, 8, "Feedback", 1, 1, "C")
+
+            pdf.set_font("Arial", "", 10)
+            row_fill = False
+            for _, row in df_display.iterrows():
+                assn = clean_for_pdf(str(row["assignment"]))
+                score_txt = clean_for_pdf(str(row["score"]))
+                date_txt = clean_for_pdf(str(row["date"]))
+                label = clean_for_pdf(score_label_fmt(row["score"], plain=True))
+                pdf.cell(COL_ASSN_W, 8, assn, 1, 0, "L", row_fill)
+                pdf.cell(COL_SCORE_W, 8, score_txt, 1, 0, "C", row_fill)
+                pdf.cell(COL_DATE_W, 8, date_txt, 1, 0, "C", row_fill)
+                pdf.multi_cell(FEEDBACK_W, 8, label, 1, "C", row_fill)
+                row_fill = not row_fill
+
+            pdf_bytes = pdf.output(dest="S").encode("latin1", "replace")
+            st.download_button(
+                label="Download PDF",
+                data=pdf_bytes,
+                file_name=f"{code_key}_results_{level}.pdf",
+                mime="application/pdf",
+            )
+            b64 = _b64.b64encode(pdf_bytes).decode()
+            st.markdown(
+                f'<a href="data:application/pdf;base64,{b64}" download="{code_key}_results_{level}.pdf" '
+                f'style="font-size:1.1em;font-weight:600;color:#2563eb;">📥 Click here to download PDF (manual)</a>',
+                unsafe_allow_html=True,
+            )
+            st.info(
+                "If the button does not work, right-click the blue link above and choose 'Save link as...'"
+            )
+
+    elif rr_page == "Resources":
+        st.subheader("Useful Resources")
+        st.markdown(
+            """
+**1. [A1 Schreiben Practice Questions](https://drive.google.com/file/d/1X_PFF2AnBXSrGkqpfrArvAnEIhqdF6fv/view?usp=sharing)**
+Practice writing tasks and sample questions for A1.
+
+**2. [A1 Exams Sprechen Guide](https://drive.google.com/file/d/1UWvbCCCcrW3_j9x7pOuWug6_Odvzcvaa/view?usp=sharing)**
+Step-by-step guide to the A1 speaking exam.
+
+**3. [German Writing Rules](https://drive.google.com/file/d/1o7_ez3WSNgpgxU_nEtp6EO1PXDyi3K3b/view?usp=sharing)**
+Tips and grammar rules for better writing.
+
+**4. [A2 Sprechen Guide](https://drive.google.com/file/d/1TZecDTjNwRYtZXpEeshbWnN8gCftryhI/view?usp=sharing)**
+A2-level speaking exam guide.
+
+**5. [B1 Sprechen Guide](https://drive.google.com/file/d/1snk4mL_Q9-xTBXSRfgiZL_gYRI9tya8F/view?usp=sharing)**
+How to prepare for your B1 oral exam.
+            """
+        )
+
+
+__all__ = ["load_assignment_scores", "render_results_and_resources_tab"]

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,68 @@
+"""Application configuration utilities.
+
+This module centralises setup for shared resources such as the
+:class:`EncryptedCookieManager`.  ``a1sprechen.py`` previously embedded
+this logic directly which made the main script rather unwieldy.  Moving
+it here allows tests and other modules to import the initialised cookie
+manager without pulling in the whole application.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+
+import streamlit as st
+from streamlit_cookies_manager import EncryptedCookieManager
+
+from .session_management import bootstrap_cookie_manager
+
+# Default number of sentences per session in Sentence Builder.  This
+# constant lives here so that any module may import it without touching
+# the main ``a1sprechen`` entrypoint.
+SB_SESSION_TARGET = int(os.environ.get("SB_SESSION_TARGET", 5))
+
+# ---------------------------------------------------------------------------
+# Cookie manager bootstrap
+# ---------------------------------------------------------------------------
+
+# IMPORTANT: use a long, random phrase (>= 32 chars) in production.  The
+# repository contains a short fallback purely so tests can run without
+# secrets configured.
+_HARDCODED_COOKIE_PASSPHRASE = os.environ.get(
+    "FALOWEN_COOKIE_FALLBACK", "Felix029"
+)
+
+# Hash the passphrase so the raw value isn't stored directly.
+_FALLBACK_COOKIE_PASSWORD = hashlib.sha256(
+    _HARDCODED_COOKIE_PASSPHRASE.encode("utf-8")
+).hexdigest()
+
+
+def get_cookie_manager() -> EncryptedCookieManager:
+    """Return an initialised :class:`EncryptedCookieManager` instance.
+
+    The password is resolved from ``st.secrets`` or environment variables
+    with a deterministic fallback suitable for development and tests.
+    The returned manager is wrapped by ``bootstrap_cookie_manager`` so
+    that downstream code receives the same type regardless of environment.
+    """
+
+    cookie_password = (
+        st.secrets.get("cookie_password", None)
+        or os.environ.get("COOKIE_PASSWORD")
+        or _FALLBACK_COOKIE_PASSWORD
+    )
+
+    if cookie_password == _FALLBACK_COOKIE_PASSWORD and os.getenv("DEBUG", "0") == "1":
+        logging.warning(
+            "Using built-in fallback cookie password (set `cookie_password` or `COOKIE_PASSWORD` for production)."
+        )
+
+    return bootstrap_cookie_manager(
+        EncryptedCookieManager(password=cookie_password, prefix="falowen")
+    )
+
+
+__all__ = ["get_cookie_manager", "SB_SESSION_TARGET"]

--- a/src/stats_ui.py
+++ b/src/stats_ui.py
@@ -1,0 +1,79 @@
+"""UI helpers for displaying student statistics."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from .stats import get_vocab_stats, get_schreiben_stats
+
+
+def render_vocab_stats(student_code: str):
+    """Render the vocabulary practice statistics expander.
+
+    Returns the statistics dictionary so callers can reuse it without
+    performing another Firestore lookup.
+    """
+
+    stats = get_vocab_stats(student_code)
+    with st.expander("📝 Your Vocab Stats", expanded=False):
+        st.markdown(f"- **Sessions:** {stats['total_sessions']}")
+        st.markdown(f"- **Last Practiced:** {stats['last_practiced']}")
+        st.markdown(f"- **Unique Words:** {len(stats['completed_words'])}")
+        if st.checkbox("Show Last 5 Sessions"):
+            for a in stats["history"][-5:][::-1]:
+                st.markdown(
+                    f"- {a['timestamp']} | {a['correct']}/{a['total']} | {a['level']}<br>"
+                    f"<span style='font-size:0.9em;'>Words: {', '.join(a['practiced_words'])}</span>",
+                    unsafe_allow_html=True,
+                )
+    return stats
+
+
+def render_schreiben_stats(student_code: str):
+    """Show writing statistics and return them for further use."""
+
+    stats = get_schreiben_stats(student_code)
+    if stats:
+        total = stats.get("total", 0)
+        passed = stats.get("passed", 0)
+        pass_rate = stats.get("pass_rate", 0)
+
+        if total <= 2:
+            writer_title = "🟡 Beginner Writer"
+            milestone = "Write 3 letters to become a Rising Writer!"
+        elif total <= 5 or pass_rate < 60:
+            writer_title = "🟡 Rising Writer"
+            milestone = "Achieve 60% pass rate and 6 letters to become a Confident Writer!"
+        elif total <= 7 or (60 <= pass_rate < 80):
+            writer_title = "🔵 Confident Writer"
+            milestone = "Reach 8 attempts and 80% pass rate to become an Advanced Writer!"
+        elif total >= 8 and pass_rate >= 80 and not (total >= 10 and pass_rate >= 95):
+            writer_title = "🟢 Advanced Writer"
+            milestone = "Reach 10 attempts and 95% pass rate to become a Master Writer!"
+        elif total >= 10 and pass_rate >= 95:
+            writer_title = "🏅 Master Writer!"
+            milestone = "You've reached the highest milestone! Keep maintaining your skills 🎉"
+        else:
+            writer_title = "✏️ Active Writer"
+            milestone = "Keep going to unlock your next milestone!"
+
+        st.markdown(
+            f"""
+            <div style="background:#fff8e1;padding:18px 12px 14px 12px;border-radius:12px;margin-bottom:12px;
+                        box-shadow:0 1px 6px #00000010;">
+                <span style="font-weight:bold;font-size:1.25rem;color:#d63384;">{writer_title}</span><br>
+                <span style="font-weight:bold;font-size:1.09rem;color:#444;">📊 Your Writing Stats</span><br>
+                <span style="color:#202020;font-size:1.05rem;"><b>Total Attempts:</b> {total}</span><br>
+                <span style="color:#202020;font-size:1.05rem;"><b>Passed:</b> {passed}</span><br>
+                <span style="color:#202020;font-size:1.05rem;"><b>Pass Rate:</b> {pass_rate:.1f}%</span><br>
+                <span style="color:#e65100;font-weight:bold;font-size:1.03rem;">{milestone}</span>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+    else:
+        st.info("No writing stats found yet. Write your first letter to see progress!")
+    return stats
+
+
+__all__ = ["render_vocab_stats", "render_schreiben_stats"]


### PR DESCRIPTION
## Summary
- centralize cookie manager setup in `src/config`
- move results/resources and assignment helpers to `src/assignment_ui`
- extract stats display widgets into `src/stats_ui`
- streamline `a1sprechen.py` to import new modules
- fix cookie clearing in auth helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b08b66bfd483218163e5707d932923