### PR TITLE
Replace UTC usage with timezone.utc

### DIFF
--- a/src/stats.py
+++ b/src/stats.py
@@ -6,7 +6,7 @@ been extracted so they can be imported independently and tested.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Iterable, Optional
 
 import os
@@ -184,7 +184,7 @@ def save_vocab_attempt(
         "total": total_int,
         "correct": correct_int,
         "practiced_words": list(practiced_words or []),
-        "timestamp": datetime.now(tz=UTC).isoformat(timespec="minutes"),
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(timespec="minutes"),
         "session_id": session_id,
     }
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import src.stats as stats
 
@@ -235,4 +235,4 @@ def test_save_vocab_attempt_uses_utc_timestamp():
     stats.save_vocab_attempt("stud", "A1", 1, 1, [])
     attempt = stats.get_vocab_stats("stud")["history"][-1]
     dt = datetime.fromisoformat(attempt["timestamp"])
-    assert dt.tzinfo == UTC
+    assert dt.tzinfo == timezone.utc


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.UTC` usage with `timezone.utc`
- mirror import and usage changes in `tests/test_stats.py`

## Testing
- `PYTHONPATH=. pytest tests/test_stats.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0aef44b4c83218f4ff117f3dcf2cd