### PR TITLE
Fix badges markdown string delimitation

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -444,12 +444,12 @@ def render_results_and_resources_tab() -> None:
         with st.expander("What badges can you earn?", expanded=False):
             st.markdown(
                 """
-                - 🏆 **Completion Trophy**: Finish all assignments for your level.
-                - 🥇 **Gold Badge**: Maintain an average score above 80.
-                - 🥈 **Silver Badge**: Average score above 70.
-                - 🥉 **Bronze Badge**: Average score above 60.
-                - 🌟 **Star Performer**: Score 85 or higher on any assignment.
-                """
+- 🏆 **Completion Trophy**: Finish all assignments for your level.
+- 🥇 **Gold Badge**: Maintain an average score above 80.
+- 🥈 **Silver Badge**: Average score above 70.
+- 🥉 **Bronze Badge**: Average score above 60.
+- 🌟 **Star Performer**: Score 85 or higher on any assignment.
+"""
             )
 
         badge_count = 0


### PR DESCRIPTION
## Summary
- Fix markdown bullet list in Badges section to use a clean triple-quoted string

## Testing
- `python -m py_compile src/assignment_ui.py`
- `streamlit run a1sprechen.py`

------
https://chatgpt.com/codex/tasks/task_e_68b57b8a2a4c8321aa16a8748ef95598