### PR TITLE
Refresh session on page load

### DIFF
--- a/templates/falowen_login.html
+++ b/templates/falowen_login.html
@@ -128,5 +128,10 @@
       </section>
     </div>
   </div>
+  <script>
+    window.addEventListener("load", () => {
+      fetch("/auth/refresh", { credentials: "include" }).catch(console.error);
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- trigger `/auth/refresh` via `fetch` when the login page loads to keep sessions active

## Testing
- `flake8` *(fails: F821 undefined name 'FPDF')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68b73f0656848321be09767c14f37b2f