### PR TITLE
Import GAS_RESET_URL for password reset in Streamlit app

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -40,7 +40,7 @@ from streamlit.components.v1 import html as st_html
 from streamlit_quill import st_quill
 
 # --- Falowen modules ---
-from falowen.email_utils import send_reset_email, build_gas_reset_link
+from falowen.email_utils import send_reset_email, build_gas_reset_link, GAS_RESET_URL
 from falowen.sessions import (
     db,
     create_session_token,


### PR DESCRIPTION
## Summary
- Import GAS_RESET_URL from `falowen.email_utils` in `a1sprechen.py` to fix missing constant errors when building reset links

## Testing
- `pytest`
- `streamlit run a1sprechen.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68b090a2a0cc832186d94caec8f517a7