### PR TITLE
Reduce announcement section gap

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4695,7 +4695,7 @@ if tab == "My Course":
                         ts_label = ""
                     st.markdown(
                         f"<div style='padding:10px 12px; background:{'#fff7ed' if is_pinned else '#f8fafc'}; "
-                        f"border:1px solid #e5e7eb; border-radius:8px; margin:8px 0;'>"
+                        f"border:1px solid #e5e7eb; border-radius:8px; margin:4px 0;'>"
                         f"{'📌 <b>Pinned</b> • ' if is_pinned else ''}"
                         f"<b>Teacher</b> <span style='color:#888;'>{ts_label} GMT</span><br>"
                         f"{row.get('Announcement','')}"


### PR DESCRIPTION
## Summary
- Reduce announcement component margin for tighter spacing

## Testing
- `pytest` *(fails: render_returning_login_form not found, _load_falowen_login_html attribute errors)*
- `streamlit run a1sprechen.py`

------
https://chatgpt.com/codex/tasks/task_e_68b40a133b0483219581a9a43a6fe035