### PR TITLE
Replace rerun flag with direct rerun calls

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -50,9 +50,6 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-if st.session_state.pop("needs_rerun", False):
-    st.rerun()
-
 
 # --- Falowen modules ---
 from falowen.email_utils import send_reset_email, build_gas_reset_link, GAS_RESET_URL
@@ -1249,8 +1246,8 @@ def _do_logout():
     for k in list(st.session_state.keys()):
         if k.startswith("__google_btn_rendered::"):
             st.session_state.pop(k, None)
-    st.session_state["needs_rerun"] = True
     st.success("You’ve been logged out.")
+    st.rerun()
 
 def render_logged_in_topbar():
     name  = st.session_state.get("student_name", "")
@@ -1345,7 +1342,7 @@ def render_sidebar_published():
         st.session_state["nav_sel"] = tab_name
         st.session_state["main_tab_select"] = tab_name
         _qp_set_safe(tab=tab_name)
-        st.session_state["needs_rerun"] = True
+        st.rerun()
 
     st.sidebar.markdown("## Quick access")
     st.sidebar.button("🏠 Dashboard",                use_container_width=True, on_click=_go, args=("Dashboard",))

--- a/src/resume.py
+++ b/src/resume.py
@@ -40,7 +40,7 @@ def render_resume_banner() -> None:
     if isinstance(pos, int) and pos > 0:
         def _jump() -> None:
             st.query_params["section"] = str(pos)
-            st.session_state["needs_rerun"] = True
+            st.rerun()
 
         st.info(
             f"You last stopped at section {pos} – pick up where you left off!"

--- a/tests/test_resume_banner.py
+++ b/tests/test_resume_banner.py
@@ -7,6 +7,7 @@ class DummyST:
         self.query_params = {}
         self.info_messages = []
         self.button_calls = []
+        self.rerun_called = False
 
     def info(self, msg):
         self.info_messages.append(msg)
@@ -14,6 +15,9 @@ class DummyST:
     def button(self, label, *, on_click=None):
         self.button_calls.append((label, on_click))
         return False
+
+    def rerun(self):
+        self.rerun_called = True
 
 @pytest.fixture
 def dummy_st(monkeypatch):
@@ -45,4 +49,5 @@ def test_resume_navigation_callback(dummy_st):
     assert cb is not None
     cb()
     assert dummy_st.query_params["section"] == "4"
-    assert dummy_st.session_state["needs_rerun"] is True
+    assert dummy_st.rerun_called is True
+    assert "needs_rerun" not in dummy_st.session_state

--- a/tests/test_sidebar_go_rerun.py
+++ b/tests/test_sidebar_go_rerun.py
@@ -21,10 +21,8 @@ def load_go_module():
     exec(code, mod.__dict__)
     return mod
 
-def test_go_sets_flag_and_triggers_rerun():
+def test_go_triggers_rerun_directly():
     mod = load_go_module()
     mod._go("Dashboard")
-    assert mod.st.session_state["needs_rerun"] is True
-    if mod.st.session_state.pop("needs_rerun", False):
-        mod.st.rerun()
+    assert "needs_rerun" not in mod.st.session_state
     mod.st.rerun.assert_called_once()


### PR DESCRIPTION
## Summary
- Call `st.rerun()` directly in sidebar navigation and logout handler
- Drop `needs_rerun` flag usage and top-level rerun check
- Adjust resume banner and tests to expect direct reruns

## Testing
- `pytest -q`
- `ruff check .` *(fails: unrecognized subcommand '.' / multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b2b7b900832186e89a81d28fafd0