### PR TITLE
Batch Firestore writes and rename migration fields

### DIFF
--- a/scripts/migrate_qna_to_board.py
+++ b/scripts/migrate_qna_to_board.py
@@ -8,6 +8,8 @@ def migrate():
     firebase_admin.initialize_app()
     db = firestore.client()
     qna_ref = db.collection("class_qna")
+    batch = db.batch()
+    ops = 0
     for class_doc in qna_ref.stream():
         class_name = class_doc.id
         questions_ref = class_doc.reference.collection("questions")
@@ -17,22 +19,46 @@ def migrate():
                 "content": qdata.get("question"),
                 "posted_by_name": qdata.get("asked_by_name"),
                 "posted_by_code": qdata.get("asked_by_code"),
-                "timestamp": qdata.get("timestamp"),
+                "created_at": qdata.get("timestamp"),
                 "topic": qdata.get("topic", ""),
             }
-            post_ref = db.collection("class_board").document(class_name).collection("posts").document(qdoc.id)
-            post_ref.set(post_data)
+            if qdata.get("updated_at") is not None:
+                post_data["updated_at"] = qdata.get("updated_at")
+
+            post_ref = (
+                db.collection("class_board")
+                .document(class_name)
+                .collection("posts")
+                .document(qdoc.id)
+            )
+            batch.set(post_ref, post_data)
+            ops += 1
 
             replies_ref = qdoc.reference.collection("replies")
             for rdoc in replies_ref.stream():
                 rdata = rdoc.to_dict() or {}
                 comment_data = {
-                    "comment_text": rdata.get("reply_text"),
+                    "content": rdata.get("reply_text"),
                     "commented_by_name": rdata.get("replied_by_name"),
                     "commented_by_code": rdata.get("replied_by_code"),
-                    "timestamp": rdata.get("timestamp"),
+                    "created_at": rdata.get("timestamp"),
                 }
-                post_ref.collection("comments").document(rdoc.id).set(comment_data)
+                if rdata.get("updated_at") is not None:
+                    comment_data["updated_at"] = rdata.get("updated_at")
+
+                comment_ref = post_ref.collection("comments").document(rdoc.id)
+                batch.set(comment_ref, comment_data)
+                ops += 1
+
+                if ops >= 450:
+                    batch.commit()
+                    batch = db.batch()
+                    ops = 0
+
+        if ops:
+            batch.commit()
+            batch = db.batch()
+            ops = 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Rename `comment_text` to `content` and `timestamp` to `created_at`
- Carry over `updated_at` when present
- Use Firestore batch writes with commit threshold

## Testing
- `ruff check scripts/migrate_qna_to_board.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b83ebc79a48321b77d2a10e3a5bd89