### PR TITLE
feat: lighten PDF results row background

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -726,6 +726,7 @@ def render_results_and_resources_tab() -> None:
                 pdf.cell(FEEDBACK_W, 8, "Feedback", 1, 1, "C")
 
                 pdf.set_font("Arial", "", 10)
+                pdf.set_fill_color(240, 240, 240)
                 row_fill = False
                 for _, row in df_display.iterrows():
                     assn = clean_for_pdf(str(row["assignment"]))
@@ -737,6 +738,7 @@ def render_results_and_resources_tab() -> None:
                     pdf.cell(COL_DATE_W, 8, date_txt, 1, 0, "C", row_fill)
                     pdf.multi_cell(FEEDBACK_W, 8, label, 1, "C", row_fill)
                     row_fill = not row_fill
+                pdf.set_fill_color(255, 255, 255)
 
                 pdf_bytes = pdf.output(dest="S").encode("latin1", "replace")
                 st.download_button(


### PR DESCRIPTION
## Summary
- Use light gray fill for alternating rows in Results PDF table
- Reset fill color after rendering table to keep rest of document white

## Testing
- `ruff check src/assignment_ui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c3e484788321ac64765c51350212