### PR TITLE
Reset Google sign-in button state on logout

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1235,6 +1235,7 @@ def _do_logout():
         "session_token": "",
         "student_level": "",
     })
+    st.session_state.pop("_google_btn_rendered", None)
     st.success("You’ve been logged out.")
     st.rerun()
 

--- a/tests/test_logout_rerenders_google_button.py
+++ b/tests/test_logout_rerenders_google_button.py
@@ -1,0 +1,48 @@
+import ast
+import pathlib
+import types
+from unittest.mock import MagicMock
+
+
+def load_module():
+    path = pathlib.Path(__file__).resolve().parents[1] / "a1sprechen.py"
+    source = path.read_text()
+    module_ast = ast.parse(source)
+    nodes = []
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef) and node.name in {"_do_logout", "render_google_signin_once"}:
+            nodes.append(node)
+    mod = types.ModuleType("logout_module")
+    mod.__file__ = str(path)
+    mod.st = types.SimpleNamespace(
+        session_state={},
+        success=MagicMock(),
+        rerun=MagicMock(),
+        link_button=MagicMock(),
+    )
+    mod.components = types.SimpleNamespace(html=MagicMock())
+    mod.clear_session = MagicMock()
+    mod.destroy_session_token = MagicMock()
+    mod.cookie_manager = object()
+    mod.logging = types.SimpleNamespace(exception=MagicMock())
+    code = compile(ast.Module(body=nodes, type_ignores=[]), "logout_module", "exec")
+    exec(code, mod.__dict__)
+    return mod
+
+
+def test_google_button_reappears_after_logout():
+    mod = load_module()
+
+    # Initial render simulates login page showing the button
+    mod.render_google_signin_once("https://auth.example")
+    assert mod.st.session_state.get("_google_btn_rendered") is True
+    mod.components.html.assert_called_once()
+
+    # After logout the flag should be cleared
+    mod.components.html.reset_mock()
+    mod._do_logout()
+    assert "_google_btn_rendered" not in mod.st.session_state
+
+    # Rendering login again should call html once more
+    mod.render_google_signin_once("https://auth.example")
+    mod.components.html.assert_called_once()


### PR DESCRIPTION
## Summary
- Clear `_google_btn_rendered` flag during logout so the Google login button renders again
- Add regression test to ensure the Google sign-in button reappears after logging out

## Testing
- `ruff check .` *(fails: 178 errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b41935776083218e96485420587ba9