### PR TITLE
feat: load keychain token and bootstrap refresh

### DIFF
--- a/KeychainHelper.swift
+++ b/KeychainHelper.swift
@@ -22,6 +22,24 @@ func saveToken(_ token: String, key: KeychainKey) {
     SecItemAdd(addQuery as CFDictionary, nil)
 }
 
+/// Retrieve a token stored under the provided key.
+/// - Parameter key: The key associated with the token.
+/// - Returns: The token string if found, otherwise `nil`.
+func loadToken(for key: KeychainKey) -> String? {
+    let query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrAccount as String: key.rawValue,
+        kSecReturnData as String: true,
+        kSecMatchLimit as String: kSecMatchLimitOne
+    ]
+    var result: AnyObject?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    if status == errSecSuccess, let data = result as? Data {
+        return String(data: data, encoding: .utf8)
+    }
+    return nil
+}
+
 /// Delete a token stored under the provided key.
 func deleteToken(for key: KeychainKey) {
     let query: [String: Any] = [

--- a/ios/AuthViewModel.swift
+++ b/ios/AuthViewModel.swift
@@ -40,9 +40,19 @@ final class AuthViewModel: ObservableObject {
         self.refreshInterval = maxAge - 60
         self.retryBaseDelay = retryBaseDelay
 
+        #if canImport(Security)
+        if loadToken(for: .refreshToken) != nil {
+            scheduleRefresh()
+            // Extend the cookie immediately when the app launches.
+            refreshSession()
+        } else {
+            needsLogin = true
+        }
+        #else
         scheduleRefresh()
         // Extend the cookie immediately when the app launches.
         refreshSession()
+        #endif
     }
 
     private func scheduleRefresh() {


### PR DESCRIPTION
## Summary
- implement `loadToken` in Swift keychain helper
- add Python bridge for `get_token`/`getToken`
- have the iOS auth view model load keychain token on launch and refresh if present

## Testing
- `ruff check .` *(fails: Found 179 errors)*
- `pytest` *(fails: 1 failed, 94 passed)*
- `cd ios && swift test` *(fails: actor isolation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b75cfed48483219e8f59350bb5fe9b