### PR TITLE
Make navigation banner sticky

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1306,6 +1306,8 @@ def inject_notice_css():
       .pill-purple { background:#efe9ff; color:#5b21b6; }
       .pill-amber { background:#fff7ed; color:#7c2d12; }
 
+      .nav-sticky { position: sticky; top: 0; z-index: 100; background: white; margin: 0; padding: 0; }
+
       @media (max-width: 640px){
         .chip{ padding:7px 10px; font-size:.95rem; }
         .minicard{ padding:11px; }


### PR DESCRIPTION
## Summary
- add CSS rule `.nav-sticky` to keep navigation bar fixed at top with proper spacing

## Testing
- `pytest`
- `streamlit run a1sprechen.py --server.headless true --server.port 9999`

------
https://chatgpt.com/codex/tasks/task_e_68b0d513ff1c83219f7530931881e944