### PR TITLE
Improve practice letters prompt selection

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6887,14 +6887,23 @@ if tab == "Schreiben Trainer":
                 return []
 
         prompts = get_prompts_for_level(schreiben_level)
-        options = prompts or ["(no prompts available)"]
-        selected_prompt = st.selectbox(
-            "Choose a prompt",
-            options,
-            key=f"practice_prompt_{student_code}",
-        )
         if prompts:
-            st.markdown(f"### ✉️ Prompt\n\n{selected_prompt}")
+            options = [p["Thema"] for p in prompts]
+            selected_theme = st.selectbox(
+                "Choose a prompt",
+                options,
+                key=f"practice_prompt_{student_code}",
+            )
+            prompt = next((p for p in prompts if p["Thema"] == selected_theme), None)
+            if prompt:
+                st.markdown(f"### ✉️ {prompt['Thema']}")
+                st.markdown("\n".join(f"- {p}" for p in prompt['Punkte']))
+        else:
+            st.selectbox(
+                "Choose a prompt",
+                ["(no prompts available)"],
+                key=f"practice_prompt_{student_code}",
+            )
         st.info(
             "Use \u201cIdeas Generator (Letter Coach)\u201d for ideas and \u201cMark My Letter\u201d to submit your response for evaluation.",
         )


### PR DESCRIPTION
## Summary
- Revamp Practice Letters prompt picker to display topics and bullet points
- Gracefully handle missing prompts with a placeholder option

## Testing
- `ruff check a1sprechen.py` *(fails: Found 161 errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b80c735e5c83218ad592e1e63063fc