### PR TITLE
Run flake8 in CI to catch undefined names

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+select = F821
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run linter
+        run: flake8 .
       - name: Run tests
         run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ fastapi==0.116.1
 uvicorn==0.35.0
 pytest==8.4.1
 rapidfuzz==3.13.0
+flake8==7.1.1


### PR DESCRIPTION
## Summary
- ensure CI executes flake8 to catch undefined names
- configure flake8 to focus on undefined-name errors

## Testing
- `pytest`
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c6278fe483218e0c9b942e3ac918