### PR TITLE
Add tests for cookie sync and token retrieval

### DIFF
--- a/KeychainHelper.swift
+++ b/KeychainHelper.swift
@@ -22,6 +22,26 @@ func saveToken(_ token: String, key: KeychainKey) {
     SecItemAdd(addQuery as CFDictionary, nil)
 }
 
+/// Retrieve a token from the Keychain.
+/// - Returns: The token if it exists, otherwise ``nil``.
+func loadToken(for key: KeychainKey) -> String? {
+    let query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrAccount as String: key.rawValue,
+        kSecReturnData as String: true,
+        kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &item)
+    if status == errSecSuccess,
+       let data = item as? Data,
+       let token = String(data: data, encoding: .utf8) {
+        return token
+    }
+    return nil
+}
+
 /// Delete a token stored under the provided key.
 func deleteToken(for key: KeychainKey) {
     let query: [String: Any] = [

--- a/ios/AuthViewModel.swift
+++ b/ios/AuthViewModel.swift
@@ -29,11 +29,12 @@ final class AuthViewModel: ObservableObject {
     private let refreshInterval: TimeInterval
     private let retryBaseDelay: TimeInterval
     private let maxRetries = 3
+    nonisolated(unsafe) static var protocolClasses: [AnyClass]? = nil
 
     /// - Parameters:
     ///   - baseURL: Base URL of the backend server.
     ///   - maxAge: Maximum age of the session cookie in seconds.
-    init(baseURL: URL, maxAge: TimeInterval = 60 * 60 * 24 * 30, retryBaseDelay: TimeInterval = 1) {
+    init(baseURL: URL, maxAge: TimeInterval = 60 * 60 * 24 * 30, retryBaseDelay: TimeInterval = 1, performInitialRefresh: Bool = true) {
         self.refreshURL = baseURL.appendingPathComponent("/auth/refresh")
 
         // Refresh one minute before the cookie expires.
@@ -42,7 +43,9 @@ final class AuthViewModel: ObservableObject {
 
         scheduleRefresh()
         // Extend the cookie immediately when the app launches.
-        refreshSession()
+        if performInitialRefresh {
+            refreshSession()
+        }
     }
 
     private func scheduleRefresh() {
@@ -59,6 +62,9 @@ final class AuthViewModel: ObservableObject {
         var config = URLSessionConfiguration.default
         // Ensure cookies from the refresh response replace the existing ones.
         config.httpCookieStorage = HTTPCookieStorage.shared
+        if let classes = AuthViewModel.protocolClasses {
+            config.protocolClasses = classes
+        }
         let session = URLSession(configuration: config)
 
         var request = URLRequest(url: refreshURL)
@@ -97,4 +103,12 @@ final class AuthViewModel: ObservableObject {
         }
     }
 #endif
+
+    /// Retrieve the current session token from ``HTTPCookieStorage.shared``.
+    /// - Returns: The session token if present.
+    func loadToken() -> String? {
+        HTTPCookieStorage.shared.cookies?
+            .first(where: { $0.name == "session" })?
+            .value
+    }
 }

--- a/tests/test_keychain_get_token.py
+++ b/tests/test_keychain_get_token.py
@@ -1,0 +1,16 @@
+import types
+from src import keychain
+
+
+def test_get_token_returns_saved(monkeypatch):
+    def fake_run(args, input, check, stdout, stderr):
+        return types.SimpleNamespace(stdout=b"saved-token")
+    monkeypatch.setattr(keychain, "_SWIFT_BIN", "swift")
+    monkeypatch.setattr(keychain.subprocess, "run", fake_run)
+    token = keychain.get_token(keychain.KeychainKey.accessToken)
+    assert token == "saved-token"
+
+
+def test_get_token_handles_absence(monkeypatch):
+    monkeypatch.setattr(keychain, "_SWIFT_BIN", None)
+    assert keychain.get_token(keychain.KeychainKey.accessToken) is None


### PR DESCRIPTION
## Summary
- Allow injecting URL protocol classes into `AuthViewModel` and expose session token loader
- Provide Swift keychain `loadToken` helper and Python bridge `get_token`
- Add Swift tests for cookie syncing and token-based refresh
- Add Python unit tests for keychain token retrieval

## Testing
- `swift test`
- `pytest -q` *(fails: assert second_expires > first_expires)*
- `python -m pytest tests/test_keychain_get_token.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75cfe8f9c83218de635468a4f4181