### PR TITLE
feat: add configurable letterhead and watermark

### DIFF
--- a/tests/test_enrollment_letter_pdf.py
+++ b/tests/test_enrollment_letter_pdf.py
@@ -16,7 +16,10 @@ def test_generate_enrollment_letter_pdf_returns_bytes(monkeypatch):
         def raise_for_status(self):
             return None
 
+    call_count = {"count": 0}
+
     def fake_get(url, timeout=0):
+        call_count["count"] += 1
         return DummyResp()
 
     # Patch network call and QR code generator
@@ -28,3 +31,5 @@ def test_generate_enrollment_letter_pdf_returns_bytes(monkeypatch):
     )
     assert isinstance(pdf_bytes, (bytes, bytearray))
     assert len(pdf_bytes) > 0
+    # Letterhead and watermark images should each trigger a download
+    assert call_count["count"] == 2


### PR DESCRIPTION
## Summary
- add configurable LETTERHEAD_URL and WATERMARK_URL constants
- include letterhead and centered watermark in enrollment PDF generation
- adjust PDF tests to mock image downloads and validate bytes output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5919d1c588321a5ea7c69ff4f65a0