### PR TITLE
test: ensure _go updates nav and main tab

### DIFF
--- a/tests/test_sidebar_go_rerun.py
+++ b/tests/test_sidebar_go_rerun.py
@@ -1,5 +1,6 @@
 import ast, types, pathlib
 from unittest.mock import MagicMock
+import pytest
 
 def load_go_module():
     path = pathlib.Path(__file__).resolve().parents[1] / "a1sprechen.py"
@@ -21,9 +22,22 @@ def load_go_module():
     exec(code, mod.__dict__)
     return mod
 
-def test_go_sets_flag_and_triggers_rerun():
+@pytest.mark.parametrize(
+    "tab",
+    [
+        "Dashboard",
+        "My Course",
+        "My Results and Resources",
+        "Exams Mode & Custom Chat",
+        "Vocab Trainer",
+        "Schreiben Trainer",
+    ],
+)
+def test_go_updates_state_and_triggers_rerun(tab: str):
     mod = load_go_module()
-    mod._go("Dashboard")
+    mod._go(tab)
+    assert mod.st.session_state["nav_sel"] == tab
+    assert mod.st.session_state["main_tab_select"] == tab
     assert mod.st.session_state["needs_rerun"] is True
     if mod.st.session_state.pop("needs_rerun", False):
         mod.st.rerun()


### PR DESCRIPTION
## Summary
- parameterize sidebar navigation `_go` tests for all quick access tabs
- verify `_go` sets `nav_sel` and `main_tab_select` along with triggering rerun

## Testing
- `pytest tests/test_sidebar_go_rerun.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b2c4b2e4832187af72007c9db532