### PR TITLE
Guard announcement rendering to avoid duplicates

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1467,7 +1467,6 @@ announcements = [
     {"title": "Lesson Links — One Download", "body": "Grab all lesson resources as a single TXT under **Your Work & Links**.", "tag": "New"},
     {"title": "Sprechen", "body": "Record speaking and get instant, level-aware AI feedback in Tools → Sprechen.", "tag": "New"},
 ]
-render_announcements_once(announcements)
 
 st.markdown("---")
 st.markdown("**You’re logged in.** Continue to your lessons and tools from the navigation.")
@@ -1716,6 +1715,9 @@ except Exception as e:
     st.warning(f"Navigation init issue: {e}. Falling back to Dashboard.")
     tab = "Dashboard"
 
+if tab != "Dashboard":
+    render_announcements_once(announcements)
+
 # =========================================================
 # ===================== Dashboard =========================
 # =========================================================
@@ -1781,7 +1783,7 @@ if tab == "Dashboard":
         
     st.divider()
     # ---------- 1) Announcements (top) ----------
-    render_announcements(announcements)
+    render_announcements_once(announcements)
     st.markdown("<div style='height:6px'></div>", unsafe_allow_html=True)
 
     st.divider()


### PR DESCRIPTION
## Summary
- Guard global announcement rendering so it skips when viewing the Dashboard
- Render Dashboard announcements via `render_announcements_once`

## Testing
- `ruff check a1sprechen.py` *(fails: 159 errors)*
- `flake8 a1sprechen.py` *(fails: F821 undefined name 'FPDF')*
- `pytest` *(fails: 6 failed, 71 passed)*
- `streamlit run a1sprechen.py --server.headless true --server.port 8501` *(server started; manual check in browser showed announcement once)*

------
https://chatgpt.com/codex/tasks/task_e_68b36725b020832199a0db00dd510a9e