### PR TITLE
Add tests for writing prompts module

### DIFF
--- a/tests/test_schreiben_prompts_module.py
+++ b/tests/test_schreiben_prompts_module.py
@@ -1,0 +1,23 @@
+"""Tests for the writing prompts module."""
+
+import src.schreiben_prompts_module as prompts
+
+
+def test_get_prompts_for_level_structure():
+    """Ensure A1 prompts have expected structure."""
+    prompts_list = prompts.get_prompts_for_level("A1")
+    assert isinstance(prompts_list, list)
+    assert all(isinstance(p, dict) for p in prompts_list)
+    assert all("Thema" in p and "Punkte" in p for p in prompts_list)
+
+
+def test_each_level_has_at_least_ten_prompts():
+    """All defined CEFR levels should provide at least ten prompts."""
+    for level in ["A1", "A2", "B1"]:
+        prompts_list = prompts.get_prompts_for_level(level)
+        assert len(prompts_list) >= 10
+
+
+def test_unknown_level_returns_empty_list():
+    """Unknown CEFR levels should result in an empty list."""
+    assert prompts.get_prompts_for_level("C1") == []


### PR DESCRIPTION
## Summary
- add tests checking structure and level coverage for writing prompts retrieval

## Testing
- `ruff check tests/test_schreiben_prompts_module.py`
- `PYTHONPATH=. pytest tests/test_schreiben_prompts_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68b80c76e42483218c2797ba0d7b8781