### PR TITLE
Handle announcement rendering errors gracefully

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1412,8 +1412,13 @@ def render_sidebar_published():
 # ------------------------------------------------------------------------------
 def render_announcements_once(data: list):
     if not st.session_state.get("_ann_rendered"):
-        render_announcements(data)
-        st.session_state["_ann_rendered"] = True
+        try:
+            render_announcements(data)
+        except Exception:
+            logging.exception("Failed to render announcements")
+            st.warning("Announcements are temporarily unavailable.")
+        else:
+            st.session_state["_ann_rendered"] = True
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_announcements_persist_after_multiple_logout.py
+++ b/tests/test_announcements_persist_after_multiple_logout.py
@@ -29,7 +29,9 @@ def load_module():
     mod.cookie_manager = object()
     mod.logging = types.SimpleNamespace(exception=MagicMock())
     mod.render_announcements = MagicMock()
-    mod._fetch_announcements_csv_cached = MagicMock(side_effect=["df1", "df2"])
+    data1 = types.SimpleNamespace(copy=MagicMock(return_value="df1"))
+    data2 = types.SimpleNamespace(copy=MagicMock(return_value="df2"))
+    mod._fetch_announcements_csv_cached = MagicMock(side_effect=[data1, data2])
     code = compile(ast.Module(body=nodes, type_ignores=[]), "logout_module", "exec")
     exec(code, mod.__dict__)
     return mod

--- a/tests/test_render_announcements_once_error_handling.py
+++ b/tests/test_render_announcements_once_error_handling.py
@@ -1,0 +1,35 @@
+import ast
+import pathlib
+import types
+from unittest.mock import MagicMock
+
+
+def load_module():
+    path = pathlib.Path(__file__).resolve().parents[1] / "a1sprechen.py"
+    source = path.read_text()
+    module_ast = ast.parse(source)
+    nodes = []
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "render_announcements_once":
+            nodes.append(node)
+    mod = types.ModuleType("ann_module")
+    mod.__file__ = str(path)
+    mod.st = types.SimpleNamespace(
+        session_state={},
+        warning=MagicMock(),
+        error=MagicMock(),
+    )
+    mod.render_announcements = MagicMock(side_effect=Exception("boom"))
+    mod.logging = types.SimpleNamespace(exception=MagicMock())
+    code = compile(ast.Module(body=nodes, type_ignores=[]), "ann_module", "exec")
+    exec(code, mod.__dict__)
+    return mod
+
+
+def test_render_announcements_once_handles_exception():
+    mod = load_module()
+    mod.render_announcements_once([{ "title": "t", "body": "b" }])
+    mod.render_announcements.assert_called_once()
+    mod.logging.exception.assert_called_once()
+    mod.st.warning.assert_called_once()
+    assert "_ann_rendered" not in mod.st.session_state


### PR DESCRIPTION
## Summary
- guard announcement rendering with try/except so failures are logged and warned without blocking retries
- adjust announcement tests to use copyable mocks and add coverage for exception handling

## Testing
- `ruff check .` *(fails: multiple existing lint errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4252cc1c48321882ef781620e3dae