### PR TITLE
Use static login page file

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -18,6 +18,7 @@ from datetime import date, timedelta, timezone as _timezone, UTC
 from datetime import datetime
 from datetime import datetime as _dt
 from uuid import uuid4
+from pathlib import Path
 
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -813,50 +814,9 @@ def login_page():
     st.markdown('<style>.page-wrap{max-width:1100px;margin:0 auto;}</style>', unsafe_allow_html=True)
 
     # HERO FIRST
+    html_path = Path(__file__).parent / "public" / "index.html"
     components.html(
-        """
-    <div class="page-wrap">
-      <div class="hero" aria-label="Falowen app introduction">
-    <style>
-      .hero-intro {
-        text-align: center;
-        color: #25317e;
-      }
-      .hero-tagline {
-        text-align: center;
-        font-size: 1.1em;
-        color: #555;
-      }
-      .feature-list {
-        max-width: 700px;
-        margin: 16px auto;
-        color: #444;
-        font-size: 1em;
-        line-height: 1.5;
-      }
-      .feature-item {
-        margin: 4px 0;
-        color: #444;
-      }
-    </style>
-        <h1 class="hero-intro">👋 Welcome to <strong>Falowen</strong></h1>
-        <p class="hero-tagline">
-          Falowen is your all-in-one German learning platform, powered by
-          <b>Learn Language Education Academy</b>, with courses and vocabulary from
-          <b>A1 to C1</b> levels and live tutor support.
-        </p>
-        <ul class="feature-list">
-          <li class="feature-item">📊 <b>Dashboard</b>: Track your learning streaks, assignment progress, active contracts, and more.</li>
-          <li class="feature-item">📚 <b>Course Book</b>: Access lecture videos, grammar modules, and submit assignments for levels A1–C1 in one place.</li>
-          <li class="feature-item">📝 <b>Exams & Quizzes</b>: Take practice tests and official exam prep right in the app.</li>
-          <li class="feature-item">💬 <b>Custom Chat</b>: Sprechen & expression trainer for live feedback on your speaking.</li>
-          <li class="feature-item">🏆 <b>Results Tab</b>: View your grades, feedback, and historical performance at a glance.</li>
-          <li class="feature-item">🔤 <b>Vocab Trainer</b>: Practice and master A1–C1 vocabulary with spaced-repetition quizzes.</li>
-          <li class="feature-item">✍️ <b>Schreiben Trainer</b>: Improve your writing with guided exercises and instant corrections.</li>
-        </ul>
-      </div>
-    </div>
-    """,
+        html_path.read_text(encoding="utf-8"),
         height=500,
         scrolling=False,
     )


### PR DESCRIPTION
## Summary
- Load login page HTML directly from `public/index.html` instead of embedding a huge string.

## Testing
- `pytest`
- `streamlit run a1sprechen.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68b0f9defc288321aedf57d3fc1e9ea6