### PR TITLE
Render announcements across all tabs

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1761,9 +1761,7 @@ try:
 except Exception as e:
     st.warning(f"Navigation init issue: {e}. Falling back to Dashboard.")
     tab = "Dashboard"
-
-if tab != "Dashboard":
-    render_announcements_once(announcements)
+render_announcements_once(announcements)
 
 
 # =========================================================


### PR DESCRIPTION
## Summary
- render global announcements unconditionally after tab selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d13bec908321a429b03c6f3a6008