### PR TITLE
Remove unused st_html import

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -36,7 +36,6 @@ from firebase_admin import firestore
 from fpdf import FPDF
 from gtts import gTTS
 from openai import OpenAI
-from streamlit.components.v1 import html as st_html
 from streamlit_quill import st_quill
 
 # --- Streamlit page config (do this first) ---


### PR DESCRIPTION
## Summary
- clean up a1sprechen imports by dropping unused st_html reference

## Testing
- `python -m py_compile a1sprechen.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1c262ea7c832189feeae779bb649a