### PR TITLE
Return copy when loading announcements

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1596,7 +1596,7 @@ def _fetch_announcements_csv_cached():
 def fetch_announcements_csv():
     if "announcements_df" not in st.session_state:
         st.session_state["announcements_df"] = _fetch_announcements_csv_cached()
-    return st.session_state["announcements_df"]
+    return st.session_state["announcements_df"].copy()
 
 def parse_contract_start(date_str: str):
 

--- a/tests/test_fetch_announcements_returns_pristine_copy.py
+++ b/tests/test_fetch_announcements_returns_pristine_copy.py
@@ -1,0 +1,48 @@
+import ast
+import types
+from pathlib import Path
+
+import pandas as pd
+
+
+def _load_fetch_module():
+    src_path = Path(__file__).resolve().parents[1] / "a1sprechen.py"
+    tree = ast.parse(src_path.read_text())
+    mod = types.ModuleType("_fetch_mod")
+
+    class FakeStreamlit:
+        def __init__(self):
+            self.session_state = {}
+            self.secrets = {}
+
+        def cache_data(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            if args and callable(args[0]) and not kwargs:
+                return args[0]
+            return decorator
+
+    mod.st = FakeStreamlit()
+    mod.pd = pd
+
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in (
+            "_fetch_announcements_csv_cached",
+            "fetch_announcements_csv",
+        ):
+            code = compile(ast.Module(body=[node], type_ignores=[]), filename=str(src_path), mode="exec")
+            exec(code, mod.__dict__)
+    return mod
+
+
+def test_fetch_announcements_returns_pristine_copy():
+    mod = _load_fetch_module()
+    original = pd.DataFrame({"Announcement": ["Hello"]})
+    mod._fetch_announcements_csv_cached = lambda: original.copy()
+
+    first = mod.fetch_announcements_csv()
+    first.loc[0, "Announcement"] = "Changed"
+    first["Extra"] = 1
+
+    second = mod.fetch_announcements_csv()
+    pd.testing.assert_frame_equal(second, original)


### PR DESCRIPTION
## Summary
- Ensure `fetch_announcements_csv` returns a copy of the cached announcements DataFrame, preventing in-place mutation from affecting session state
- Add unit test verifying repeated calls to `fetch_announcements_csv` remain pristine after DataFrame processing

## Testing
- `ruff check tests/test_fetch_announcements_returns_pristine_copy.py`
- `pytest tests/test_fetch_announcements_returns_pristine_copy.py -q`
- `ruff check a1sprechen.py tests/test_fetch_announcements_returns_pristine_copy.py` *(fails: existing lint errors in repository)*


------
https://chatgpt.com/codex/tasks/task_e_68b4209c774c8321a1c33f9693fae747