### PR TITLE
Prevent restoring session with overdue balance

### DIFF
--- a/tests/test_contract_active.py
+++ b/tests/test_contract_active.py
@@ -1,0 +1,49 @@
+import ast
+from pathlib import Path
+from datetime import UTC
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.contracts import is_contract_expired
+
+
+def _load_contract_active():
+    """Load the `_contract_active` function from `a1sprechen.py` without executing
+    the whole module."""
+
+    src = Path(__file__).resolve().parents[1] / "a1sprechen.py"
+    mod_ast = ast.parse(src.read_text())
+    func_node = next(
+        n for n in mod_ast.body if isinstance(n, ast.FunctionDef) and n.name == "_contract_active"
+    )
+    temp_module = ast.Module(body=[func_node], type_ignores=[])
+    code = compile(temp_module, filename="a1sprechen.py", mode="exec")
+    ns: dict = {}
+    exec(code, {"pd": pd, "UTC": UTC, "is_contract_expired": is_contract_expired}, ns)
+    return ns["_contract_active"]
+
+
+def test_contract_inactive_when_expired():
+    _contract_active = _load_contract_active()
+    df = pd.DataFrame([{"StudentCode": "abc", "ContractEnd": "2020-01-01"}])
+    assert _contract_active("abc", df) is False
+
+
+def test_contract_inactive_when_balance_over_30_days():
+    _contract_active = _load_contract_active()
+    start = (pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=40)).strftime("%Y-%m-%d")
+    end = (pd.Timestamp.now(tz="UTC") + pd.Timedelta(days=20)).strftime("%Y-%m-%d")
+    df = pd.DataFrame(
+        [
+            {
+                "StudentCode": "abc",
+                "ContractStart": start,
+                "ContractEnd": end,
+                "Balance": 10,
+            }
+        ]
+    )
+    assert _contract_active("abc", df) is False
+


### PR DESCRIPTION
## Summary
- Extend `_contract_active` to compute days since `ContractStart` and block restoration when balance remains after 30 days.
- Add helper login form and HTML loader utilities to support tests.
- Cover overdue-balance and expired-contract scenarios with tests.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b40ca35b588321817dc777e6ccb87d