### PR TITLE
Defer rerun in sidebar navigation via session flag

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1340,7 +1340,7 @@ def render_sidebar_published():
         st.session_state["nav_sel"] = tab_name
         st.session_state["main_tab_select"] = tab_name
         _qp_set_safe(tab=tab_name)
-        st.rerun()
+        st.session_state["needs_rerun"] = True
 
     st.sidebar.markdown("## Quick access")
     st.sidebar.button("🏠 Dashboard",                use_container_width=True, on_click=_go, args=("Dashboard",))


### PR DESCRIPTION
## Summary
- mark sidebar navigation callback to rerun via `st.session_state["needs_rerun"]` instead of calling `st.rerun()` immediately
- rely on existing `needs_rerun` check at startup to trigger reruns after callbacks complete

## Testing
- `ruff check a1sprechen.py` *(fails: Found 160 errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d14c6b2c832188ef11dc2eef886f