### PR TITLE
Default Level to A1 when missing in vocab lists

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6138,10 +6138,18 @@ def load_vocab_lists():
         return {}, {}
 
     df.columns = df.columns.str.strip()
-    missing = [c for c in ("Level","German","English") if c not in df.columns]
-    if missing:
-        st.error(f"Missing column(s) in your vocab sheet: {missing}")
+
+    # "German" and "English" are required.  If they're missing we cannot proceed.
+    required = ["German", "English"]
+    missing_required = [c for c in required if c not in df.columns]
+    if missing_required:
+        st.error(f"Missing column(s) in your vocab sheet: {missing_required}")
         return {}, {}
+
+    # If "Level" is missing, default all rows to A1 and warn the user.
+    if "Level" not in df.columns:
+        st.warning("Missing 'Level' column in your vocab sheet. Defaulting to 'A1'.")
+        df["Level"] = "A1"
 
     # Normalize
     df["Level"]  = df["Level"].astype(str).str.strip()

--- a/tests/test_vocab_default_level.py
+++ b/tests/test_vocab_default_level.py
@@ -1,0 +1,52 @@
+import ast
+import types
+from pathlib import Path
+import pandas as pd
+
+def _load_module(df):
+    src = Path(__file__).resolve().parents[1] / "a1sprechen.py"
+    mod_ast = ast.parse(src.read_text())
+    func_nodes = [n for n in mod_ast.body if isinstance(n, ast.FunctionDef) and n.name == "load_vocab_lists"]
+    temp_module = ast.Module(body=func_nodes, type_ignores=[])
+    code = compile(temp_module, filename="a1sprechen.py", mode="exec")
+
+    # Dummy streamlit with error/warning capture and cache_data decorator
+    class DummyStreamlit:
+        def __init__(self):
+            self.errors = []
+            self.warnings = []
+        def error(self, msg):
+            self.errors.append(msg)
+        def warning(self, msg):
+            self.warnings.append(msg)
+    def cache_data(func=None, **kwargs):
+        if func is None:
+            def wrapper(f):
+                return f
+            return wrapper
+        return func
+    st = DummyStreamlit()
+    st.cache_data = cache_data
+
+    mod = types.ModuleType("temp_vocab_module")
+    mod.pd = pd
+    mod.st = st
+    mod.SHEET_ID = "dummy"
+    mod.SHEET_GID = 0
+
+    # Patch read_csv to return our DataFrame
+    mod.pd.read_csv = lambda url: df
+
+    exec(code, mod.__dict__)
+    return mod, st
+
+
+def test_missing_level_defaults_to_a1():
+    df = pd.DataFrame({"German": ["Hallo"], "English": ["Hello"]})
+    mod, st = _load_module(df)
+    vocab, audio = mod.load_vocab_lists()
+
+    assert st.warnings, "Expected a warning when Level column is missing"
+    assert not st.errors, "Should not report errors when Level is missing"
+    assert vocab == {"A1": [("Hallo", "Hello")]}
+    assert audio[("A1", "Hallo")] == {"normal": "", "slow": ""}


### PR DESCRIPTION
## Summary
- Default to level "A1" when the vocab sheet lacks the `Level` column and warn the user.
- Add regression test for loading vocab lists without `Level` column.

## Testing
- `ruff check tests/test_vocab_default_level.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81810de1c8321855a7735634e8505