### PR TITLE
Cache school logo for PDF reports

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -17,7 +17,7 @@ from fpdf import FPDF
 
 from .assignment import linkify_html, _clean_link, _is_http_url
 from .schedule import get_level_schedules as _get_level_schedules
-from .pdf_utils import make_qr_code
+from .pdf_utils import make_qr_code, load_school_logo
 from .data_loading import load_student_data
 
 # URLs for letterhead and watermark images are configurable via environment
@@ -583,33 +583,14 @@ def render_results_and_resources_tab() -> None:
             FEEDBACK_W = PAGE_WIDTH - 2 * MARGIN - (
                 COL_ASSN_W + COL_SCORE_W + COL_DATE_W
             )
-            LOGO_URL = "https://i.imgur.com/iFiehrp.png"
-
-            def fetch_logo():
-                try:
-                    r = requests.get(LOGO_URL, timeout=6)
-                    r.raise_for_status()
-                    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
-                    tmp.write(r.content)
-                    tmp.flush()
-                    tmp.close()
-                    return tmp.name
-                except Exception:
-                    return None
-
             class PDFReport(FPDF):
                 def header(self):
-                    logo_path = fetch_logo()
+                    logo_path = load_school_logo()
                     if logo_path:
                         try:
                             self.image(logo_path, 10, 8, 30)
                         except Exception:
                             pass
-                        finally:
-                            try:
-                                os.unlink(logo_path)
-                            except Exception:
-                                pass
                         self.ln(20)
                     else:
                         self.ln(28)

--- a/src/pdf_utils.py
+++ b/src/pdf_utils.py
@@ -1,10 +1,13 @@
-from __future__ import annotations
-
 """PDF-related helper utilities."""
+
+from __future__ import annotations
 
 import base64
 import io
-from typing import Any
+from pathlib import Path
+from typing import Optional
+
+import requests
 
 try:  # pragma: no cover - optional dependency
     import qrcode
@@ -20,6 +23,12 @@ except Exception:  # pragma: no cover
 _FALLBACK_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
 )
+
+
+LOGO_URL = "https://i.imgur.com/iFiehrp.png"
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+LOCAL_LOGO = PROJECT_ROOT / "logo.png"
+CACHE_LOGO = Path("/tmp/school_logo.png")
 
 
 def make_qr_code(data: str) -> bytes:
@@ -45,4 +54,28 @@ def make_qr_code(data: str) -> bytes:
     return _FALLBACK_PNG
 
 
-__all__ = ["make_qr_code"]
+def load_school_logo() -> Optional[str]:
+    """Return a path to the school logo image.
+
+    Preference order:
+    1. Project-local ``logo.png``
+    2. Cached file at ``/tmp/school_logo.png``
+    3. Download from ``LOGO_URL`` and cache it
+    """
+
+    if LOCAL_LOGO.exists():
+        return str(LOCAL_LOGO)
+
+    if CACHE_LOGO.exists():
+        return str(CACHE_LOGO)
+
+    try:  # pragma: no cover - network is best effort
+        resp = requests.get(LOGO_URL, timeout=6)
+        resp.raise_for_status()
+        CACHE_LOGO.write_bytes(resp.content)
+        return str(CACHE_LOGO)
+    except Exception:
+        return None
+
+
+__all__ = ["make_qr_code", "load_school_logo"]

--- a/tests/test_load_school_logo.py
+++ b/tests/test_load_school_logo.py
@@ -1,0 +1,56 @@
+from src import pdf_utils
+
+
+def test_load_school_logo_prefers_local(tmp_path, monkeypatch):
+    local = tmp_path / "logo.png"
+    local.write_bytes(b"local")
+    monkeypatch.setattr(pdf_utils, "LOCAL_LOGO", local)
+    monkeypatch.setattr(pdf_utils, "CACHE_LOGO", tmp_path / "school_logo.png")
+
+    called = False
+
+    def fake_get(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network should not be called")
+
+    monkeypatch.setattr(pdf_utils.requests, "get", fake_get)
+    path = pdf_utils.load_school_logo()
+    assert path == str(local)
+    assert called is False
+
+
+def test_load_school_logo_uses_cache(tmp_path, monkeypatch):
+    cache = tmp_path / "school_logo.png"
+    cache.write_bytes(b"cache")
+    monkeypatch.setattr(pdf_utils, "LOCAL_LOGO", tmp_path / "missing.png")
+    monkeypatch.setattr(pdf_utils, "CACHE_LOGO", cache)
+
+    called = False
+
+    def fake_get(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network should not be called")
+
+    monkeypatch.setattr(pdf_utils.requests, "get", fake_get)
+    path = pdf_utils.load_school_logo()
+    assert path == str(cache)
+    assert called is False
+
+
+def test_load_school_logo_downloads_when_needed(tmp_path, monkeypatch):
+    cache = tmp_path / "school_logo.png"
+    monkeypatch.setattr(pdf_utils, "LOCAL_LOGO", tmp_path / "missing.png")
+    monkeypatch.setattr(pdf_utils, "CACHE_LOGO", cache)
+
+    class Resp:
+        content = b"net"
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(pdf_utils.requests, "get", lambda *a, **k: Resp())
+    path = pdf_utils.load_school_logo()
+    assert path == str(cache)
+    assert cache.read_bytes() == b"net"


### PR DESCRIPTION
## Summary
- add `load_school_logo()` with project/local cache before network download
- use cached logo path in PDF report header
- test logo caching behavior

## Testing
- `ruff check src/pdf_utils.py src/assignment_ui.py tests/test_load_school_logo.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b64dfce88321923517179a6958f5