### PR TITLE
Remove unused auth_url parameter from login hero

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -396,12 +396,9 @@ def _load_falowen_login_html() -> str:
     return html
 
 
-def render_falowen_login(auth_url: str) -> None:
+def render_falowen_login() -> None:
     """Render the Falowen hero section.
 
-
-
-    The `auth_url` parameter is kept for compatibility but isn't used yet.
     If the HTML template can't be loaded, display an error message instead of
     raising an exception so the rest of the page can still render.
     """
@@ -641,8 +638,8 @@ def render_reviews_landing():
 # Login page (Hero only + returning form; tabs for Sign Up / Request Access)
 # ------------------------------------------------------------------------------
 def login_page():
-    auth_url = render_google_oauth(return_url=True) or ""
-    render_falowen_login(auth_url)  # hero only (no login inside HTML)
+    render_falowen_login()  # hero only (no login inside HTML)
+    render_google_oauth()  # Google sign-in button near the hero
 
     st.markdown("<div style='text-align:center; margin:10px 0;'>⎯⎯⎯ or ⎯⎯⎯</div>", unsafe_allow_html=True)
     login_success = render_returning_login_form()

--- a/tests/test_render_falowen_login.py
+++ b/tests/test_render_falowen_login.py
@@ -15,6 +15,7 @@ def load_login_module():
         if isinstance(node, ast.FunctionDef) and node.name in {"_load_falowen_login_html", "render_falowen_login"}:
             nodes.append(node)
     mod = types.ModuleType("login_module")
+    mod.__file__ = str(path)
     mod.Path = pathlib.Path
     mod.re = __import__("re")
     mod.lru_cache = __import__("functools").lru_cache
@@ -44,13 +45,13 @@ def test_render_calls_components_html(login_mod, monkeypatch):
     login_mod._load_falowen_login_html.cache_clear()
     expected_html = login_mod._load_falowen_login_html()
     login_mod.components.html.reset_mock()
-    login_mod.render_falowen_login("auth_url")
+    login_mod.render_falowen_login()
     login_mod.components.html.assert_called_once_with(expected_html, height=720, scrolling=True, key="falowen_hero")
 
 
 def test_missing_template_shows_error(login_mod, monkeypatch):
     monkeypatch.setattr(pathlib.Path, "read_text", MagicMock(side_effect=FileNotFoundError))
     login_mod._load_falowen_login_html.cache_clear()
-    login_mod.render_falowen_login("auth_url")
+    login_mod.render_falowen_login()
     login_mod.st.error.assert_called_once()
     assert not login_mod.components.html.called


### PR DESCRIPTION
## Summary
- drop unused `auth_url` parameter from `render_falowen_login`
- call `render_google_oauth` separately and simplify login page flow
- update tests for new signature and set `__file__` for template loading

## Testing
- `ruff check tests/test_render_falowen_login.py`
- `pytest tests/test_render_falowen_login.py -q`
- `ruff check a1sprechen.py tests/test_render_falowen_login.py` *(fails: multiple existing style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cc65352883218b61a6917fb7738b