### PR TITLE
Remove letter coach usage tracking

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -107,8 +107,6 @@ from src.schreiben import (
     save_schreiben_feedback,
     load_schreiben_feedback,
     delete_schreiben_feedback,
-    get_letter_coach_usage,
-    inc_letter_coach_usage,
 )
 from src.group_schedules import load_group_schedules
 from src.schedule import load_level_schedules, get_level_schedules
@@ -7864,13 +7862,6 @@ if tab == "Schreiben Trainer":
             unsafe_allow_html=True
         )
 
-        IDEAS_LIMIT = 14
-        ideas_so_far = get_letter_coach_usage(student_code)
-        st.markdown(f"**Daily usage:** {ideas_so_far} / {IDEAS_LIMIT}")
-        if ideas_so_far >= IDEAS_LIMIT:
-            st.warning("You have reached today's letter coach limit. Please come back tomorrow.")
-            st.stop()
-
         # --- Stage 0: Prompt input ---
         if st.session_state[ns("stage")] == 0:
             if st.button("Start new write-up"):
@@ -7951,7 +7942,6 @@ if tab == "Schreiben Trainer":
 
                     st.session_state[ns("chat")] = chat_history
                     st.session_state[ns("stage")] = 1
-                    inc_letter_coach_usage(student_code)
                     save_letter_coach_progress(
                         student_code,
                         student_level,

--- a/src/schreiben.py
+++ b/src/schreiben.py
@@ -7,7 +7,7 @@ extracted into their own module for easier reuse and testing.
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime
+from datetime import datetime
 from typing import Optional, Tuple
 
 import streamlit as st
@@ -212,48 +212,6 @@ def delete_schreiben_feedback(student_code: str) -> None:
     db.collection("schreiben_feedback").document(student_code).delete()
 
 
-# ---------------------------------------------------------------------------
-# Letter Coach usage tracking
-# ---------------------------------------------------------------------------
-
-
-def get_letter_coach_usage(student_code: str) -> int:
-    if not student_code:
-        st.warning("No student code provided; usage assumed 0.")
-        return 0
-    if db is None:
-        st.warning("Firestore not initialized; usage assumed 0.")
-        return 0
-
-    today = str(date.today())
-    doc = db.collection("letter_coach_usage").document(
-        f"{student_code}_{today}"
-    ).get()
-    return doc.to_dict().get("count", 0) if doc.exists else 0
-
-
-def inc_letter_coach_usage(student_code: str) -> None:
-    if not student_code:
-        st.warning("No student code provided; usage assumed 0.")
-        return
-    if db is None:
-        st.warning("Firestore not initialized; usage assumed 0.")
-        return
-
-    today = str(date.today())
-    doc_ref = db.collection("letter_coach_usage").document(
-        f"{student_code}_{today}"
-    )
-    try:
-        doc = doc_ref.get()
-        if doc.exists:
-            doc_ref.update({"count": firestore.Increment(1)})
-        else:
-            doc_ref.set({"student_code": student_code, "date": today, "count": 1})
-    except Exception as exc:  # pragma: no cover - network failure
-        st.error(f"Failed to increment Letter Coach usage: {exc}")
-
-
 __all__ = [
     "update_schreiben_stats",
     "get_schreiben_stats",
@@ -261,6 +219,4 @@ __all__ = [
     "save_schreiben_feedback",
     "load_schreiben_feedback",
     "delete_schreiben_feedback",
-    "get_letter_coach_usage",
-    "inc_letter_coach_usage",
 ]

--- a/tests/test_schreiben_helpers.py
+++ b/tests/test_schreiben_helpers.py
@@ -14,9 +14,7 @@ def helpers(monkeypatch):
     monkeypatch.setattr(mod, "db", MagicMock())
     monkeypatch.setattr(mod, "FieldFilter", MagicMock())
     monkeypatch.setattr(mod, "firestore", MagicMock())
-    monkeypatch.setattr(mod, "date", MagicMock())
 
-    mod.date.today = MagicMock()
     return mod
 
 
@@ -101,9 +99,3 @@ def test_save_submission_no_db(monkeypatch):
     mod.st.warning.assert_called_once()
 
 
-def test_get_letter_coach_usage_empty(helpers):
-    count = helpers.get_letter_coach_usage("")
-    helpers.db.collection.assert_not_called()
-    helpers.date.today.assert_not_called()
-    helpers.st.warning.assert_called_once()
-    assert count == 0


### PR DESCRIPTION
## Summary
- Drop letter coach usage counters and daily limit from the main app.
- Simplify `src.schreiben` by removing usage tracking helpers and cleaning `__all__`.
- Adjust Schreiben helper tests to reflect removed APIs.

## Testing
- `ruff check .` *(fails: Multiple style errors across repo)*
- `ruff check src/schreiben.py tests/test_schreiben_helpers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48d96620c832185f7175e4cbb5109