### PR TITLE
Persist dashboard announcements

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1240,7 +1240,7 @@ def _do_logout():
     })
     st.session_state.pop("_google_btn_rendered", None)
     st.session_state.pop("_google_cta_rendered", None)
-    st.session_state.pop("_ann_rendered", None)
+    st.session_state.pop("_ann_hash", None)
     for k in list(st.session_state.keys()):
         if k.startswith("__google_btn_rendered::"):
             st.session_state.pop(k, None)
@@ -1411,12 +1411,15 @@ def render_sidebar_published():
 
 
 # ------------------------------------------------------------------------------
-# Small helper: render announcements once per rerun
+# Small helper: render announcements when dashboard is active or data changes
 # ------------------------------------------------------------------------------
-def render_announcements_once(data: list):
-    if not st.session_state.get("_ann_rendered"):
-        render_announcements(data)
-        st.session_state["_ann_rendered"] = True
+def render_announcements_once(data: list, dashboard_active: bool):
+    data_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8")).hexdigest()
+    prev_hash = st.session_state.get("_ann_hash")
+    if dashboard_active or data_hash != prev_hash:
+        if dashboard_active:
+            render_announcements(data)
+        st.session_state["_ann_hash"] = data_hash
 
 
 # ------------------------------------------------------------------------------
@@ -1770,7 +1773,7 @@ try:
 except Exception as e:
     st.warning(f"Navigation init issue: {e}. Falling back to Dashboard.")
     tab = "Dashboard"
-render_announcements_once(announcements)
+render_announcements_once(announcements, tab == "Dashboard")
 
 
 # =========================================================

--- a/tests/test_logout_clears_ann_flag.py
+++ b/tests/test_logout_clears_ann_flag.py
@@ -15,7 +15,7 @@ def load_module():
     mod = types.ModuleType("logout_module")
     mod.__file__ = str(path)
     mod.st = types.SimpleNamespace(
-        session_state={"_ann_rendered": True},
+        session_state={"_ann_hash": "abc"},
         success=MagicMock(),
         rerun=MagicMock(),
     )
@@ -30,6 +30,6 @@ def load_module():
 
 def test_ann_flag_reset_after_logout():
     mod = load_module()
-    assert mod.st.session_state.get("_ann_rendered") is True
+    assert mod.st.session_state.get("_ann_hash") == "abc"
     mod._do_logout()
-    assert "_ann_rendered" not in mod.st.session_state
+    assert "_ann_hash" not in mod.st.session_state

--- a/tests/test_logout_rerenders_google_button.py
+++ b/tests/test_logout_rerenders_google_button.py
@@ -34,6 +34,8 @@ def load_module():
     mod.cookie_manager = object()
     mod.logging = types.SimpleNamespace(exception=MagicMock())
     mod.render_announcements = MagicMock()
+    mod.hashlib = __import__("hashlib")
+    mod.json = __import__("json")
     code = compile(ast.Module(body=nodes, type_ignores=[]), "logout_module", "exec")
     exec(code, mod.__dict__)
     return mod
@@ -43,8 +45,8 @@ def test_logout_rerenders_components():
     mod = load_module()
 
     # Initial renders
-    mod.render_announcements_once([{"title": "t", "body": "b"}])
-    assert mod.st.session_state.get("_ann_rendered") is True
+    mod.render_announcements_once([{"title": "t", "body": "b"}], True)
+    assert mod.st.session_state.get("_ann_hash")
     mod.render_announcements.assert_called_once()
 
     mod.st.markdown.reset_mock()
@@ -67,13 +69,13 @@ def test_logout_rerenders_components():
     mod.components.html.reset_mock()
     mod.st.markdown.reset_mock()
     mod._do_logout()
-    assert "_ann_rendered" not in mod.st.session_state
+    assert "_ann_hash" not in mod.st.session_state
     assert "_google_cta_rendered" not in mod.st.session_state
     assert "__google_btn_rendered::primary" not in mod.st.session_state
     assert "_google_btn_rendered" not in mod.st.session_state
 
     # Re-render components after logout
-    mod.render_announcements_once([{"title": "t", "body": "b"}])
+    mod.render_announcements_once([{"title": "t", "body": "b"}], True)
     mod.render_announcements.assert_called_once()
 
     mod.st.markdown.reset_mock()


### PR DESCRIPTION
## Summary
- Re-render announcements on dashboard or when announcement data changes
- Pass dashboard active state to announcement renderer and clear hash on logout
- Update logout tests for new announcement hash logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5ac714d4c83219ec4bd9269771770