### PR TITLE
Remove redundant key from Falowen login component call

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1097,7 +1097,7 @@ def render_falowen_login(google_auth_url: str = "", show_google_in_hero: bool = 
         st.error("Falowen login template missing or unreadable.")
         logging.exception("Failed to load Falowen login HTML")
         return
-    components.html(html, height=720, scrolling=True, key="falowen_hero")
+    components.html(html, height=720, scrolling=True)
 
 # ------------------------------------------------------------------------------
 # Login page (hero + single Google CTA under 'Returning user login' + tabs)

--- a/tests/test_render_falowen_login.py
+++ b/tests/test_render_falowen_login.py
@@ -47,7 +47,7 @@ def test_render_calls_components_html(login_mod, monkeypatch):
     expected_html = login_mod._load_falowen_login_html()
     login_mod.components.html.reset_mock()
     login_mod.render_falowen_login()
-    login_mod.components.html.assert_called_once_with(expected_html, height=720, scrolling=True, key="falowen_hero")
+    login_mod.components.html.assert_called_once_with(expected_html, height=720, scrolling=True)
 
 
 def test_load_html_removes_multiple_scripts(login_mod, monkeypatch):


### PR DESCRIPTION
## Summary
- Drop `key` parameter when rendering the Falowen login HTML.
- Adjust unit test to match the updated `components.html` call.

## Testing
- `pytest`
- `flake8 a1sprechen.py tests/test_render_falowen_login.py` *(fails: F821 undefined name 'FPDF')*
- `streamlit run a1sprechen.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68b40f886e188321ba7283b7358bace3