### PR TITLE
Handle Latin-1 encoding when generating PDFs

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -82,6 +82,7 @@ def clean_for_pdf(text: str) -> str:
     text = _ud.normalize("NFKD", text)
     text = text.replace("\n", " ").replace("\r", " ")
     text = "".join(c if c.isprintable() else "?" for c in text)
+    text = text.encode("latin-1", "replace").decode("latin-1")
     return text
 
 


### PR DESCRIPTION
## Summary
- Ensure `clean_for_pdf` normalizes and encodes text using Latin-1 to avoid UnicodeEncodeError when exporting PDFs

## Testing
- `ruff check src/assignment_ui.py tests/test_enrollment_letter_pdf.py tests/test_receipt_pdf.py`
- `PYTHONPATH=. pytest tests/test_enrollment_letter_pdf.py tests/test_receipt_pdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c86363f48321901f12c445bcfe00