### PR TITLE
Make Falowen DB path configurable and safe

### DIFF
--- a/falowen/db.py
+++ b/falowen/db.py
@@ -1,137 +1,159 @@
-"""SQLite helpers for Falowen."""
+"""SQLite helpers for Falowen.
 
-import atexit
+The database location can be configured either by passing a path to
+``get_connection`` (and helpers that call it) or by setting the
+``FALOWEN_DB_PATH`` environment variable.  By default a file named
+``vocab_progress.db`` in the current working directory is used.
+"""
+
+from __future__ import annotations
+
+import os
 import sqlite3
 from datetime import date
-
-import streamlit as st
+from typing import Optional
 
 
 FALOWEN_DAILY_LIMIT = 20
 VOCAB_DAILY_LIMIT = 20
 SCHREIBEN_DAILY_LIMIT = 5
 
-
-def get_connection():
-    if "conn" not in st.session_state:
-        st.session_state["conn"] = sqlite3.connect(
-            "vocab_progress.db", check_same_thread=False
-        )
-        atexit.register(st.session_state["conn"].close)
-    return st.session_state["conn"]
+DEFAULT_DB_PATH = "vocab_progress.db"
 
 
-def init_db():
-    conn = get_connection()
-    c = conn.cursor()
-    c.execute(
-        """
-        CREATE TABLE IF NOT EXISTS vocab_progress (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            student_code TEXT,
-            name TEXT,
-            level TEXT,
-            word TEXT,
-            student_answer TEXT,
-            is_correct INTEGER,
-            date TEXT
-        )
-        """
-    )
-    c.execute(
-        """
-        CREATE TABLE IF NOT EXISTS schreiben_progress (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            student_code TEXT,
-            name TEXT,
-            level TEXT,
-            essay TEXT,
-            score INTEGER,
-            feedback TEXT,
-            date TEXT
-        )
-        """
-    )
-    c.execute(
-        """
-        CREATE TABLE IF NOT EXISTS sprechen_progress (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            student_code TEXT,
-            name TEXT,
-            level TEXT,
-            teil TEXT,
-            message TEXT,
-            score INTEGER,
-            feedback TEXT,
-            date TEXT
-        )
-        """
-    )
-    c.execute(
-        """
-        CREATE TABLE IF NOT EXISTS exam_progress (
-            student_code TEXT,
-            level TEXT,
-            teil TEXT,
-            remaining TEXT,
-            used TEXT,
-            PRIMARY KEY (student_code, level, teil)
-        )
-        """
-    )
-    c.execute(
-        """
-        CREATE TABLE IF NOT EXISTS my_vocab (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            student_code TEXT,
-            level TEXT,
-            word TEXT,
-            translation TEXT,
-            date_added TEXT
-        )
-        """
-    )
-    for tbl in ["sprechen_usage", "letter_coach_usage", "schreiben_usage"]:
+def get_connection(db_path: Optional[str] = None) -> sqlite3.Connection:
+    """Return a SQLite connection using the configured database path.
+
+    If ``db_path`` is not provided it falls back to the ``FALOWEN_DB_PATH``
+    environment variable and finally to ``DEFAULT_DB_PATH``.
+    """
+
+    path = db_path or os.getenv("FALOWEN_DB_PATH", DEFAULT_DB_PATH)
+    return sqlite3.connect(path, check_same_thread=False)
+
+
+def init_db(db_path: Optional[str] = None) -> None:
+    """Initialise all required tables in the configured database."""
+
+    with get_connection(db_path) as conn:
+        c = conn.cursor()
         c.execute(
-            f"""
-            CREATE TABLE IF NOT EXISTS {tbl} (
+            """
+            CREATE TABLE IF NOT EXISTS vocab_progress (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
                 student_code TEXT,
-                date TEXT,
-                count INTEGER,
-                PRIMARY KEY (student_code, date)
+                name TEXT,
+                level TEXT,
+                word TEXT,
+                student_answer TEXT,
+                is_correct INTEGER,
+                date TEXT
             )
             """
         )
-    conn.commit()
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schreiben_progress (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                student_code TEXT,
+                name TEXT,
+                level TEXT,
+                essay TEXT,
+                score INTEGER,
+                feedback TEXT,
+                date TEXT
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sprechen_progress (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                student_code TEXT,
+                name TEXT,
+                level TEXT,
+                teil TEXT,
+                message TEXT,
+                score INTEGER,
+                feedback TEXT,
+                date TEXT
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS exam_progress (
+                student_code TEXT,
+                level TEXT,
+                teil TEXT,
+                remaining TEXT,
+                used TEXT,
+                PRIMARY KEY (student_code, level, teil)
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS my_vocab (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                student_code TEXT,
+                level TEXT,
+                word TEXT,
+                translation TEXT,
+                date_added TEXT
+            )
+            """
+        )
+        for tbl in ["sprechen_usage", "letter_coach_usage", "schreiben_usage"]:
+            c.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {tbl} (
+                    student_code TEXT,
+                    date TEXT,
+                    count INTEGER,
+                    PRIMARY KEY (student_code, date)
+                )
+                """
+            )
 
 
-def get_sprechen_usage(student_code):
+def get_sprechen_usage(student_code: str, db_path: Optional[str] = None) -> int:
+    """Return today's sprechen usage for ``student_code``."""
+
     today = str(date.today())
