### PR TITLE
Strip script tags from Falowen login template

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -371,9 +371,9 @@ def _load_falowen_login_html() -> str:
     this module.  We remove legacy login markup so only the hero section
     remains:
 
-    * strip the ``<!-- Right: Login -->`` aside block and any paired script;
-    * collapse a two-column grid into a single column; and
-    * drop remaining ``<script>`` tags.
+    * drop any ``<script>`` blocks;
+    * strip the ``<!-- Right: Login -->`` aside block and any paired script; and
+    * collapse a two-column grid into a single column.
 
     Because the cleanup uses simple regular expressions, it assumes the
     template’s structure matches expected patterns. Substantial changes to the
@@ -382,14 +382,21 @@ def _load_falowen_login_html() -> str:
     html_path = Path(__file__).parent / "templates" / "falowen_login.html"
     html = html_path.read_text(encoding="utf-8")
 
-    # Remove legacy "Right: Login" aside block and its script if present
-    html = re.sub(r'<!--\s*Right:\s*Login\s*-->[\s\S]*?</aside>', '', html, flags=re.IGNORECASE)
+    # Drop all <script> blocks up front so closing </body> remains.
+    html = re.sub(r'<script[\s\S]*?</script>', '', html, flags=re.IGNORECASE)
+
+    # Remove legacy "Right: Login" aside block if present
+    html = re.sub(
+        r'<!--\s*Right:\s*Login\s*-->[\s\S]*?</aside>',
+        '',
+        html,
+        flags=re.IGNORECASE,
+    )
     html = re.sub(
         r'grid-template-columns:\s*1\.2fr\s*\.8fr;',
         'grid-template-columns: 1fr;',
         html,
     )  # make single column
-    html = re.sub(r'<script>[\s\S]*?</script>\s*</body>', '</body>', html)
 
     # After cleanup, no login markup or scripts should remain.
     # Update the above regexes if new login patterns appear in the template.

--- a/tests/test_render_falowen_login.py
+++ b/tests/test_render_falowen_login.py
@@ -49,6 +49,21 @@ def test_render_calls_components_html(login_mod, monkeypatch):
     login_mod.components.html.assert_called_once_with(expected_html, height=720, scrolling=True, key="falowen_hero")
 
 
+def test_load_html_removes_multiple_scripts(login_mod, monkeypatch):
+    sample_html = """
+<!-- Right: Login -->
+<aside>legacy</aside>
+<script>one</script>
+<div style=\"grid-template-columns:1.2fr .8fr;\">X</div>
+<script>two</script></body>
+"""
+    monkeypatch.setattr(pathlib.Path, "read_text", lambda self, encoding='utf-8': sample_html)
+    login_mod._load_falowen_login_html.cache_clear()
+    cleaned = login_mod._load_falowen_login_html()
+    assert "<script" not in cleaned
+    assert cleaned.count("</body>") == 1
+
+
 def test_missing_template_shows_error(login_mod, monkeypatch):
     monkeypatch.setattr(pathlib.Path, "read_text", MagicMock(side_effect=FileNotFoundError))
     login_mod._load_falowen_login_html.cache_clear()


### PR DESCRIPTION
## Summary
- sanitize Falowen login HTML by removing all <script> blocks before other cleanup
- add regression test ensuring multiple scripts are removed and </body> remains

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1cf6fc488832198e459964098c383