### PR TITLE
Add AuthViewModel with cookie refresh timer

### DIFF
--- a/ios/AuthViewModel.swift
+++ b/ios/AuthViewModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Combine
+
+@MainActor
+final class AuthViewModel: ObservableObject {
+    /// Indicates whether the user needs to log in again.
+    @Published var needsLogin = false
+
+    private var timer: AnyCancellable?
+    private let refreshURL: URL
+    private let refreshInterval: TimeInterval
+
+    /// - Parameters:
+    ///   - baseURL: Base URL of the backend server.
+    ///   - maxAge: Maximum age of the session cookie in seconds.
+    init(baseURL: URL, maxAge: TimeInterval = 60 * 60 * 24 * 30) {
+        self.refreshURL = baseURL.appendingPathComponent("/auth/refresh")
+        // Refresh one minute before the cookie expires.
+        self.refreshInterval = maxAge - 60
+        scheduleRefresh()
+    }
+
+    private func scheduleRefresh() {
+        timer = Timer.publish(every: refreshInterval, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.refreshSession()
+            }
+    }
+
+    private func refreshSession() {
+        var config = URLSessionConfiguration.default
+        // Ensure cookies from the refresh response replace the existing ones.
+        config.httpCookieStorage = HTTPCookieStorage.shared
+        let session = URLSession(configuration: config)
+
+        var request = URLRequest(url: refreshURL)
+        request.httpMethod = "GET"
+
+        let task = session.dataTask(with: request) { [weak self] _, response, _ in
+            guard let httpResponse = response as? HTTPURLResponse else { return }
+            if httpResponse.statusCode == 401 {
+                DispatchQueue.main.async {
+                    // Prompt the user to log in again on 401 responses.
+                    self?.needsLogin = true
+                }
+            }
+        }
+        task.resume()
+    }
+}


### PR DESCRIPTION
## Summary
- Add SwiftUI `AuthViewModel` to refresh auth cookie before expiration
- Replace cookie on refresh using `URLSessionConfiguration` with shared storage
- Expose flag to prompt login on 401 responses

## Testing
- `ruff check .` *(fails: existing style errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68b744a0c46c8321ac8bfcc83d410827