### PR TITLE
Include logo and contract info in receipt PDF

### DIFF
--- a/tests/test_receipt_pdf.py
+++ b/tests/test_receipt_pdf.py
@@ -2,6 +2,8 @@ from src.assignment_ui import generate_receipt_pdf
 
 
 def test_generate_receipt_pdf_returns_bytes():
-    pdf_bytes = generate_receipt_pdf("Jane Doe", "A1", 100.0, 50.0, "2024-05-01")
+    pdf_bytes = generate_receipt_pdf(
+        "Jane Doe", "A1", "S123", "2024-01-01", 100.0, 50.0, "2024-05-01"
+    )
     assert isinstance(pdf_bytes, (bytes, bytearray))
     assert len(pdf_bytes) > 0


### PR DESCRIPTION
## Summary
- add `load_school_logo` helper to fetch and cache logo image
- expand `generate_receipt_pdf` with logo, student code and contract start info
- update downloads tab and tests for new receipt PDF signature

## Testing
- `ruff check src/assignment_ui.py tests/test_receipt_pdf.py`
- `PYTHONPATH=. pytest tests/test_receipt_pdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b5e3062c83219cd91921f4c51118