### PR TITLE
Clear announcements cache on logout

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1241,6 +1241,7 @@ def _do_logout():
     st.session_state.pop("_google_btn_rendered", None)
     st.session_state.pop("_google_cta_rendered", None)
     st.session_state.pop("_ann_rendered", None)
+    st.session_state.pop("announcements_df", None)
     for k in list(st.session_state.keys()):
         if k.startswith("__google_btn_rendered::"):
             st.session_state.pop(k, None)

--- a/tests/test_announcements_persist_after_multiple_logout.py
+++ b/tests/test_announcements_persist_after_multiple_logout.py
@@ -1,0 +1,59 @@
+import ast
+import pathlib
+import types
+from unittest.mock import MagicMock
+
+
+def load_module():
+    path = pathlib.Path(__file__).resolve().parents[1] / "a1sprechen.py"
+    source = path.read_text()
+    module_ast = ast.parse(source)
+    nodes = []
+    wanted = {
+        "_do_logout",
+        "fetch_announcements_csv",
+        "render_announcements_once",
+    }
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef) and node.name in wanted:
+            nodes.append(node)
+    mod = types.ModuleType("logout_module")
+    mod.__file__ = str(path)
+    mod.st = types.SimpleNamespace(
+        session_state={"logged_in": True},
+        success=MagicMock(),
+        rerun=MagicMock(),
+    )
+    mod.clear_session = MagicMock()
+    mod.destroy_session_token = MagicMock()
+    mod.cookie_manager = object()
+    mod.logging = types.SimpleNamespace(exception=MagicMock())
+    mod.render_announcements = MagicMock()
+    mod._fetch_announcements_csv_cached = MagicMock(side_effect=["df1", "df2"])
+    code = compile(ast.Module(body=nodes, type_ignores=[]), "logout_module", "exec")
+    exec(code, mod.__dict__)
+    return mod
+
+
+def test_announcements_render_after_double_logout():
+    mod = load_module()
+
+    # Initial login and fetch
+    assert mod.fetch_announcements_csv() == "df1"
+    assert mod._fetch_announcements_csv_cached.call_count == 1
+    mod.render_announcements_once([{"title": "t", "body": "b"}])
+    mod.render_announcements.assert_called_once()
+
+    # Logout twice
+    mod._do_logout()
+    mod._do_logout()
+
+    # Simulate logging in again
+    mod.st.session_state["logged_in"] = True
+    mod.render_announcements.reset_mock()
+
+    # Fresh fetch and render
+    assert mod.fetch_announcements_csv() == "df2"
+    assert mod._fetch_announcements_csv_cached.call_count == 2
+    mod.render_announcements_once([{"title": "t2", "body": "b2"}])
+    mod.render_announcements.assert_called_once()


### PR DESCRIPTION
## Summary
- Clear cached announcements DataFrame during logout so each session reloads announcements
- Add regression test covering double logout and subsequent announcements rendering

## Testing
- `ruff check tests/test_announcements_persist_after_multiple_logout.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4209aeb48832184550e2c4d18dcbe