### PR TITLE
Revise announcements labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ This value is required for secure cookie management.
 
 ## Usage
 
-- From the Dashboard, use **View all announcements** to jump to the full classroom announcements feed.
+- From the Dashboard, use **View all class announcements** to jump to the full classroom announcements feed.

--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1370,7 +1370,7 @@ def render_sidebar_published():
 - **Practice speaking:** **Tools → Sprechen** for instant pronunciation feedback.
 - **Build vocab:** **Vocab Trainer** for daily words & review cycles.
 - **Track progress:** **Dashboard** shows streaks, next lesson, and missed items.
-- **See announcements:** Dashboard → **View all announcements** for class updates.
+- **See announcements:** Dashboard → **View all class announcements** for class updates.
             """
         )
 
@@ -1791,7 +1791,7 @@ if tab == "Dashboard":
         _qp_set(tab="My Course")
         st.rerun()
 
-    st.button("View all announcements", on_click=_go_announcements, use_container_width=True)
+    st.button("View all class announcements", on_click=_go_announcements, use_container_width=True)
 
     # ---------- Helpers ----------
     def safe_get(row, key, default=""):


### PR DESCRIPTION
## Summary
- Clarify announcements button and quick guide text as "View all class announcements"
- Update README usage example to match new terminology

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1043c2883218fd1471bb211f650