### PR TITLE
refactor login page styles into shared css

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -726,14 +726,18 @@ def render_login_form():
 
 
 def login_page():
+    for css_path in ("static/css/theme.css", "static/css/login.css"):
+        with open(css_path) as f:
+            st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
+
     st.markdown('<style>.page-wrap{max-width:1100px;margin:0 auto;}</style>', unsafe_allow_html=True)
 
     # HERO FIRST
     st.markdown("""
     <div class="page-wrap">
       <div class="hero" aria-label="Falowen app introduction">
-        <h1 style="text-align:center; color:#25317e;">👋 Welcome to <strong>Falowen</strong></h1>
-        <p style="text-align:center; font-size:1.1em; color:#555;">
+        <h1 style="text-align:center;">👋 Welcome to <strong>Falowen</strong></h1>
+        <p style="text-align:center; font-size:1.1em;">
           Falowen is your all-in-one German learning platform, powered by
           <b>Learn Language Education Academy</b>, with courses and vocabulary from
           <b>A1 to C1</b> levels and live tutor support.
@@ -748,27 +752,6 @@ def login_page():
           <li>🔤 <b>Vocab Trainer</b>: Practice and master A1–C1 vocabulary with spaced-repetition quizzes.</li>
           <li>✍️ <b>Schreiben Trainer</b>: Improve your writing with guided exercises and instant corrections.</li>
         </ul>
-        <style>
-          .feature-list {
-            max-width:700px;
-            margin:16px auto;
-            color:#444;
-            font-size:1em;
-            line-height:1.5;
-            list-style:none;
-            padding-left:0;
-            display:flex;
-            flex-wrap:wrap;
-            gap:4px 16px;
-          }
-          .feature-list li {
-            flex:1 1 calc(50% - 16px);
-            margin-bottom:6px;
-          }
-          @media (max-width:560px) {
-            .feature-list li { flex-basis:100%; }
-          }
-        </style>
       </div>
     </div>
     """, unsafe_allow_html=True)

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -1,0 +1,19 @@
+.feature-list {
+  max-width:700px;
+  margin:16px auto;
+  color: var(--color-text);
+  font-size:1em;
+  line-height:1.5;
+  list-style:none;
+  padding-left:0;
+  display:flex;
+  flex-wrap:wrap;
+  gap:4px 16px;
+}
+.feature-list li {
+  flex:1 1 calc(50% - 16px);
+  margin-bottom:6px;
+}
+@media (max-width:560px) {
+  .feature-list li { flex-basis:100%; }
+}

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,20 @@
+:root {
+  --color-primary: #25317e;
+  --color-text: #444;
+  --color-muted: #555;
+  --font-base: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+}
+
+body {
+  color: var(--color-text);
+  font-family: var(--font-base);
+}
+
+p {
+  color: var(--color-muted);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: var(--color-primary);
+  font-family: var(--font-base);
+}


### PR DESCRIPTION
## Summary
- externalize login feature list styles to `static/css/login.css`
- add shared color and font variables in `static/css/theme.css`
- load external styles in login page and remove inline color attributes

## Testing
- `pytest` *(fails: module 'playlist_module' has no attribute 'fetch_youtube_playlist_videos')*

------
https://chatgpt.com/codex/tasks/task_e_68b0da1692308321834d4940af0e1838