### PR TITLE
Set hero spacing to zero

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -204,9 +204,9 @@ st.markdown("""
 
 /* Keep hero flush and compact */
   .hero {
-    margin-top: 2px !important;      /* was 0/12 — pulls hero up */
+    margin-top: 0 !important;      /* was 0/12 — pulls hero up */
     margin-bottom: 4px !important;   /* tighter space before tabs */
-    padding-top: 6px !important;
+    padding-top: 0 !important;
     display: flow-root;
   }
 .hero h1:first-child { margin-top: 0 !important; }


### PR DESCRIPTION
## Summary
- Remove extra spacing so the hero section sits flush against the top

## Testing
- `streamlit run a1sprechen.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0cccaead88321a12674620ff45db6