### PR TITLE
Serve fonts via Tornado and load in Streamlit UI

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -186,6 +186,15 @@ st.set_page_config(
 # Top spacing + chrome (tighter)
 st.markdown("""
 <style>
+@font-face {
+  font-family: 'DejaVu Sans';
+  src: url('/font/DejaVuSans.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+body {
+  font-family: 'DejaVu Sans', sans-serif;
+}
 /* Remove Streamlit's top padding */
 [data-testid="stAppViewContainer"] > .main .block-container {
   padding-top: 0 !important;

--- a/app_wrapper_NOT_USED.py
+++ b/app_wrapper_NOT_USED.py
@@ -15,6 +15,7 @@ if not COOKIE_SECRET:
 
 BASE = os.path.dirname(__file__)
 PUBLIC = os.path.join(BASE, "public")
+FONT = os.path.join(BASE, "font")
 
 class AssetLinks(tornado.web.RequestHandler):
     def get(self):
@@ -41,6 +42,7 @@ def make_app():
         (r"/health", Health),
         (r"/\.well-known/assetlinks\.json", AssetLinks),
         (r"/manifest\.webmanifest", WebManifest),
+        (r"/font/(.*)", tornado.web.StaticFileHandler, {"path": FONT}),
         (r"/(.*)", tornado.web.StaticFileHandler, {
             "path": PUBLIC,
             "default_filename": "index.html"


### PR DESCRIPTION
## Summary
- Serve the `font/` directory with a dedicated `StaticFileHandler` to expose DejaVuSans.
- Inject a CSS `@font-face` rule in Streamlit to load DejaVu Sans from the new `/font/` endpoint and apply it to the page.

## Testing
- `pytest` *(fails: AttributeError in playlist_module tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ded032e48321961f2c8fd6cfbe26