### PR TITLE
Use helper to format Ghana cedis amounts

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -80,6 +80,7 @@ from src.contracts import (
     months_between,
     is_contract_expired,
 )
+from src.utils.currency import format_cedis
 from src.firestore_utils import (
     _draft_doc_ref,
     load_chat_draft_from_db,
@@ -1987,9 +1988,11 @@ if tab == "Dashboard":
         f"<b>👤 {name}</b>"
         f"<span style='background:#eef4ff;color:#2541b2;padding:2px 8px;border-radius:999px;'>Level: {level}</span>"
         f"<span style='background:#f1f5f9;color:#334155;padding:2px 8px;border-radius:999px;'>Code: <code>{code}</code></span>"
-        + (f"<span style='background:#fff7ed;color:#7c2d12;padding:2px 8px;border-radius:999px;'>Balance: ₵{bal_val:,.2f}</span>"
-           if bal_val > 0 else
-           "<span style='background:#ecfdf5;color:#065f46;padding:2px 8px;border-radius:999px;'>Balance: ₵0.00</span>")
+        + (
+            f"<span style='background:#fff7ed;color:#7c2d12;padding:2px 8px;border-radius:999px;'>Balance: {format_cedis(bal_val)}</span>"
+            if bal_val > 0
+            else f"<span style='background:#ecfdf5;color:#065f46;padding:2px 8px;border-radius:999px;'>Balance: {format_cedis(0)}</span>"
+        )
         + "</div>",
         unsafe_allow_html=True
     )
@@ -2093,19 +2096,19 @@ if tab == "Dashboard":
             _severity = "error"
             _msg = (
                 f"💸 **Overdue by {_days_over} day{'s' if _days_over != 1 else ''}.** "
-                f"Amount due: **₵{_balance:,.2f}**. First due: {_first_due:%d %b %Y}."
+                f"Amount due: **{format_cedis(_balance)}**. First due: {_first_due:%d %b %Y}."
             )
         elif _today == _first_due:
             _exp_title = "💳 Payments • due today"
             _severity = "warning"
-            _msg = f"⏳ **Payment due today** ({_first_due:%d %b %Y}). Amount due: **₵{_balance:,.2f}**."
+            _msg = f"⏳ **Payment due today** ({_first_due:%d %b %Y}). Amount due: **{format_cedis(_balance)}**."
         else:
             _exp_title = "💳 Payments (info)"
             _severity = "info"
             _days_left = (_first_due - _today).days
             _msg = (
                 f"No payment expected yet. Your first payment date is **{_first_due:%d %b %Y}** "
-                f"(in {_days_left} day{'s' if _days_left != 1 else ''}). Current balance: **₵{_balance:,.2f}**."
+                f"(in {_days_left} day{'s' if _days_left != 1 else ''}). Current balance: **{format_cedis(_balance)}**."
             )
     elif _balance > 0 and not _first_due:
         _exp_title = "💳 Payments • schedule unknown"
@@ -2143,7 +2146,7 @@ if tab == "Dashboard":
             **Details**
             - Contract start: **{_cs_str}**
             - First payment due (start + 1 month): **{_fd_str}**
