### PR TITLE
Integrate resume progress persistence

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1031,6 +1031,22 @@ if not st.session_state.get("logged_in", False):
     st.stop()
 
 
+# After a successful login, load any stored progress and display a banner
+from src.resume import load_last_position, render_resume_banner
+from src.progress_utils import save_last_position
+
+student_code = st.session_state.get("student_code", "")
+if student_code:
+    st.session_state["__last_progress"] = load_last_position(student_code) or 0
+
+render_resume_banner()
+
+_current = int(st.session_state.get("falowen_stage", 0) or 0)
+_last = int(st.session_state.get("__last_progress", 0) or 0)
+if student_code and _current > _last:
+    save_last_position(student_code, _current)
+    st.session_state["__last_progress"] = _current
+
 # ------------------------------------------------------------------------------
 # Resume helpers (Firestore) – optional label support
 # ------------------------------------------------------------------------------

--- a/src/resume.py
+++ b/src/resume.py
@@ -5,24 +5,32 @@ from typing import Any, Optional
 
 import streamlit as st
 
+from . import progress_utils
 
-def load_last_position(student_code: str) -> Optional[Any]:
-    """Return the last saved position for a student.
 
-    The real application may load this from a database. This placeholder
-    implementation simply returns ``None`` to indicate no saved progress.
+def load_last_position(student_code: str) -> Optional[int]:
+    """Return the last saved position for ``student_code``.
+
+    A ``None`` result indicates no student code was supplied. Otherwise the
+    value is retrieved via :func:`progress_utils.load_last_position` which
+    gracefully handles missing Firestore connectivity.
     """
-    return None
+    if not student_code:
+        return None
+    return progress_utils.load_last_position(student_code)
 
 
 def render_resume_banner() -> None:
-    """Render a resume banner if the user has previous progress.
+    """Render a simple banner if the user has previous progress.
 
-    The banner implementation is omitted; tests may patch this function to
-    verify that it is invoked after login. This stub merely reads the cached
-    progress from ``st.session_state`` for completeness.
+    The banner surfaces ``st.session_state['__last_progress']`` which callers
+    populate via :func:`load_last_position`.  When progress is present a small
+    information message is displayed to prompt the user to continue.
     """
-    _ = st.session_state.get("__last_progress")
+    pos = st.session_state.get("__last_progress")
+    if isinstance(pos, int) and pos > 0:
+        st.info(f"You last stopped at section {pos} – pick up where you left off!")
+
     return None
 
 

--- a/tests/test_progress_utils.py
+++ b/tests/test_progress_utils.py
@@ -1,0 +1,46 @@
+from src import progress_utils
+
+def test_save_last_position(monkeypatch):
+    saved = {}
+
+    class DummyRef:
+        def set(self, data, *, merge):
+            saved.update(data)
+            saved['merge'] = merge
+
+    monkeypatch.setattr(progress_utils, "_progress_doc_ref", lambda code: DummyRef())
+
+    progress_utils.save_last_position("stu", 5)
+    assert saved == {"last_position": 5, "merge": True}
+
+
+def test_load_last_position_roundtrip(monkeypatch):
+    class DummySnap:
+        def __init__(self, exists, data):
+            self.exists = exists
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    class DummyRef:
+        def __init__(self, snap):
+            self.snap = snap
+            self.saved = None
+
+        def get(self):
+            return self.snap
+
+        def set(self, data, *, merge):
+            self.saved = data
+
+    # existing progress
+    ref = DummyRef(DummySnap(True, {"last_position": 3}))
+    monkeypatch.setattr(progress_utils, "_progress_doc_ref", lambda code: ref)
+    assert progress_utils.load_last_position("stu") == 3
+
+    # missing document initialises to 0 and saves it
+    ref2 = DummyRef(DummySnap(False, {}))
+    monkeypatch.setattr(progress_utils, "_progress_doc_ref", lambda code: ref2)
+    assert progress_utils.load_last_position("stu") == 0
+    assert ref2.saved == {"last_position": 0}


### PR DESCRIPTION
## Summary
- Integrate resume helpers with Firestore progress utilities
- Persist section advancement to Firestore and display resume banner on login
- Add tests for saving and loading progress

## Testing
- `pip install pytest -q` *(fails: externally-managed-environment)*
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c0144a9483219f13db0e08829d56