### PR TITLE
Expand CEFR writing prompts for A1–B1 levels

### DIFF
--- a/src/schreiben_prompts_module.py
+++ b/src/schreiben_prompts_module.py
@@ -10,10 +10,340 @@ WRITING_PROMPTS = {
                 "Sagen Sie: den Grund für die Absage.",
                 "Fragen Sie: nach einem neuen Termin."
             ],
-        }
+        },
+        {
+            "Thema": "Schreiben Sie eine Einladung an Ihren Freund zur Feier Ihres neuen Jobs.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wann ist die Feier?",
+                "Wer soll was mitbringen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Postkarte an Ihren Freund aus dem Urlaub in Spanien.",
+            "Punkte": [
+                "Wo sind Sie?",
+                "Wie ist das Wetter?",
+                "Was machen Sie morgen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an Ihren Lehrer und sagen Sie, dass Sie krank sind.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wie fühlen Sie sich?",
+                "Wann kommen Sie wieder in den Kurs?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Nachricht an Ihren Vermieter wegen einer kaputten Heizung.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Was ist das Problem?",
+                "Was möchten Sie vom Vermieter?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Zettel an Ihren Nachbarn, Sie fahren in den Urlaub.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wann sind Sie zurück?",
+                "Was soll der Nachbar machen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Einladung an Ihre Kollegin zum Mittagessen.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wo treffen Sie sich?",
+                "Wann treffen Sie sich?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Postkarte an Ihre Eltern aus Berlin.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Was haben Sie gesehen?",
+                "Wann fahren Sie zurück?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an einen Freund und bitten Sie um Hilfe beim Umzug.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wann ziehen Sie um?",
+                "Was soll Ihr Freund mitbringen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Nachricht an Ihre Freundin, Sie möchten morgen lernen.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wo wollen Sie lernen?",
+                "Um wie viel Uhr?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an ein Hotel und reservieren Sie ein Zimmer.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Für welche Daten?",
+                "Was für ein Zimmer möchten Sie?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Nachricht an Ihren Bruder, er soll Ihre Katze füttern.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wann sind Sie weg?",
+                "Wie oft soll er kommen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an Ihren Sportverein und kündigen Sie die Mitgliedschaft.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Ab wann möchten Sie kündigen?",
+                "Bitten Sie um Bestätigung."
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Nachricht an Ihre Freundin, Sie kommen zu spät zum Treffen.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wie spät kommen Sie?",
+                "Was sollen Sie machen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an die Busfirma, Sie haben eine Tasche im Bus vergessen.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Was haben Sie verloren?",
+                "Wo können Sie die Tasche abholen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Brief an Ihren Chef, Sie brauchen einen freien Tag.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Für welchen Tag brauchen Sie frei?",
+                "Bitten Sie um Antwort."
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Nachricht an Ihren Freund, Sie möchten sein Buch leihen.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Welches Buch möchten Sie?",
+                "Wann geben Sie es zurück?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an Ihre Schule, Sie möchten den Deutschkurs wechseln.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "In welchen Kurs möchten Sie?",
+                "Wann können Sie beginnen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Nachricht an Ihre Nachbarin, sie soll Ihr Paket annehmen.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wann kommt das Paket?",
+                "Was soll die Nachbarin tun?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Postkarte an Ihren Freund, Sie sind am Meer.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wie ist das Meer?",
+                "Was machen Sie heute?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an eine Freundin, Sie planen eine Geburtstagsfeier.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wann ist die Feier?",
+                "Was soll sie mitbringen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Nachricht an Ihren Kollegen, das Meeting ist verschoben.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Auf wann ist das Meeting verschoben?",
+                "Wo findet es statt?"
+            ],
+        },
     ],
