### PR TITLE
docs: clarify vocab sheet format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ This value is required for secure cookie management.
 
 - From the Dashboard, use **View all class announcements** to jump to the full classroom announcements feed.
 
+### Vocab Sheet Format
+
+The vocabulary sheet must include the following columns:
+
+- `Level`
+- `German`
+- `English`
+
+| Level | German | English |
+|-------|--------|---------|
+| A1    | Haus   | house   |
+
 ## Keychain Helper
 
 The application uses a small Swift utility to read and write OAuth tokens from


### PR DESCRIPTION
## Summary
- document required vocabulary sheet columns
- add sample table with Level, German, and English headers

## Testing
- `ruff check .` (fails: 179 errors)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b818102d7483219507c9ea25b51525