### PR TITLE
Show Gmail button below login form

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1101,10 +1101,10 @@ def login_page():
     # 2) Branded hero (Google button suppressed inside the template)
     render_falowen_login(auth_url, show_google_in_hero=False)
 
-    # 3) Returning user section + the ONE Google CTA here
+    # 3) Returning user section (Google CTA below the form)
     st.markdown("### Returning user login")
-    render_google_brand_button_once(auth_url, center=True)
     login_success = render_returning_login_area()
+    render_google_brand_button_once(auth_url, center=True)
     if login_success:
         st.rerun()
 


### PR DESCRIPTION
## Summary
- Show Google sign-in button below the returning user login form

## Testing
- `pytest` *(fails: module 'login_module' has no attribute '_load_falowen_login_html')*


------
https://chatgpt.com/codex/tasks/task_e_68b4081c7acc8321b889f08c7a342cbd