### PR TITLE
Restore unindented login page hero HTML

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -12,7 +12,6 @@ import random
 import re
 import tempfile
 import time
-import textwrap
 import urllib.parse as _urllib
 from urllib.parse import urlsplit, parse_qs, urlparse
 from datetime import date, timedelta, timezone as _timezone, UTC
@@ -740,97 +739,96 @@ def login_page():
 
     # HERO FIRST
     st.markdown(
-        textwrap.dedent(
-            """\
-            <div class="page-wrap">
-              <div class="hero" aria-label="Falowen app introduction">
-                <h1 style="text-align:center; color:#25317e;">👋 Welcome to <strong>Falowen</strong></h1>
-                <p style="text-align:center; font-size:1.1em; color:#555;">
-                  Falowen is your all-in-one German learning platform, powered by
-                  <b>Learn Language Education Academy</b>, with courses and vocabulary from
-                  <b>A1 to C1</b> levels and live tutor support.
-                </p>
+        """\
+<div class="page-wrap">
+  <div class="hero" aria-label="Falowen app introduction">
+    <h1 style="text-align:center; color:#25317e;">👋 Welcome to <strong>Falowen</strong></h1>
+    <p style="text-align:center; font-size:1.1em; color:#555;">
+      Falowen is your all-in-one German learning platform, powered by
+      <b>Learn Language Education Academy</b>, with courses and vocabulary from
+      <b>A1 to C1</b> levels and live tutor support.
+    </p>
 
-                <ul class="feature-list">
+    <ul class="feature-list">
 
-                  <li>
-                    <span class="feature-icon" role="img" aria-label="Dashboard">📊</span>
-                    <span class="feature-title">Dashboard</span>: Track your learning streaks, assignment progress, active contracts, and more.
-                  </li>
-                  <li>
-                    <span class="feature-icon" role="img" aria-label="Course Book">📚</span>
-                    <span class="feature-title">Course Book</span>: Access lecture videos, grammar modules, and submit assignments for levels A1–C1 in one place.
-                  </li>
-                  <li>
-                    <span class="feature-icon" role="img" aria-label="Exams and Quizzes">📝</span>
-                    <span class="feature-title">Exams &amp; Quizzes</span>: Take practice tests and official exam prep right in the app.
-                  </li>
-                  <li>
-                    <span class="feature-icon" role="img" aria-label="Custom Chat">💬</span>
-                    <span class="feature-title">Custom Chat</span>: Sprechen &amp; expression trainer for live feedback on your speaking.
-                  </li>
-                  <li>
-                    <span class="feature-icon" role="img" aria-label="Results Tab">🏆</span>
-                    <span class="feature-title">Results Tab</span>: View your grades, feedback, and historical performance at a glance.
-                  </li>
-                  <li>
-                    <span class="feature-icon" role="img" aria-label="Vocab Trainer">🔤</span>
-                    <span class="feature-title">Vocab Trainer</span>: Practice and master A1–C1 vocabulary with spaced-repetition quizzes.
-                  </li>
-                  <li>
-                    <span class="feature-icon" role="img" aria-label="Schreiben Trainer">✍️</span>
-                    <span class="feature-title">Schreiben Trainer</span>: Improve your writing with guided exercises and instant corrections.
-                  </li>
-                </ul>
+      <li>
+        <span class="feature-icon" role="img" aria-label="Dashboard">📊</span>
+        <span class="feature-title">Dashboard</span>: Track your learning streaks, assignment progress, active contracts, and more.
+      </li>
+      <li>
+        <span class="feature-icon" role="img" aria-label="Course Book">📚</span>
+        <span class="feature-title">Course Book</span>: Access lecture videos, grammar modules, and submit assignments for levels A1–C1 in one place.
+      </li>
+      <li>
+        <span class="feature-icon" role="img" aria-label="Exams and Quizzes">📝</span>
+        <span class="feature-title">Exams &amp; Quizzes</span>: Take practice tests and official exam prep right in the app.
+      </li>
+      <li>
+        <span class="feature-icon" role="img" aria-label="Custom Chat">💬</span>
+        <span class="feature-title">Custom Chat</span>: Sprechen &amp; expression trainer for live feedback on your speaking.
+      </li>
+      <li>
+        <span class="feature-icon" role="img" aria-label="Results Tab">🏆</span>
+        <span class="feature-title">Results Tab</span>: View your grades, feedback, and historical performance at a glance.
+      </li>
+      <li>
+        <span class="feature-icon" role="img" aria-label="Vocab Trainer">🔤</span>
+        <span class="feature-title">Vocab Trainer</span>: Practice and master A1–C1 vocabulary with spaced-repetition quizzes.
+      </li>
+      <li>
+        <span class="feature-icon" role="img" aria-label="Schreiben Trainer">✍️</span>
+        <span class="feature-title">Schreiben Trainer</span>: Improve your writing with guided exercises and instant corrections.
+      </li>
+    </ul>
 
-                <style>
-                  .feature-grid {
-                    max-width:700px;
-                    margin:16px auto;
-                    display:grid;
-                    grid-template-columns:repeat(auto-fit, minmax(250px, 1fr));
-                    gap:16px;
-                  }
-                  .feature-card {
-                    background:#f9f9f9;
-                    padding:16px;
-                    border-radius:12px;
-                    box-shadow:0 1px 4px rgba(0,0,0,0.08);
-                    display:flex;
-                    align-items:flex-start;
-                    gap:12px;
-                    color:#444;
-                    font-size:1em;
-                    line-height:1.5;
-                    transition:transform .2s ease, box-shadow .2s ease;
-                  }
-                  .feature-card:hover {
-                    transform:scale(1.02);
-                    box-shadow:0 4px 12px rgba(0,0,0,0.15);
-                  }
-                  .feature-icon {
-                    font-size:1.2em;
-                    display:inline-block;
-                    width:1.4em;
-                    text-align:center;
-                    vertical-align:middle;
-                    color:var(--feature-icon-color,#25317e);
-                    margin-right:4px;
-                  }
-                  .feature-title {
-                    font-weight:600;
-                    color:var(--feature-title-color,#25317e);
-                    margin-right:2px;
-                  }
-                  @media (max-width:560px) {
-                    .feature-list li { flex-basis:100%; }
+    <style>
+      .feature-grid {
+        max-width:700px;
+        margin:16px auto;
+        display:grid;
+        grid-template-columns:repeat(auto-fit, minmax(250px, 1fr));
+        gap:16px;
+      }
+      .feature-card {
+        background:#f9f9f9;
+        padding:16px;
+        border-radius:12px;
+        box-shadow:0 1px 4px rgba(0,0,0,0.08);
+        display:flex;
+        align-items:flex-start;
+        gap:12px;
+        color:#444;
+        font-size:1em;
+        line-height:1.5;
+        transition:transform .2s ease, box-shadow .2s ease;
+      }
+      .feature-card:hover {
+        transform:scale(1.02);
+        box-shadow:0 4px 12px rgba(0,0,0,0.15);
+      }
+      .feature-icon {
 
-                  }
-                </style>
-              </div>
-            </div>
-            """,
-        ),
+        font-size:1.2em;
+        display:inline-block;
+        width:1.4em;
+        text-align:center;
+        vertical-align:middle;
+        color:var(--feature-icon-color,#25317e);
+        margin-right:4px;
+      }
+      .feature-title {
+        font-weight:600;
+        color:var(--feature-title-color,#25317e);
+        margin-right:2px;
+      }
+      @media (max-width:560px) {
+        .feature-list li { flex-basis:100%; }
+
+      }
+    </style>
+  </div>
+</div>
+""",
         unsafe_allow_html=True,
     )
 


### PR DESCRIPTION
## Summary
- revert hero section to previous unindented HTML snippet and keep it wrapped in `st.markdown(..., unsafe_allow_html=True)` so Streamlit renders the feature list as styled HTML

## Testing
- `python -m py_compile a1sprechen.py`
- `streamlit run a1sprechen.py`
- `pytest -q` *(fails: module 'playlist_module' has no attribute 'fetch_youtube_playlist_videos', module 'playlist_module' has no attribute 'get_playlist_ids_for_level')*

------
https://chatgpt.com/codex/tasks/task_e_68b0e553732c83219cbc7ba4e093cb9b