### PR TITLE
Handle commas in balance check for contract_active

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1432,10 +1432,14 @@ def _contract_active(sc: str, roster):
         days_since_start = (
             pd.Timestamp.now(tz=UTC).date() - start_date.date()
         ).days
-        try:
-            balance = float(row.get("Balance", 0) or 0)
-        except (TypeError, ValueError):
-            balance = 0.0
+        def _read_money(x):
+            try:
+                s = str(x).replace(",", "").replace(" ", "").strip()
+                return float(s) if s not in ("", "nan", "None") else 0.0
+            except Exception:
+                return 0.0
+
+        balance = _read_money(row.get("Balance", 0))
         if balance > 0 and days_since_start >= 30:
             return False
 

--- a/tests/test_contract_active.py
+++ b/tests/test_contract_active.py
@@ -47,3 +47,20 @@ def test_contract_inactive_when_balance_over_30_days():
     )
     assert _contract_active("abc", df) is False
 
+
+def test_balance_string_with_comma_blocks_login():
+    _contract_active = _load_contract_active()
+    start = (pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=35)).strftime("%Y-%m-%d")
+    end = (pd.Timestamp.now(tz="UTC") + pd.Timedelta(days=10)).strftime("%Y-%m-%d")
+    df = pd.DataFrame(
+        [
+            {
+                "StudentCode": "abc",
+                "ContractStart": start,
+                "ContractEnd": end,
+                "Balance": "1,000",
+            }
+        ]
+    )
+    assert _contract_active("abc", df) is False
+


### PR DESCRIPTION
## Summary
- Parse balance with helper stripping commas/spaces in `_contract_active`
- Add regression test to ensure comma-formatted balances trigger login block after 30 days

## Testing
- `pytest tests/test_contract_active.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4132bc24c83219cfe14ba8f8dc42a