### PR TITLE
Ensure logout clears announcement and Google button state

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1236,6 +1236,11 @@ def _do_logout():
         "student_level": "",
     })
     st.session_state.pop("_google_btn_rendered", None)
+    st.session_state.pop("_google_cta_rendered", None)
+    st.session_state.pop("_ann_rendered", None)
+    for k in list(st.session_state.keys()):
+        if k.startswith("__google_btn_rendered::"):
+            st.session_state.pop(k, None)
     st.success("You’ve been logged out.")
     st.rerun()
 

--- a/tests/test_logout_rerenders_google_button.py
+++ b/tests/test_logout_rerenders_google_button.py
@@ -9,8 +9,15 @@ def load_module():
     source = path.read_text()
     module_ast = ast.parse(source)
     nodes = []
+    wanted = {
+        "_do_logout",
+        "render_google_signin_once",
+        "render_google_brand_button_once",
+        "render_google_button_once",
+        "render_announcements_once",
+    }
     for node in module_ast.body:
-        if isinstance(node, ast.FunctionDef) and node.name in {"_do_logout", "render_google_signin_once"}:
+        if isinstance(node, ast.FunctionDef) and node.name in wanted:
             nodes.append(node)
     mod = types.ModuleType("logout_module")
     mod.__file__ = str(path)
@@ -19,30 +26,64 @@ def load_module():
         success=MagicMock(),
         rerun=MagicMock(),
         link_button=MagicMock(),
+        markdown=MagicMock(),
     )
     mod.components = types.SimpleNamespace(html=MagicMock())
     mod.clear_session = MagicMock()
     mod.destroy_session_token = MagicMock()
     mod.cookie_manager = object()
     mod.logging = types.SimpleNamespace(exception=MagicMock())
+    mod.render_announcements = MagicMock()
     code = compile(ast.Module(body=nodes, type_ignores=[]), "logout_module", "exec")
     exec(code, mod.__dict__)
     return mod
 
 
-def test_google_button_reappears_after_logout():
+def test_logout_rerenders_components():
     mod = load_module()
 
-    # Initial render simulates login page showing the button
+    # Initial renders
+    mod.render_announcements_once([{"title": "t", "body": "b"}])
+    assert mod.st.session_state.get("_ann_rendered") is True
+    mod.render_announcements.assert_called_once()
+
+    mod.st.markdown.reset_mock()
+    mod.render_google_brand_button_once("https://auth.example")
+    assert mod.st.session_state.get("_google_cta_rendered") is True
+    mod.st.markdown.assert_called_once()
+
+    mod.st.markdown.reset_mock()
+    mod.render_google_button_once("https://auth.example", key="primary")
+    assert mod.st.session_state.get("__google_btn_rendered::primary") is True
+    mod.st.markdown.assert_called_once()
+
+    mod.components.html.reset_mock()
     mod.render_google_signin_once("https://auth.example")
     assert mod.st.session_state.get("_google_btn_rendered") is True
     mod.components.html.assert_called_once()
 
-    # After logout the flag should be cleared
+    # After logout the flags should be cleared
+    mod.render_announcements.reset_mock()
     mod.components.html.reset_mock()
+    mod.st.markdown.reset_mock()
     mod._do_logout()
+    assert "_ann_rendered" not in mod.st.session_state
+    assert "_google_cta_rendered" not in mod.st.session_state
+    assert "__google_btn_rendered::primary" not in mod.st.session_state
     assert "_google_btn_rendered" not in mod.st.session_state
 
-    # Rendering login again should call html once more
+    # Re-render components after logout
+    mod.render_announcements_once([{"title": "t", "body": "b"}])
+    mod.render_announcements.assert_called_once()
+
+    mod.st.markdown.reset_mock()
+    mod.render_google_brand_button_once("https://auth.example")
+    mod.st.markdown.assert_called_once()
+
+    mod.st.markdown.reset_mock()
+    mod.render_google_button_once("https://auth.example", key="primary")
+    mod.st.markdown.assert_called_once()
+
+    mod.components.html.reset_mock()
     mod.render_google_signin_once("https://auth.example")
     mod.components.html.assert_called_once()


### PR DESCRIPTION
## Summary
- Clear announcement and Google button flags from session on logout
- Extend logout tests to assert all render flags are removed and components re-render

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41b34bb1c8321b3502b50ac2f1a35