-    conn = get_connection()
-    c = conn.cursor()
-    c.execute(
-        "SELECT count FROM sprechen_usage WHERE student_code=? AND date=?",
-        (student_code, today),
-    )
-    row = c.fetchone()
+    with get_connection(db_path) as conn:
+        c = conn.cursor()
+        c.execute(
+            "SELECT count FROM sprechen_usage WHERE student_code=? AND date=?",
+            (student_code, today),
+        )
+        row = c.fetchone()
     return row[0] if row else 0
 
 
-def inc_sprechen_usage(student_code):
+def inc_sprechen_usage(student_code: str, db_path: Optional[str] = None) -> None:
+    """Increment today's sprechen usage for ``student_code``."""
+
     today = str(date.today())
-    conn = get_connection()
-    c = conn.cursor()
-    c.execute(
-        """
-        INSERT INTO sprechen_usage (student_code, date, count)
-        VALUES (?, ?, 1)
-        ON CONFLICT(student_code, date)
-        DO UPDATE SET count = count + 1
-        """,
-        (student_code, today),
-    )
-    conn.commit()
+    with get_connection(db_path) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            INSERT INTO sprechen_usage (student_code, date, count)
+            VALUES (?, ?, 1)
+            ON CONFLICT(student_code, date)
+            DO UPDATE SET count = count + 1
+            """,
+            (student_code, today),
+        )
+        conn.commit()
 
 
-def has_sprechen_quota(student_code, limit: int = FALOWEN_DAILY_LIMIT):
-    return get_sprechen_usage(student_code) < limit
+def has_sprechen_quota(
+    student_code: str,
+    limit: int = FALOWEN_DAILY_LIMIT,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Return ``True`` if ``student_code`` has remaining sprechen quota."""
+
+    return get_sprechen_usage(student_code, db_path=db_path) < limit

--- a/tests/test_falowen_db.py
+++ b/tests/test_falowen_db.py
@@ -1,0 +1,21 @@
+import os
+
+from falowen import db
+
+
+def test_sprechen_usage_with_temp_db(tmp_path):
+    db_file = tmp_path / "test.db"
+    db.init_db(db_path=str(db_file))
+
+    assert db.get_sprechen_usage("stu", db_path=str(db_file)) == 0
+    db.inc_sprechen_usage("stu", db_path=str(db_file))
+    assert db.get_sprechen_usage("stu", db_path=str(db_file)) == 1
+    assert db.has_sprechen_quota("stu", limit=1, db_path=str(db_file)) is False
+
+
+def test_get_connection_env_var(tmp_path, monkeypatch):
+    env_db = tmp_path / "env.db"
+    monkeypatch.setenv("FALOWEN_DB_PATH", str(env_db))
+    with db.get_connection() as conn:
+        conn.execute("CREATE TABLE t (id INTEGER)")
+    assert os.path.exists(env_db)


### PR DESCRIPTION
## Summary
- allow configuring Falowen's SQLite path via argument or FALOWEN_DB_PATH env var
- use context managers for SQLite connections
- exercise DB helpers in tests with a temporary file

## Testing
- `ruff check falowen/db.py tests/test_falowen_db.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71a6092d48321800f165d4ec991a6