### PR TITLE
refactor: rename post_message fields

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2289,16 +2289,24 @@ def fetch_latest(level: str, code: str, lesson_key: str) -> Optional[Dict[str, A
 # -------------------------
 # Misc existing helper preserved
 # -------------------------
-def post_message(level: str, code: str, name: str, text: str, reply_to: Optional[str] = None) -> None:
+def post_message(
+    level: str,
+    code: str,
+    name: str,
+    content: str,
+    reply_to: Optional[str] = None,
+) -> None:
     """Post a message to the class board."""
     posts_ref = db.collection("class_board").document(level).collection("posts")
-    posts_ref.add({
-        "student_code": code,
-        "student_name": name,
-        "text": text.strip(),
-        "timestamp": _dt.now(_timezone.utc),
-        "reply_to": reply_to,
-    })
+    posts_ref.add(
+        {
+            "student_code": code,
+            "student_name": name,
+            "content": content.strip(),
+            "created_at": _dt.now(_timezone.utc),
+            "reply_to": reply_to,
+        }
+    )
 
 RESOURCE_LABELS = {
     'video': '🎥 Video',


### PR DESCRIPTION
## Summary
- rename post_message argument to `content`
- record `content` and `created_at` in Firestore posts

## Testing
- `ruff check .` (fails: E701, E702, E401, F841, F401)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b83eb7eb948321b91a60cac005fac5