### PR TITLE
feat: allow cache clearing in development

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -39,6 +39,7 @@ from gtts import gTTS
 from bs4 import BeautifulSoup
 from openai import OpenAI
 from streamlit_quill import st_quill
+from src.cache_utils import clear_cache_if_dev
 
 # --- Streamlit page config (do this first) ---
 st.set_page_config(
@@ -47,6 +48,9 @@ st.set_page_config(
     layout="wide",
     initial_sidebar_state="expanded"
 )
+
+# Clear Streamlit caches when running locally in development.
+clear_cache_if_dev()
 
 # --- Falowen modules ---
 from falowen.email_utils import send_reset_email, build_gas_reset_link, GAS_RESET_URL

--- a/src/cache_utils.py
+++ b/src/cache_utils.py
@@ -1,0 +1,27 @@
+"""Utilities for clearing Streamlit caches in development."""
+from __future__ import annotations
+
+import os
+import streamlit as st
+
+
+def clear_cache_if_dev() -> None:
+    """Clear Streamlit caches when running in development mode.
+
+    If the ``A1SPRECHEN_DEV`` environment variable is set to ``"1"``,
+    both ``st.cache_data`` and ``st.cache_resource`` are cleared. This
+    allows developers to refresh cached data quickly while iterating
+    locally without impacting production deployments.
+    """
+    if os.environ.get("A1SPRECHEN_DEV") != "1":
+        return
+
+    try:
+        st.cache_data.clear()
+    except Exception:
+        pass
+
+    try:
+        st.cache_resource.clear()
+    except Exception:
+        pass

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,36 @@
+import types
+from unittest.mock import MagicMock
+
+from src import cache_utils
+
+
+def test_clear_cache_if_dev(monkeypatch):
+    cd_clear = MagicMock()
+    cr_clear = MagicMock()
+    st_mock = types.SimpleNamespace(
+        cache_data=types.SimpleNamespace(clear=cd_clear),
+        cache_resource=types.SimpleNamespace(clear=cr_clear),
+    )
+    monkeypatch.setattr(cache_utils, "st", st_mock)
+    monkeypatch.setenv("A1SPRECHEN_DEV", "1")
+
+    cache_utils.clear_cache_if_dev()
+
+    cd_clear.assert_called_once()
+    cr_clear.assert_called_once()
+
+
+def test_clear_cache_if_dev_disabled(monkeypatch):
+    cd_clear = MagicMock()
+    cr_clear = MagicMock()
+    st_mock = types.SimpleNamespace(
+        cache_data=types.SimpleNamespace(clear=cd_clear),
+        cache_resource=types.SimpleNamespace(clear=cr_clear),
+    )
+    monkeypatch.setattr(cache_utils, "st", st_mock)
+    monkeypatch.delenv("A1SPRECHEN_DEV", raising=False)
+
+    cache_utils.clear_cache_if_dev()
+
+    cd_clear.assert_not_called()
+    cr_clear.assert_not_called()


### PR DESCRIPTION
## Summary
- add `clear_cache_if_dev` helper for Streamlit cache cleanup
- call helper during app startup
- test cache clearing behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1c62cbe4483218313da9077849b3f