### PR TITLE
Require login before rendering page content

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -423,6 +423,10 @@ if not st.session_state.get("logged_in", False):
         reset_password_page(tok)
         st.stop()
 
+if not st.session_state.get("logged_in", False):
+    login_page()
+    st.stop()
+
 # ------------------------------------------------------------------------------
 # CSS + OAuth UI helpers, etc.
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Ensure unauthenticated users are directed to login before any other content

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b15e98f49083218425fc41a0f061f0