### PR TITLE
Clear announcement flag on logout

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1236,6 +1236,7 @@ def _do_logout():
         "student_level": "",
     })
     st.session_state.pop("_google_btn_rendered", None)
+    st.session_state.pop("_ann_rendered", None)
     st.success("You’ve been logged out.")
     st.rerun()
 

--- a/tests/test_logout_clears_ann_flag.py
+++ b/tests/test_logout_clears_ann_flag.py
@@ -1,0 +1,35 @@
+import ast
+import pathlib
+import types
+from unittest.mock import MagicMock
+
+
+def load_module():
+    path = pathlib.Path(__file__).resolve().parents[1] / "a1sprechen.py"
+    source = path.read_text()
+    module_ast = ast.parse(source)
+    nodes = []
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_do_logout":
+            nodes.append(node)
+    mod = types.ModuleType("logout_module")
+    mod.__file__ = str(path)
+    mod.st = types.SimpleNamespace(
+        session_state={"_ann_rendered": True},
+        success=MagicMock(),
+        rerun=MagicMock(),
+    )
+    mod.clear_session = MagicMock()
+    mod.destroy_session_token = MagicMock()
+    mod.cookie_manager = object()
+    mod.logging = types.SimpleNamespace(exception=MagicMock())
+    code = compile(ast.Module(body=nodes, type_ignores=[]), "logout_module", "exec")
+    exec(code, mod.__dict__)
+    return mod
+
+
+def test_ann_flag_reset_after_logout():
+    mod = load_module()
+    assert mod.st.session_state.get("_ann_rendered") is True
+    mod._do_logout()
+    assert "_ann_rendered" not in mod.st.session_state


### PR DESCRIPTION
## Summary
- Clear `_ann_rendered` flag in `_do_logout` to reset announcements
- Add unit test ensuring announcement flag is cleared after logout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41b3c792c832191dad49393ab4406