### PR TITLE
Ensure vt_mode key is always initialized for vocab practice

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6621,6 +6621,7 @@ if tab == "Vocab Trainer":
         defaults = {
             "vt_history": [], "vt_list": [], "vt_index": 0,
             "vt_score": 0, "vt_total": None, "vt_saved": False, "vt_session_id": None,
+            "vt_mode": "Only new words",
         }
         for k, v in defaults.items():
             st.session_state.setdefault(k, v)
@@ -6675,7 +6676,7 @@ if tab == "Vocab Trainer":
         else:
             st.markdown("### Daily Practice Setup")
             st.info(
-                f"{st.session_state.vt_total} words · {st.session_state.vt_mode}"
+                f"{st.session_state.vt_total} words · {st.session_state.get('vt_mode')}"
             )
             if st.button("Change goal", key="vt_change_goal"):
                 st.session_state.vt_total = None


### PR DESCRIPTION
## Summary
- Add `vt_mode` to vocab practice defaults so session resets include mode
- Avoid crashes if session state clears by guarding vocab practice info display

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0c768c0d08321b05c28c9614d3704