### PR TITLE
Handle missing ContractEnd column when loading students

### DIFF
--- a/src/data_loading.py
+++ b/src/data_loading.py
@@ -146,6 +146,10 @@ def _load_student_data_cached() -> Optional[pd.DataFrame]:
     for col in df.columns:
         s = df[col]
         df[col] = s.where(s.isna(), s.astype(str).str.strip())
+    if "ContractEnd" not in df.columns:
+        logging.warning("Student roster missing 'ContractEnd' column")
+        st.warning("The student roster is missing a 'ContractEnd' column.")
+        return None
 
     df = df[df["ContractEnd"].notna() & (df["ContractEnd"].str.len() > 0)]
 


### PR DESCRIPTION
## Summary
- log warning and return `None` when the student roster lacks `ContractEnd`
- apply `ContractEnd` filters only when the column exists

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c279cfa48321ac95bc8db73b4ec7