### PR TITLE
Deduplicate Falowen login template cleanup

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -376,22 +376,10 @@ def _load_falowen_login_html() -> str:
     return html
 
 
-    for aside in soup.find_all("aside"):
-        aside.decompose()
-
-    for script in soup.find_all("script"):
-        script.decompose()
-
-    style_tag = soup.find("style")
-    if style_tag and style_tag.string:
-        style_tag.string = style_tag.string.replace(
-            "grid-template-columns:1.2fr .8fr;", "grid-template-columns:1fr;"
-        )
-        style_tag.string = style_tag.string.replace(
-            "grid-template-columns: 1.2fr .8fr;", "grid-template-columns: 1fr;"
-        )
-
-    components.html(str(soup), height=720, scrolling=True, key="falowen_hero")
+def render_falowen_login() -> None:
+    """Render the preprocessed Falowen hero HTML once."""
+    html = _load_falowen_login_html()
+    components.html(html, height=720, scrolling=True, key="falowen_hero")
 
 
 # ------------------------------------------------------------------------------
@@ -622,7 +610,7 @@ def render_reviews_landing():
 # ------------------------------------------------------------------------------
 def login_page():
     auth_url = render_google_oauth(return_url=True) or ""
-    render_falowen_login(auth_url)  # hero only (no login inside HTML)
+    render_falowen_login()  # hero only (no login inside HTML)
 
     st.markdown("<div style='text-align:center; margin:10px 0;'>⎯⎯⎯ or ⎯⎯⎯</div>", unsafe_allow_html=True)
     login_success = render_returning_login_form()


### PR DESCRIPTION
## Summary
- handle cleanup when loading falowen login template and cache processed HTML
- simplify `render_falowen_login` to just output preprocessed template
- drop unused `auth_url` parameter from login page render call

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1c616f4788321880a1ffac106f860