### PR TITLE
Refresh session daily to maintain cookie expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ repository root.  Include this file in the Xcode project or build process so it
 is compiled and bundled with the app.  The Python bridge executes the helper via
 `swift KeychainHelper.swift -` and sends short snippets that call `saveToken` and
 `deleteToken`.
+
+## Session Refresh
+
+The iOS app proactively refreshes its session cookie. Safari's Intelligent
+Tracking Prevention shortens cookie lifetimes to about a week when they aren't
+updated. A daily refresh ensures the cookie expiry is extended well before the
+platform can discard it.

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -1,0 +1,36 @@
+from http.cookies import SimpleCookie
+from email.utils import parsedate_to_datetime
+
+from flask import Flask
+
+from auth import auth_bp, MAX_AGE
+
+
+def create_app():
+    app = Flask(__name__)
+    app.register_blueprint(auth_bp)
+    return app
+
+
+def _cookie_expires(resp):
+    cookie = SimpleCookie()
+    cookie.load(resp.headers["Set-Cookie"])
+    return parsedate_to_datetime(cookie["session"]["expires"]), cookie["session"].OutputString()
+
+
+def test_refresh_extends_cookie_expiry():
+    app = create_app()
+    client = app.test_client()
+
+    login_resp = client.post("/auth/login", json={"user_id": "u"})
+    first_expires, cookie_header = _cookie_expires(login_resp)
+
+    refresh_resp1 = client.get("/auth/refresh", headers={"Cookie": cookie_header})
+    second_expires, cookie_header2 = _cookie_expires(refresh_resp1)
+
+    refresh_resp2 = client.get("/auth/refresh", headers={"Cookie": cookie_header2})
+    third_expires, _ = _cookie_expires(refresh_resp2)
+
+    assert second_expires > first_expires
+    assert third_expires > second_expires
+    assert f"max-age={MAX_AGE}" in refresh_resp2.headers["Set-Cookie"].lower()


### PR DESCRIPTION
## Summary
- refresh session cookies at most daily or half the max-age to stay ahead of platform cookie purges
- trigger a refresh on app launch and document Safari ITP limitations
- add tests ensuring refresh endpoints extend cookie expiration

## Testing
- `ruff check tests/test_auth_refresh.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask==3.0.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b74d9d42448321966a7a90eaca0abc