### PR TITLE
Show vocabulary practice progress and score

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6662,13 +6662,24 @@ if tab == "Vocab Trainer":
                 st.session_state.vt_session_id = str(uuid4())
                 st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
 
+        tot = st.session_state.vt_total
+        idx = st.session_state.vt_index
+        score = st.session_state.vt_score
+
         if st.session_state.vt_history:
+            if isinstance(tot, int) and tot:
+                remaining = tot - idx
+                c1, c2 = st.columns(2)
+                with c1:
+                    st.metric("Words", f"{idx}/{tot}", f"{remaining} left")
+                    st.progress(idx / tot)
+                with c2:
+                    st.metric("Score", score)
+
             st.markdown("### 🗨️ Practice Chat")
             for who, msg in st.session_state.vt_history:
                 render_message(who, msg)
 
-        tot = st.session_state.vt_total
-        idx = st.session_state.vt_index
         if isinstance(tot, int) and idx < tot:
             word, answer = st.session_state.vt_list[idx]
 


### PR DESCRIPTION
## Summary
- add progress and score panel to vocab practice
- compute remaining words and update progress bar each iteration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0c23fe9c483218b1aa8b474140775