### PR TITLE
Handle missing student code on session restore

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1472,11 +1472,16 @@ if restored is not None and not st.session_state.get("logged_in", False):
     sc_cookie = restored["student_code"]
     token = restored["session_token"]
     roster = restored.get("data")
-    row = (
-        roster[roster["StudentCode"].str.lower() == sc_cookie].iloc[0]
+    matches = (
+        roster[roster["StudentCode"].str.lower() == sc_cookie]
         if roster is not None and "StudentCode" in roster.columns
-        else {}
+        else pd.DataFrame()
     )
+    if matches.empty:
+        logging.warning("Student code %s not found in roster", sc_cookie)
+        row = {}
+    else:
+        row = matches.iloc[0]
     level = determine_level(sc_cookie, row)
     st.session_state.update({
         "logged_in": True,


### PR DESCRIPTION
## Summary
- Prevent IndexError when student code is absent during session restoration by checking matches before accessing
- Update session restore tests to use safe row lookup and add regression test for missing student codes

## Testing
- `ruff check a1sprechen.py tests/test_session_restore.py` *(fails: existing lint errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4aee6e3648321b70119aa6177eee6