### PR TITLE
Handle UnicodeDecodeError when loading Falowen login template

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -380,7 +380,12 @@ def _load_falowen_login_html() -> str:
     template may require updating these rules.
     """
     html_path = Path(__file__).parent / "templates" / "falowen_login.html"
-    html = html_path.read_text(encoding="utf-8")
+    try:
+        html = html_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise RuntimeError(
+            "Falowen login template is not valid UTF-8"
+        ) from exc
 
     # Remove legacy "Right: Login" aside block and its script if present
     html = re.sub(r'<!--\s*Right:\s*Login\s*-->[\s\S]*?</aside>', '', html, flags=re.IGNORECASE)

--- a/tests/test_render_falowen_login.py
+++ b/tests/test_render_falowen_login.py
@@ -55,3 +55,11 @@ def test_missing_template_shows_error(login_mod, monkeypatch):
     login_mod.render_falowen_login()
     login_mod.st.error.assert_called_once()
     assert not login_mod.components.html.called
+
+
+def test_unicode_decode_error_raises_runtime_error(login_mod, monkeypatch):
+    err = UnicodeDecodeError("utf-8", b"", 0, 1, "bad data")
+    monkeypatch.setattr(pathlib.Path, "read_text", MagicMock(side_effect=err))
+    login_mod._load_falowen_login_html.cache_clear()
+    with pytest.raises(RuntimeError, match="valid UTF-8"):
+        login_mod._load_falowen_login_html()


### PR DESCRIPTION
## Summary
- Ensure Falowen login template loader raises a clear error when file is not UTF-8
- Add regression test for UnicodeDecodeError scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1cf71dbb883219c4ad4cec568a90b