### PR TITLE
Reduce login page hero and stats margins

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -734,7 +734,7 @@ def login_page():
           <b>Learn Language Education Academy</b>, with courses and vocabulary from
           <b>A1 to C1</b> levels and live tutor support.
         </p>
-        <ul style="max-width:700px; margin:16px auto; color:#444; font-size:1em; line-height:1.5;">
+        <ul style="max-width:700px; margin:8px auto; color:#444; font-size:1em; line-height:1.5;">
           <li>📊 <b>Dashboard</b>: Track your learning streaks, assignment progress, active contracts, and more.</li>
           <li>📚 <b>Course Book</b>: Access lecture videos, grammar modules, and submit assignments for levels A1–C1 in one place.</li>
           <li>📝 <b>Exams & Quizzes</b>: Take practice tests and official exam prep right in the app.</li>
@@ -750,7 +750,7 @@ def login_page():
     # Stats strip
     st.markdown("""
       <style>
-        .stats-strip { display:flex; flex-wrap:wrap; gap:10px; justify-content:center; margin:10px auto 4px auto; max-width:820px; }
+        .stats-strip { display:flex; flex-wrap:wrap; gap:10px; justify-content:center; margin:4px auto 4px auto; max-width:820px; }
         .stat { background:#0ea5e9; color:#ffffff; border-radius:12px; padding:12px 14px; min-width:150px; text-align:center;
                 box-shadow:0 2px 10px rgba(2,132,199,0.15); outline: none; }
         .stat:focus-visible { outline:3px solid #1f2937; outline-offset:2px; }


### PR DESCRIPTION
## Summary
- Tighten hero feature list spacing by reducing `<ul>` margins to `8px auto` for a sleeker look
- Trim `.stats-strip` top margin to `4px` to keep the hero and statistics bar visually balanced

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0d2edc8c48321a5be8cc69c5a31f8