-            - Current balance: **₵{_balance:,.2f}**
+            - Current balance: **{format_cedis(_balance)}**
             """
         )
 
@@ -2155,12 +2158,12 @@ if tab == "Dashboard":
             if _days_left < 0:
                 st.error(
                     f"⚠️ Your contract ended on **{_ce_date:%d %b %Y}**. "
-                    f"If you need more time, extension costs **₵{EXT_FEE:,}/month**."
+                    f"If you need more time, extension costs **{format_cedis(EXT_FEE)}/month**."
                 )
             elif _days_left <= 14:
                 st.warning(
                     f"⏰ Your contract ends in **{_days_left} day{'s' if _days_left != 1 else ''}** "
-                    f"(**{_ce_date:%d %b %Y}**). Extension costs **₵{EXT_FEE:,}/month**."
+                    f"(**{_ce_date:%d %b %Y}**). Extension costs **{format_cedis(EXT_FEE)}/month**."
                 )
 
     # ---------- Always-visible Contract Alert ----------
@@ -2208,13 +2211,13 @@ if tab == "Dashboard":
             if _days_left < 0:
                 _msg = (
                     f"⚠️ <b>Your contract ended on {_ce_date:%d %b %Y}.</b> "
-                    f"To continue, extension costs <b>₵{_ext_fee:,}/month</b>."
+                    f"To continue, extension costs <b>{format_cedis(_ext_fee)}/month</b>."
                 )
                 _cls = "ca-err"
             elif _days_left <= 14:
                 _msg = (
                     f"⏰ <b>Your contract ends in {_days_left} day{'s' if _days_left != 1 else ''} "
-                    f"({_ce_date:%d %b %Y}).</b> Extension costs <b>₵{_ext_fee:,}/month</b>."
+                    f"({_ce_date:%d %b %Y}).</b> Extension costs <b>{format_cedis(_ext_fee)}/month</b>."
                 )
                 _cls = "ca-warn"
             else:
@@ -2383,9 +2386,9 @@ if tab == "Dashboard":
         if exam_info:
             exam_date, fee, module_fee = exam_info
             days_to_exam = (exam_date - date.today()).days
-            fee_text = f"**Fee:** ₵{fee:,}"
+            fee_text = f"**Fee:** {format_cedis(fee)}"
             if module_fee:
-                fee_text += f" &nbsp; | &nbsp; **Per Module:** ₵{module_fee:,}"
+                fee_text += f" &nbsp; | &nbsp; **Per Module:** {format_cedis(module_fee)}"
             if days_to_exam > 0:
                 st.info(
                     f"Your {level} exam is in {days_to_exam} days ({exam_date:%d %b %Y}).  \n"

--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -20,6 +20,7 @@ from .schedule import get_level_schedules as _get_level_schedules
 # ``load_school_logo`` is defined below; only import QR helper here.
 from .pdf_utils import make_qr_code
 from .data_loading import load_student_data
+from .utils.currency import format_cedis
 
 # URLs for letterhead and watermark images are configurable via environment
 # variables so deployments can easily swap in different assets without touching
@@ -415,8 +416,8 @@ def generate_receipt_pdf(
         f"Student: {student_name} ({student_level})",
         f"Student Code: {student_code}",
         f"Contract Start: {contract_start}",
-        f"Amount Paid: ₵{paid:,.2f}",
-        f"Balance: ₵{balance:,.2f}",
+        f"Amount Paid: {format_cedis(paid)}",
+        f"Balance: {format_cedis(balance)}",
         f"Date: {receipt_date}",
     ]
     for line in lines:

--- a/src/utils/currency.py
+++ b/src/utils/currency.py
@@ -1,0 +1,17 @@
+"""Currency formatting helpers."""
+from __future__ import annotations
+
+
+def format_cedis(amount: float) -> str:
+    """Return amount formatted in Ghana cedis.
+
+    A positive ``amount`` is formatted with two decimal places followed by
+    ``" cedis"``. Non‑positive values are returned as ``"0"``.
+    """
+    try:
+        value = float(amount)
+    except Exception:
+        return "0"
+    if value > 0:
+        return f"{value:,.2f} cedis"
+    return "0"

--- a/tests/test_currency_formatting.py
+++ b/tests/test_currency_formatting.py
@@ -1,0 +1,10 @@
+from src.utils.currency import format_cedis
+
+
+def test_format_cedis_positive():
+    assert format_cedis(1234.5) == "1,234.50 cedis"
+
+
+def test_format_cedis_non_positive():
+    assert format_cedis(0) == "0"
+    assert format_cedis(-100) == "0"

--- a/tests/test_no_cedi_symbol.py
+++ b/tests/test_no_cedi_symbol.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+def test_no_cedi_symbol_present():
+    text = Path('a1sprechen.py').read_text()
+    assert '₵' not in text

--- a/tests/test_receipt_pdf.py
+++ b/tests/test_receipt_pdf.py
@@ -7,3 +7,14 @@ def test_generate_receipt_pdf_returns_bytes():
     )
     assert isinstance(pdf_bytes, (bytes, bytearray))
     assert len(pdf_bytes) > 0
+    import re, zlib
+
+    extracted = b""
+    for match in re.finditer(rb"stream\r?\n(.+?)\r?\nendstream", pdf_bytes, re.DOTALL):
+        data = match.group(1)
+        try:
+            extracted += zlib.decompress(data)
+        except Exception:
+            extracted += data
+    assert b"\x00c\x00e\x00d\x00i\x00s" in extracted
+    assert b"\xe2\x82\xb5" not in extracted


### PR DESCRIPTION
## Summary
- add `format_cedis` helper for consistent cedi formatting
- update receipt PDF and app UI to use helper instead of the `₵` symbol
- add tests verifying outputs include `cedis`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d0b4f3908321b11b6a235a0ef98b