### PR TITLE
Ensure clean_for_pdf handles non-Latin-1 characters

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -82,6 +82,10 @@ def clean_for_pdf(text: str) -> str:
     text = _ud.normalize("NFKD", text)
     text = text.replace("\n", " ").replace("\r", " ")
     text = "".join(c if c.isprintable() else "?" for c in text)
+    # Ensure the result is compatible with the Latin-1 encoding used by FPDF.
+    # Characters outside that range are replaced with ``?`` so encoding will
+    # not fail when generating PDFs.
+    text = text.encode("latin-1", "replace").decode("latin-1")
     return text
 
 

--- a/tests/test_clean_for_pdf.py
+++ b/tests/test_clean_for_pdf.py
@@ -1,0 +1,11 @@
+from src.assignment_ui import clean_for_pdf
+
+
+def test_clean_for_pdf_handles_non_latin1():
+    text = "Score ✓ and emoji 😊"
+    cleaned = clean_for_pdf(text)
+    # Should encode to Latin-1 without raising an exception
+    cleaned.encode("latin-1")
+    # Non-Latin-1 characters should be replaced
+    assert cleaned == "Score ? and emoji ?"
+


### PR DESCRIPTION
## Summary
- Sanitize text for PDF generation by replacing characters outside Latin-1 with `?` to avoid encoding errors.
- Add unit test to confirm `clean_for_pdf` replaces unsupported characters and remains Latin-1 encodable.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c865ce1c8321904faf22328f74dd