### PR TITLE
Add receipt PDF generation with student balance support

### DIFF
--- a/tests/test_receipt_pdf.py
+++ b/tests/test_receipt_pdf.py
@@ -1,0 +1,7 @@
+from src.assignment_ui import generate_receipt_pdf
+
+
+def test_generate_receipt_pdf_returns_bytes():
+    pdf_bytes = generate_receipt_pdf("Jane Doe", "A1", 100.0, 50.0, "2024-05-01")
+    assert isinstance(pdf_bytes, (bytes, bytearray))
+    assert len(pdf_bytes) > 0


### PR DESCRIPTION
## Summary
- Add `generate_receipt_pdf` helper to produce simple payment receipts
- Pull `Paid` and `Balance` columns via `load_student_data` and expose a receipt generator in downloads
- Include tests for receipt PDF generation

## Testing
- `ruff check src/assignment_ui.py tests/test_receipt_pdf.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58e577cb48321a438837d8131b3ed