### PR TITLE
Check contract balance during login

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -626,6 +626,9 @@ def render_login_form(login_id: str, login_pass: str) -> bool:
     if is_contract_expired(student_row):
         st.error("Your contract has expired. Contact the office."); return False
 
+    if not _contract_active(student_row["StudentCode"], df):
+        st.error("Outstanding balance past due. Contact the office."); return False
+
     doc_ref = db.collection("students").document(student_row["StudentCode"])
     doc = doc_ref.get()
     if not doc.exists:

--- a/tests/test_login_outstanding_balance.py
+++ b/tests/test_login_outstanding_balance.py
@@ -1,0 +1,60 @@
+import ast
+import types
+from pathlib import Path
+from datetime import UTC
+import pandas as pd
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.contracts import is_contract_expired
+
+
+def _load_login_funcs():
+    src_path = Path(__file__).resolve().parents[1] / "a1sprechen.py"
+    mod_ast = ast.parse(src_path.read_text())
+    nodes = [
+        n
+        for n in mod_ast.body
+        if isinstance(n, ast.FunctionDef) and n.name in {"render_login_form", "_contract_active"}
+    ]
+    temp_module = ast.Module(body=nodes, type_ignores=[])
+    code = compile(temp_module, filename="a1sprechen.py", mode="exec")
+
+    mod = types.ModuleType("login_test_module")
+    mod.pd = pd
+    mod.UTC = UTC
+    mod.is_contract_expired = is_contract_expired
+
+    errors: list[str] = []
+
+    class DummyStreamlit:
+        def error(self, msg):
+            errors.append(msg)
+
+    mod.st = DummyStreamlit()
+
+    start = (pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=40)).strftime("%Y-%m-%d")
+    end = (pd.Timestamp.now(tz="UTC") + pd.Timedelta(days=10)).strftime("%Y-%m-%d")
+    df = pd.DataFrame(
+        [
+            {
+                "StudentCode": "abc",
+                "Email": "abc@example.com",
+                "Name": "Alice",
+                "ContractStart": start,
+                "ContractEnd": end,
+                "Balance": 5,
+            }
+        ]
+    )
+    mod.load_student_data = lambda: df
+
+    exec(code, mod.__dict__)
+    return mod, errors
+
+
+def test_login_rejected_when_balance_overdue():
+    mod, errors = _load_login_funcs()
+    ok = mod.render_login_form("abc", "pw")
+    assert ok is False
+    assert errors and "Outstanding balance past due" in errors[0]


### PR DESCRIPTION
## Summary
- Verify _contract_active within login to block users with overdue balances
- Add regression test for login rejection when balance overdue

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4176c3f848321b1205e136c246a7c