### PR TITLE
Add banner around announcements

### DIFF
--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -130,6 +130,7 @@ def render_announcements(announcements: list) -> None:
     if not announcements:
         st.info("📣 No new updates to show.")
         return
+    banner_message = "www.falowen.app – your German conversational partner"
     _html = """
     <style>
       :root{ --brand:#1d4ed8; --ring:#93c5fd; --text:#0b1220; --muted:#475569; --card:#ffffff;
@@ -139,6 +140,7 @@ def render_announcements(announcements: list) -> None:
       }
       .page-wrap{max-width:1100px;margin:0 auto;padding:0 10px;}
       .ann-title{font-weight:800;font-size:1.05rem;line-height:1.2; padding-left:12px;border-left:5px solid var(--brand);margin:0 0 6px 0;color:var(--text);}
+      .ann-banner{text-align:center;font-weight:700;margin:8px 0;}
       .ann-shell{border-radius:14px;border:1px solid var(--shell-border);background:var(--card);box-shadow:0 6px 18px rgba(2,6,23,.12);padding:12px 14px;overflow:hidden;}
       .ann-heading{display:flex;align-items:center;gap:10px;margin:0 0 6px 0;font-weight:800;color:var(--text);}
       .ann-chip{font-size:.78rem;font-weight:800;text-transform:uppercase;background:var(--chip-bg);color:var(--chip-fg);padding:4px 9px;border-radius:999px;border:1px solid var(--shell-border);}
@@ -151,6 +153,7 @@ def render_announcements(announcements: list) -> None:
     </style>
     <div class="page-wrap">
       <div class="ann-title">📣 New Updates</div>
+      <div class="ann-banner">__BANNER__</div>
       <div class="ann-shell" id="ann_shell" aria-live="polite">
         <div id="ann_card">
           <div class="ann-heading"><span class="ann-chip" id="ann_tag" style="display:none;"></span><span id="ann_title"></span></div>
@@ -159,6 +162,7 @@ def render_announcements(announcements: list) -> None:
         </div>
         <div class="ann-dots" id="ann_dots" role="tablist" aria-label="Announcement selector"></div>
       </div>
+      <div class="ann-banner">__BANNER__</div>
     </div>
     <script>
       const data = __DATA__;
@@ -184,10 +188,22 @@ def render_announcements(announcements: list) -> None:
     </script>
     """
     try:
-        components.html(_html.replace("__DATA__", json.dumps(announcements, ensure_ascii=False)), height=220, scrolling=False)
+        components.html(
+            _html.replace("__DATA__", json.dumps(announcements, ensure_ascii=False)).replace("__BANNER__", banner_message),
+            height=220,
+            scrolling=False,
+        )
     except TypeError:
+        st.markdown(
+            f"<div style='text-align:center;font-weight:700;margin:8px 0;'>{banner_message}</div>",
+            unsafe_allow_html=True,
+        )
         for a in announcements:
             st.markdown(f"**{a.get('title','')}** — {a.get('body','')}")
+        st.markdown(
+            f"<div style='text-align:center;font-weight:700;margin:8px 0;'>{banner_message}</div>",
+            unsafe_allow_html=True,
+        )
 
 
 def render_announcements_once(data: list, dashboard_active: bool) -> None:


### PR DESCRIPTION
## Summary
- add promotional banner before and after announcements
- ensure banner appears in fallback rendering

## Testing
- `python -m pytest`
- `ruff check src/ui_widgets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84a9f076c832189b3f1618b631864