### PR TITLE
Add hyperlink to announcement banner

### DIFF
--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -131,6 +131,9 @@ def render_announcements(announcements: list) -> None:
         st.info("📣 No new updates to show.")
         return
     banner_message = "www.falowen.app – your German conversational partner"
+    banner_link = (
+        f"<a href=\"https://www.falowen.app\" target=\"_blank\">{banner_message}</a>"
+    )
     _html = """
     <style>
       :root{ --brand:#1d4ed8; --ring:#93c5fd; --text:#0b1220; --muted:#475569; --card:#ffffff;
@@ -141,6 +144,7 @@ def render_announcements(announcements: list) -> None:
       .page-wrap{max-width:1100px;margin:0 auto;padding:0 10px;}
       .ann-title{font-weight:800;font-size:1.05rem;line-height:1.2; padding-left:12px;border-left:5px solid var(--brand);margin:0 0 6px 0;color:var(--text);}
       .ann-banner{text-align:center;font-weight:700;margin:8px 0;}
+      .ann-banner a{color:var(--link);text-decoration:underline;}
       .ann-shell{border-radius:14px;border:1px solid var(--shell-border);background:var(--card);box-shadow:0 6px 18px rgba(2,6,23,.12);padding:12px 14px;overflow:hidden;}
       .ann-heading{display:flex;align-items:center;gap:10px;margin:0 0 6px 0;font-weight:800;color:var(--text);}
       .ann-chip{font-size:.78rem;font-weight:800;text-transform:uppercase;background:var(--chip-bg);color:var(--chip-fg);padding:4px 9px;border-radius:999px;border:1px solid var(--shell-border);}
@@ -189,21 +193,20 @@ def render_announcements(announcements: list) -> None:
     """
     try:
         components.html(
-            _html.replace("__DATA__", json.dumps(announcements, ensure_ascii=False)).replace("__BANNER__", banner_message),
+            _html.replace("__DATA__", json.dumps(announcements, ensure_ascii=False)).replace("__BANNER__", banner_link),
             height=220,
             scrolling=False,
         )
     except TypeError:
-        st.markdown(
-            f"<div style='text-align:center;font-weight:700;margin:8px 0;'>{banner_message}</div>",
-            unsafe_allow_html=True,
+        banner_html = (
+            f"<div style='text-align:center;font-weight:700;margin:8px 0;'><a href='https://www.falowen.app' "
+            "target='_blank' style='color:var(--link, #1d4ed8);text-decoration:underline;'>"
+            f"{banner_message}</a></div>"
         )
+        st.markdown(banner_html, unsafe_allow_html=True)
         for a in announcements:
             st.markdown(f"**{a.get('title','')}** — {a.get('body','')}")
-        st.markdown(
-            f"<div style='text-align:center;font-weight:700;margin:8px 0;'>{banner_message}</div>",
-            unsafe_allow_html=True,
-        )
+        st.markdown(banner_html, unsafe_allow_html=True)
 
 
 def render_announcements_once(data: list, dashboard_active: bool) -> None:


### PR DESCRIPTION
## Summary
- Link announcement banner text to https://www.falowen.app
- Apply matching link in TypeError fallback with emphasized styling

## Testing
- `ruff check src/ui_widgets.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85784629c8321a7dfdf62346675f3