### PR TITLE
Display total score in leaderboard mini-card

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1910,7 +1910,8 @@ if tab == "Dashboard":
 
     if not _your_row.empty:
         _rank = int(_your_row.iloc[0]["Rank"])
-        _rank_text = f"Rank #{_rank} of {_total_students}"
+        _total_score = int(_your_row.iloc[0]["total_score"])
+        _rank_text = f"Rank #{_rank} of {_total_students} — {_total_score} pts"
         _lead_chip = "<span class='pill pill-purple'>On the board</span>"
     else:
         _rank_text = "Complete 3+ assignments to be ranked"


### PR DESCRIPTION
## Summary
- Show student's total score when displaying leaderboard rank

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5d4cedc60832182e3439d777360ce