-    "A2": [],
-    "B1": [],
+    "A2": [
+        {
+            "Thema": "Schreiben Sie eine Beschwerde an eine Firma über einen defekten Fernseher.",
+            "Punkte": [
+                "Was haben Sie gekauft?",
+                "Was ist das Problem?",
+                "Was erwarten Sie?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an eine Sprachschule und informieren Sie sich über einen Kurs.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wann möchten Sie beginnen?",
+                "Was möchten Sie wissen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Brief an Ihren Freund und erzählen Sie von Ihrem neuen Hobby.",
+            "Punkte": [
+                "Was ist Ihr Hobby?",
+                "Wie oft machen Sie es?",
+                "Warum mögen Sie es?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an Ihren Chef und erklären Sie, warum Sie heute zu spät kommen.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Was ist passiert?",
+                "Wann kommen Sie zur Arbeit?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine Nachricht an Ihren Nachbarn, Sie feiern am Samstag eine Party.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wann beginnt die Party?",
+                "Worauf sollen die Nachbarn achten?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an eine Universität und bitten Sie um Informationen zum Studium.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Welchen Studiengang möchten Sie?",
+                "Welche Fragen haben Sie?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Blogbeitrag über Ihren letzten Urlaub.",
+            "Punkte": [
+                "Wohin sind Sie gefahren?",
+                "Was haben Sie erlebt?",
+                "Würden Sie wieder dorthin fahren?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an einen Freund und bitten Sie ihn, Ihre Pflanzen zu gießen.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Wie lange sind Sie weg?",
+                "Was soll Ihr Freund noch machen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an eine Wohnungsgesellschaft und fragen Sie nach einer Wohnung.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Welche Wohnung suchen Sie?",
+                "Wann möchten Sie einziehen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Brief an Ihren Sportlehrer und melden Sie sich zum Kurs an.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Für welchen Kurs?",
+                "Wann können Sie teilnehmen?"
+            ],
+        },
+    ],
+    "B1": [
+        {
+            "Thema": "Schreiben Sie einen Leserbrief an eine Zeitung über die Umweltverschmutzung in Ihrer Stadt.",
+            "Punkte": [
+                "Warum schreiben Sie?",
+                "Welche Probleme sehen Sie?",
+                "Was schlagen Sie vor?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an einen Reiseveranstalter und beschweren Sie sich über Ihren Urlaub.",
+            "Punkte": [
+                "Wohin sind Sie gereist?",
+                "Was hat Ihnen nicht gefallen?",
+                "Was erwarten Sie als Entschädigung?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Bericht für Ihren Chef über ein erfolgreiches Projekt.",
+            "Punkte": [
+                "Welches Projekt?",
+                "Was waren die Ergebnisse?",
+                "Was empfehlen Sie für die Zukunft?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an Ihren Professor und bitten Sie um eine Verlängerung der Abgabefrist.",
+            "Punkte": [
+                "Warum brauchen Sie mehr Zeit?",
+                "Wie lange brauchen Sie?",
+                "Wie bedanken Sie sich?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Artikel für den Schulblog über gesunde Ernährung.",
+            "Punkte": [
+                "Warum ist das Thema wichtig?",
+                "Welche Tipps haben Sie?",
+                "Was ist Ihr persönlicher Rat?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an einen Freund und erzählen Sie von Ihrem Umzug in eine andere Stadt.",
+            "Punkte": [
+                "Warum sind Sie umgezogen?",
+                "Wie gefällt es Ihnen dort?",
+                "Was vermissen Sie?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Brief an Ihre Gemeinde und schlagen Sie ein neues Sportzentrum vor.",
+            "Punkte": [
+                "Warum wäre es wichtig?",
+                "Wo sollte es stehen?",
+                "Wer würde es nutzen?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie eine E-Mail an eine Firma und bewerben Sie sich um ein Praktikum.",
+            "Punkte": [
+                "Was studieren Sie?",
+                "Warum interessieren Sie sich für die Firma?",
+                "Was können Sie anbieten?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Kommentar in einem Forum über die Nutzung von Smartphones.",
+            "Punkte": [
+                "Was ist Ihre Meinung?",
+                "Welche Vorteile sehen Sie?",
+                "Welche Nachteile gibt es?"
+            ],
+        },
+        {
+            "Thema": "Schreiben Sie einen Brief an einen Freund und erzählen Sie von einem kulturellen Erlebnis.",
+            "Punkte": [
+                "Was haben Sie erlebt?",
+                "Mit wem waren Sie dort?",
+                "Wie haben Sie sich gefühlt?"
+            ],
+        },
+    ],
 }
 
 


### PR DESCRIPTION
## Summary
- Expand A1 writing prompts to 22 entries.
- Introduce A2 and B1 prompt sets with at least ten structured tasks each.
- Preserve helper for retrieving prompts by CEFR level.

## Testing
- `ruff check src/schreiben_prompts_module.py`
- `python -m flake8 src/schreiben_prompts_module.py`
- `PYTHONPATH=. pytest tests/test_schreiben_helpers.py tests/test_schreiben_stats.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80c6d74688321a0a112ee239491df