### PR TITLE
Add receipt PDF status tests

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -412,10 +412,12 @@ def generate_receipt_pdf(
     pdf.ln(10)
 
     pdf.set_font("DejaVu", size=12)
+    status = "Full payment" if balance == 0 else "Installment"
     lines = [
         f"Student: {student_name} ({student_level})",
         f"Student Code: {student_code}",
         f"Contract Start: {contract_start}",
+        f"Status: {status}",
         f"Amount Paid: {format_cedis(paid)}",
         f"Balance: {format_cedis(balance)}",
         f"Date: {receipt_date}",

--- a/tests/test_receipt_pdf.py
+++ b/tests/test_receipt_pdf.py
@@ -1,20 +1,45 @@
 from src.assignment_ui import generate_receipt_pdf
 
 
-def test_generate_receipt_pdf_returns_bytes():
-    pdf_bytes = generate_receipt_pdf(
-        "Jane Doe", "A1", "S123", "2024-01-01", 100.0, 50.0, "2024-05-01"
-    )
-    assert isinstance(pdf_bytes, (bytes, bytearray))
-    assert len(pdf_bytes) > 0
+def _extract_text(pdf_bytes: bytes) -> str:
     import re, zlib
 
     extracted = b""
     for match in re.finditer(rb"stream\r?\n(.+?)\r?\nendstream", pdf_bytes, re.DOTALL):
         data = match.group(1)
         try:
-            extracted += zlib.decompress(data)
+            data = zlib.decompress(data)
         except Exception:
-            extracted += data
-    assert b"\x00c\x00e\x00d\x00i\x00s" in extracted
-    assert b"\xe2\x82\xb5" not in extracted
+            pass
+        extracted += data
+    return extracted.replace(b"\x00", b"").decode("latin1", errors="ignore")
+
+
+def test_generate_receipt_pdf_returns_bytes():
+    pdf_bytes = generate_receipt_pdf(
+        "Jane Doe", "A1", "S123", "2024-01-01", 100.0, 50.0, "2024-05-01"
+    )
+    assert isinstance(pdf_bytes, (bytes, bytearray))
+    assert len(pdf_bytes) > 0
+    text = _extract_text(pdf_bytes)
+    assert "cedis" in text
+    assert "₵" not in text  # no cedi symbol
+
+
+def test_generate_receipt_pdf_full_payment_shows_status():
+    pdf_bytes = generate_receipt_pdf(
+        "Jane Doe", "A1", "S123", "2024-01-01", 100.0, 0.0, "2024-05-01"
+    )
+    text = _extract_text(pdf_bytes)
+    assert "Status: Full payment" in text
+
+
+def test_generate_receipt_pdf_installment_shows_balance():
+    pdf_bytes = generate_receipt_pdf(
+        "Jane Doe", "A1", "S123", "2024-01-01", 75.0, 25.0, "2024-05-01"
+    )
+    text = _extract_text(pdf_bytes)
+    from src.utils.currency import format_cedis
+
+    assert "Installment" in text
+    assert format_cedis(25.0) in text


### PR DESCRIPTION
## Summary
- include payment status in generated receipt PDFs
- verify full payment and installment balances through new tests

## Testing
- `PYTHONPATH=. pytest tests/test_receipt_pdf.py::test_generate_receipt_pdf_returns_bytes -q`
- `PYTHONPATH=. pytest tests/test_receipt_pdf.py::test_generate_receipt_pdf_full_payment_shows_status -q`
- `PYTHONPATH=. pytest tests/test_receipt_pdf.py::test_generate_receipt_pdf_installment_shows_balance -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d8a5b9a883218c3604e5133ce438