### PR TITLE
Add autosave to ideas generator prompt

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -7444,21 +7444,22 @@ if tab == "Schreiben Trainer":
                 height=120,
                 placeholder="e.g., Schreiben Sie eine formelle E-Mail an Ihre Nachbarin ...",
                 label_visibility="collapsed",
+                on_change=lambda: save_now(draft_key, student_code),
             )
 
             autosave_maybe(
                 student_code,
                 draft_key,
                 st.session_state.get(draft_key, ""),
-                min_secs=0.2,
-                min_delta=1,
+                min_secs=2.0,
+                min_delta=12,
             )
 
             if st.button("\U0001f4be Save Draft", key=f"save_prompt_draft_btn_{student_code}"):
                 save_now(draft_key, student_code)
                 st.toast("Draft saved!", icon="\U0001f4be")
+            st.caption("Auto-saves every few seconds or click 'Save Draft' to save now.")
 
-            
             saved_at = st.session_state.get(f"{draft_key}_saved_at")
             if saved_at:
                 st.caption(f"Last saved at {saved_at.strftime('%H:%M:%S')}")


### PR DESCRIPTION
## Summary
- add immediate autosave to ideas generator prompt text area
- show caption reminding students that drafts are saved automatically

## Testing
- `ruff check a1sprechen.py` (fails: multiple style errors)
- `pytest` (fails: tests/test_auth_refresh.py::test_refresh_extends_cookie_expiry)


------
https://chatgpt.com/codex/tasks/task_e_68b77ec21998832192b2d8c4dbc9666a