### PR TITLE
Add Flask dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ streamlit-oauth==0.1.14
 streamlit-quill==0.0.3
 beautifulsoup4==4.13.5
 fastapi==0.116.1
+flask==3.0.3
 uvicorn==0.35.0
 pytest==8.4.1
 rapidfuzz==3.13.0


### PR DESCRIPTION
## Summary
- add Flask 3.0.3 to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask==3.0.3)*
- `streamlit run a1sprechen.py --server.headless true` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68b74099e08483219f9544c158ba11f2