### PR TITLE
Sync WKWebView cookies with URLSession on login and launch

### DIFF
--- a/ios/AuthViewModel.swift
+++ b/ios/AuthViewModel.swift
@@ -41,6 +41,11 @@ final class AuthViewModel: ObservableObject {
         self.retryBaseDelay = retryBaseDelay
 
         scheduleRefresh()
+#if canImport(WebKit)
+        // If cookies were restored from a previous session, ensure they are
+        // available to `URLSession` requests immediately on launch.
+        syncCookies(from: WKWebsiteDataStore.default().httpCookieStore)
+#endif
         // Extend the cookie immediately when the app launches.
         refreshSession()
     }

--- a/ios/LoginWebView.swift
+++ b/ios/LoginWebView.swift
@@ -1,0 +1,44 @@
+#if canImport(SwiftUI) && canImport(WebKit)
+import SwiftUI
+import WebKit
+
+/// A `WKWebView` wrapper used for user authentication flows.
+/// When navigation reaches `completionURL` we sync cookies from the web view
+/// into `HTTPCookieStorage.shared` so subsequent `URLSession` requests can reuse
+/// them.
+struct LoginWebView: UIViewRepresentable {
+    @ObservedObject var viewModel: AuthViewModel
+    let loginURL: URL
+    /// URL indicating that authentication has completed successfully.
+    let completionURL: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: loginURL))
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        let parent: LoginWebView
+
+        init(_ parent: LoginWebView) {
+            self.parent = parent
+        }
+
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            if let url = navigationAction.request.url,
+               url == parent.completionURL {
+                parent.viewModel.syncCookies(from: webView.configuration.websiteDataStore.httpCookieStore)
+            }
+            decisionHandler(.allow)
+        }
+    }
+}
+#endif

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .target(
             name: "AuthViewModelModule",
             path: ".",
-            sources: ["AuthViewModel.swift"]
+            sources: ["AuthViewModel.swift", "LoginWebView.swift"]
         ),
         .testTarget(
             name: "AuthViewModelTests",


### PR DESCRIPTION
## Summary
- Sync cookies from `WKWebsiteDataStore` to `HTTPCookieStorage` on app launch
- Add `LoginWebView` wrapper that calls `syncCookies` when authentication completes

## Testing
- `swift test` *(fails: main actor-isolated static property 'requestCount' cannot be referenced from a nonisolated context)*
- `pytest -q` *(fails: assert second_expires > first_expires)*

------
https://chatgpt.com/codex/tasks/task_e_68b75cfea4a88321aa365e32a57fbeb3