### PR TITLE
Add payment status line to receipt PDF

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -372,7 +372,11 @@ def generate_receipt_pdf(
     balance: float,
     receipt_date: str,
 ) -> bytes:
-    """Generate a simple payment receipt as PDF bytes with improved fonts."""
+    """Generate a simple payment receipt as PDF bytes with improved fonts.
+
+    The receipt now includes a status line at the top indicating whether the
+    payment is complete or an installment with a remaining balance.
+    """
 
     pdf = FPDF()
     pdf.add_page()
@@ -412,7 +416,17 @@ def generate_receipt_pdf(
     pdf.ln(10)
 
     pdf.set_font("DejaVu", size=12)
+
+    # Add payment status before student details
+    if balance == 0:
+        status_line = "Status: Full payment"
+    else:
+        status_line = (
+            f"Status: Installment – Balance remaining {format_cedis(balance)}"
+        )
+
     lines = [
+        status_line,
         f"Student: {student_name} ({student_level})",
         f"Student Code: {student_code}",
         f"Contract Start: {contract_start}",
@@ -420,9 +434,10 @@ def generate_receipt_pdf(
         f"Balance: {format_cedis(balance)}",
         f"Date: {receipt_date}",
     ]
-    for line in lines:
+
+    for idx, line in enumerate(lines):
         pdf.multi_cell(0, 8, clean_for_pdf(line))
-        pdf.ln(2)
+        pdf.ln(4 if idx == 0 else 2)
 
     return pdf.output(dest="S").encode("latin1")
 

--- a/tests/test_receipt_pdf.py
+++ b/tests/test_receipt_pdf.py
@@ -7,7 +7,8 @@ def test_generate_receipt_pdf_returns_bytes():
     )
     assert isinstance(pdf_bytes, (bytes, bytearray))
     assert len(pdf_bytes) > 0
-    import re, zlib
+    import re
+    import zlib
 
     extracted = b""
     for match in re.finditer(rb"stream\r?\n(.+?)\r?\nendstream", pdf_bytes, re.DOTALL):


### PR DESCRIPTION
## Summary
- include payment status line in receipt PDFs, noting full payment or remaining balance
- tweak layout to insert status above student details
- split test imports for lint compliance

## Testing
- `ruff check src/assignment_ui.py tests/test_receipt_pdf.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d87c886c8321bf829fffab83d38d