### PR TITLE
chore: remove unused fastapi and uvicorn deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,6 @@ bcrypt==4.3.0
 streamlit-oauth==0.1.14
 streamlit-quill==0.0.3
 beautifulsoup4==4.13.5
-fastapi==0.116.1
-uvicorn==0.35.0
 pytest==8.4.1
 rapidfuzz==3.13.0
 flake8==7.1.1


### PR DESCRIPTION
## Summary
- remove fastapi and uvicorn from requirements

## Testing
- `pip uninstall -y fastapi uvicorn`
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b7409c8234832182b21b04b670bf28