### PR TITLE
feat: set cross-subdomain session cookies

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,5 +1,4 @@
 # auth.py
-from datetime import timedelta
 from flask import Blueprint, request, jsonify, make_response
 
 auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
@@ -17,7 +16,8 @@ def login():
         max_age=MAX_AGE,
         httponly=True,
         secure=True,
-        samesite="Strict",
+        samesite="Lax",
+        domain=".falowen.app",
     )
     return resp
 
@@ -34,6 +34,7 @@ def refresh():
         max_age=MAX_AGE,
         httponly=True,
         secure=True,
-        samesite="Strict",
+        samesite="Lax",
+        domain=".falowen.app",
     )
     return resp

--- a/src/auth.py
+++ b/src/auth.py
@@ -81,7 +81,12 @@ def create_cookie_manager() -> SimpleCookieManager:
 
 def set_student_code_cookie(cm: MutableMapping[str, Any], code: str, **kwargs: Any) -> None:
     """Store the student code in a cookie."""
-    cookie_args = {"httponly": True, "secure": True, "samesite": "Strict"}
+    cookie_args = {
+        "httponly": True,
+        "secure": True,
+        "samesite": "Lax",
+        "domain": ".falowen.app",
+    }
     cookie_args.update(kwargs)
     cm["student_code"] = code
     # ``SimpleCookieManager`` tracks cookie options for test assertions.
@@ -93,7 +98,12 @@ def set_student_code_cookie(cm: MutableMapping[str, Any], code: str, **kwargs: A
 
 def set_session_token_cookie(cm: MutableMapping[str, Any], token: str, **kwargs: Any) -> None:
     """Store the session token in a cookie."""
-    cookie_args = {"httponly": True, "secure": True, "samesite": "Strict"}
+    cookie_args = {
+        "httponly": True,
+        "secure": True,
+        "samesite": "Lax",
+        "domain": ".falowen.app",
+    }
     cookie_args.update(kwargs)
     cm["session_token"] = token
     if hasattr(cm, "store"):

--- a/tests/test_session_restore.py
+++ b/tests/test_session_restore.py
@@ -10,7 +10,7 @@ from src.contracts import is_contract_expired
 stub_sessions = types.SimpleNamespace(validate_session_token=lambda *a, **k: None)
 sys.modules.setdefault("falowen.sessions", stub_sessions)
 
-from src.auth import (
+from src.auth import (  # noqa: E402
     create_cookie_manager,
     set_student_code_cookie,
     set_session_token_cookie,
@@ -307,10 +307,16 @@ def test_cookie_functions_apply_defaults_and_allow_override():
     student_kwargs = cm.store["student_code"]["kwargs"]
     token_kwargs = cm.store["session_token"]["kwargs"]
 
-    assert student_kwargs == {"httponly": True, "secure": True, "samesite": "Strict"}
+    assert student_kwargs == {
+        "httponly": True,
+        "secure": True,
+        "samesite": "Lax",
+        "domain": ".falowen.app",
+    }
     assert token_kwargs["httponly"] is True
     assert token_kwargs["secure"] is False
     assert token_kwargs["samesite"] == "Lax"
+    assert token_kwargs["domain"] == ".falowen.app"
 
 def test_multiple_cookie_managers_are_isolated():
     """Cookies set on different managers should not leak between sessions."""
@@ -337,7 +343,8 @@ def test_multiple_cookie_managers_are_isolated():
 
 def test_obsolete_cookie_triggers_login_flow(monkeypatch):
     """If cookie student code is missing from roster, session is cleared."""
-    import types, sys, importlib
+    import sys
+    import types
     import pandas as pd
     import streamlit as st
 


### PR DESCRIPTION
## Summary
- allow auth cookies to work across subdomains by setting domain `.falowen.app`
- relax SameSite policy to `Lax` and mirror settings in helper cookie functions
- adjust cookie helper tests for new defaults

## Testing
- `ruff check auth.py src/auth.py tests/test_session_restore.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b74d92900c8321be89af2dab7b5719