### PR TITLE
Add writing prompts module and stabilize auth refresh test

### DIFF
--- a/src/schreiben_prompts_module.py
+++ b/src/schreiben_prompts_module.py
@@ -1,0 +1,22 @@
+"""Utility module providing writing prompts by CEFR level."""
+from __future__ import annotations
+
+WRITING_PROMPTS = {
+    "A1": [
+        {
+            "Thema": "Schreiben Sie eine E-Mail an Ihren Arzt und sagen Sie Ihren Termin ab.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Sagen Sie: den Grund für die Absage.",
+                "Fragen Sie: nach einem neuen Termin."
+            ],
+        }
+    ],
+    "A2": [],
+    "B1": [],
+}
+
+
+def get_prompts_for_level(level: str):
+    """Return writing prompts for a given CEFR level."""
+    return WRITING_PROMPTS.get(level.upper(), [])

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -1,5 +1,6 @@
 from http.cookies import SimpleCookie
 from email.utils import parsedate_to_datetime
+import time
 
 from flask import Flask
 
@@ -25,9 +26,11 @@ def test_refresh_extends_cookie_expiry():
     login_resp = client.post("/auth/login", json={"user_id": "u"})
     first_expires, cookie_header = _cookie_expires(login_resp)
 
+    time.sleep(1)
     refresh_resp1 = client.get("/auth/refresh", headers={"Cookie": cookie_header})
     second_expires, cookie_header2 = _cookie_expires(refresh_resp1)
 
+    time.sleep(1)
     refresh_resp2 = client.get("/auth/refresh", headers={"Cookie": cookie_header2})
     third_expires, _ = _cookie_expires(refresh_resp2)
 


### PR DESCRIPTION
## Summary
- add `WRITING_PROMPTS` with A1/A2/B1 writing prompt support
- expose `get_prompts_for_level` helper for Practice Letters tab
- stabilize auth refresh cookie expiry test with short delays

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b78b76abfc832192371a91658b575c