### PR TITLE
Handle file read errors when rendering Falowen login

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -404,7 +404,8 @@ def render_falowen_login() -> None:
     """
     try:
         html = _load_falowen_login_html()
-    except Exception:
+    except (OSError, UnicodeDecodeError) as e:
+        logging.exception("Failed to load Falowen hero template: %s", e)
         st.error("Falowen hero template missing or unreadable.")
         return
 


### PR DESCRIPTION
## Summary
- Use a more specific exception handler `(OSError, UnicodeDecodeError)` in `render_falowen_login` and log failures
- Expand tests for Falowen login rendering to cover error logging and propagation

## Testing
- `ruff check a1sprechen.py tests/test_render_falowen_login.py` *(fails: multiple existing lint errors)*
- `pytest tests/test_render_falowen_login.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1cf6e82988321896d9c8f4f2e0ec7