### PR TITLE
Reset Google button flags on logout

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1236,6 +1236,10 @@ def _do_logout():
         "student_level": "",
     })
     st.session_state.pop("_google_btn_rendered", None)
+    st.session_state.pop("_google_cta_rendered", None)
+    btn_keys = [k for k in st.session_state.keys() if k.startswith("__google_btn_rendered::")]
+    for k in btn_keys:
+        st.session_state.pop(k, None)
     st.success("You’ve been logged out.")
     st.rerun()
 


### PR DESCRIPTION
## Summary
- Clear Google button render flags on logout to ensure buttons reappear
- Extend logout tests to verify CTA and per-key Google buttons reset and rerender

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41b368b648321bd8dd30485c4189c