### PR TITLE
Add dashboard link to full announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ export COOKIE_PASSWORD=<strong-secret>
 ```
 
 This value is required for secure cookie management.
+
+## Usage
+
+- From the Dashboard, use **View all announcements** to jump to the full classroom announcements feed.

--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1370,6 +1370,7 @@ def render_sidebar_published():
 - **Practice speaking:** **Tools → Sprechen** for instant pronunciation feedback.
 - **Build vocab:** **Vocab Trainer** for daily words & review cycles.
 - **Track progress:** **Dashboard** shows streaks, next lesson, and missed items.
+- **See announcements:** Dashboard → **View all announcements** for class updates.
             """
         )
 
@@ -1777,6 +1778,18 @@ render_announcements_once(announcements)
 # ===================== Dashboard =========================
 # =========================================================
 if tab == "Dashboard":
+    def _go_announcements() -> None:
+        st.session_state["nav_sel"] = "My Course"
+        st.session_state["main_tab_select"] = "My Course"
+        st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
+        st.session_state["cb_prev_subtab"] = "🧑‍🏫 Classroom"
+        st.session_state["classroom_page"] = "Announcements"
+        st.session_state["classroom_prev_page"] = "Announcements"
+        _qp_set(tab="My Course")
+        st.rerun()
+
+    st.button("View all announcements", on_click=_go_announcements, use_container_width=True)
+
     # ---------- Helpers ----------
     def safe_get(row, key, default=""):
         try: return row.get(key, default)


### PR DESCRIPTION
## Summary
- Add "View all announcements" button on the dashboard that routes to Classroom → Announcements with proper session-state setup
- Mention the new shortcut in the sidebar quick guide and README

## Testing
- `pytest`
- `ruff check a1sprechen.py README.md` *(fails: Found 208 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac705e548321a22ddf85c6379a90