### PR TITLE
Use session flag for sidebar rerun

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -50,6 +50,9 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
+if st.session_state.pop("needs_rerun", False):
+    st.rerun()
+
 
 # --- Falowen modules ---
 from falowen.email_utils import send_reset_email, build_gas_reset_link, GAS_RESET_URL
@@ -1342,7 +1345,7 @@ def render_sidebar_published():
         st.session_state["nav_sel"] = tab_name
         st.session_state["main_tab_select"] = tab_name
         _qp_set_safe(tab=tab_name)
-        st.rerun()
+        st.session_state["needs_rerun"] = True
 
     st.sidebar.markdown("## Quick access")
     st.sidebar.button("🏠 Dashboard",                use_container_width=True, on_click=_go, args=("Dashboard",))

--- a/tests/test_sidebar_go_rerun.py
+++ b/tests/test_sidebar_go_rerun.py
@@ -22,9 +22,8 @@ def load_go_module():
     exec(code, mod.__dict__)
     return mod
 
-def test_go_triggers_rerun_directly():
+def test_go_sets_rerun_flag():
     mod = load_go_module()
     mod._go("Dashboard")
-    assert "needs_rerun" not in mod.st.session_state
-
-    mod.st.rerun.assert_called_once()
+    assert mod.st.session_state.get("needs_rerun") is True
+    mod.st.rerun.assert_not_called()


### PR DESCRIPTION
## Summary
- trigger page reruns via a session flag
- defer rerun outside `_go` callback
- update sidebar navigation test for flag-based rerun

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b564536c83219ec9afe92cbdd1b9