### PR TITLE
Rename classroom Q&A section

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -913,7 +913,7 @@ def render_sidebar_published():
         st.session_state["nav_sel"] = "My Course"
         st.session_state["main_tab_select"] = "My Course"
         st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
-        st.session_state["classroom_page"] = "Post A Grammar Question"
+        st.session_state["classroom_page"] = "Class Notes & Q&A"
         _qp_set_safe(tab="My Course")
         st.rerun()
 
@@ -924,7 +924,7 @@ def render_sidebar_published():
     st.sidebar.button("🗣️ Exams Mode & Custom Chat", use_container_width=True, on_click=_go, args=("Exams Mode & Custom Chat",))
     st.sidebar.button("📚 Vocab Trainer",            use_container_width=True, on_click=_go, args=("Vocab Trainer",))
     st.sidebar.button("✍️ Schreiben Trainer",        use_container_width=True, on_click=_go, args=("Schreiben Trainer",))
-    st.sidebar.button("❓ Post A Grammar Question",   use_container_width=True, on_click=_go_post_qna)
+    st.sidebar.button("❓ Class Notes & Q&A",         use_container_width=True, on_click=_go_post_qna)
 
     st.sidebar.divider()
 
@@ -3343,7 +3343,7 @@ if tab == "My Course":
 
         classroom_section = st.radio(
             "Classroom section",
-            ["Calendar", "Join on Zoom", "Members", "Announcements", "Post A Grammar Question"],
+            ["Calendar", "Join on Zoom", "Members", "Announcements", "Class Notes & Q&A"],
             horizontal=True,
             key="classroom_page",
             on_change=on_classroom_page_change,
@@ -4413,8 +4413,8 @@ if tab == "My Course":
                 for _, row in latest_df.iterrows():
                     render_announcement(row, is_pinned=False)
 
-        # ===================== Post A Grammar Question =====================
-        elif classroom_section == "Post A Grammar Question":
+        # ===================== Class Notes & Q&A =====================
+        elif classroom_section == "Class Notes & Q&A":
             q_base = db.collection("class_qna").document(class_name).collection("questions")
 
             _new7, _unans, _total = 0, 0, 0
@@ -4609,7 +4609,7 @@ if tab == "My Course":
                                     pass
                                 q_base.document(q_id).delete()
                                 _notify_slack(
-                                    f"🗑️ *Post A Grammar Question question deleted* — {class_name}\n"
+                                    f"🗑️ *Class Notes & Q&A question deleted* — {class_name}\n"
                                     f"*By:* {student_name} ({student_code}) • QID: {q_id}\n"
                                     f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC"
                                 )
@@ -4637,7 +4637,7 @@ if tab == "My Course":
                                     "topic": (new_topic or "").strip(),
                                 })
                                 _notify_slack(
-                                    f"✏️ *Post A Grammar Question question edited* — {class_name}\n"
+                                    f"✏️ *Class Notes & Q&A question edited* — {class_name}\n"
                                     f"*By:* {student_name} ({student_code}) • QID: {q_id}\n"
                                     f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC\n"
                                     f"*New:* {(new_text[:180] + '…') if len(new_text) > 180 else new_text}"
@@ -4679,7 +4679,7 @@ if tab == "My Course":
                                     if st.button("🗑️ Delete", key=f"r_del_btn_{q_id}_{rid}"):
                                         r.reference.delete()
                                         _notify_slack(
-                                            f"🗑️ *Post A Grammar Question reply deleted* — {class_name}\n"
+                                            f"🗑️ *Class Notes & Q&A reply deleted* — {class_name}\n"
                                             f"*By:* {student_name} ({student_code}) • QID: {q_id}\n"
                                             f"*When:* {_dt.now(_timezone.utc).strftime('%Y-%m-%d %H:%M')} UTC"
                                         )
@@ -4702,7 +4702,7 @@ if tab == "My Course":
                                              "edited_at": _dt.now(_timezone.utc),
                                         })
                                         _notify_slack(
-                                            f"✏️ *Post A Grammar Question reply edited* — {class_name}\n"
+                                            f"✏️ *Class Notes & Q&A reply edited* — {class_name}\n"
                                             f"*By:* {student_name} ({student_code}) • QID: {q_id}\n"
                                             f"*When:* {_dt.now(_timezone.utc).strftime('%Y-%m-%d %H:%M')} UTC\n"
                                             f"*New:* {(new_rtext[:180] + '…') if len(new_rtext) > 180 else new_rtext}"
@@ -4743,7 +4743,7 @@ if tab == "My Course":
                         r_ref.document(str(uuid4())[:8]).set(reply_payload)
                         prev = (reply_payload["reply_text"][:180] + "…") if len(reply_payload["reply_text"]) > 180 else reply_payload["reply_text"]
                         _notify_slack(
-                            f"💬 *New Post A Grammar Question reply* — {class_name}\n"
+                            f"💬 *New Class Notes & Q&A reply* — {class_name}\n"
                             f"*By:* {student_name} ({student_code})  •  *QID:* {q_id}\n"
                             f"*When:* {_dt.now(_timezone.utc).strftime('%Y-%m-%d %H:%M')} UTC\n"
                             f"*Reply:* {prev}"


### PR DESCRIPTION
## Summary
- Rename "Post A Grammar Question" to "Class Notes & Q&A" throughout classroom navigation
- Update sidebar quick-access button and Slack notification messages to match the new label

## Testing
- `pytest -q`
- `ruff check a1sprechen.py` *(fails: 161 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b82fa41bb88321919ebb1216be4748