### PR TITLE
Use default styles for post textareas

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4508,19 +4508,7 @@ if tab == "My Course":
                 st.session_state["q_topic"] = ""
                 st.session_state["q_text"] = ""
             topic = st.text_input("Topic (optional)", key="q_topic")
-            st.markdown(
-                """
-                <style>
-                textarea[aria-label="Your content"] {
-                    background-color: #233d2b;
-                    color: #fff;
-                    font-family: 'Chalkboard', 'Chalkduster', 'Comic Sans MS', cursive;
-                }
-                </style>
-                """,
-                unsafe_allow_html=True,
-            )
-            new_q = st.text_area("Your content", key="q_text", height=160)
+            new_q = st.text_area("Your content", key="q_text", height=120)
             if st.button("Post", key="qna_post_question") and new_q.strip():
                 q_id = str(uuid4())[:8]
                 payload = {
@@ -4624,23 +4612,11 @@ if tab == "My Course":
                                     value=st.session_state.get(f"q_edit_topic_{q_id}", ""),
                                     key=f"q_edit_topic_input_{q_id}"
                                 )
-                                st.markdown(
-                                    """
-                                    <style>
-                                    textarea[aria-label="Edit post"] {
-                                        background-color: #233d2b;
-                                        color: #fff;
-                                        font-family: 'Chalkboard', 'Chalkduster', 'Comic Sans MS', cursive;
-                                    }
-                                    </style>
-                                    """,
-                                    unsafe_allow_html=True,
-                                )
                                 new_text = st.text_area(
                                     "Edit post",
                                     value=st.session_state.get(f"q_edit_text_{q_id}", ""),
                                     key=f"q_edit_text_input_{q_id}",
-                                    height=200
+                                    height=150
                                 )
                                 save_edit = st.form_submit_button("💾 Save")
                                 cancel_edit = st.form_submit_button("❌ Cancel")


### PR DESCRIPTION
## Summary
- remove chalkboard CSS injections for post textareas
- tweak compose and edit textarea heights

## Testing
- `pytest`
- `streamlit run a1sprechen.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68b865c75e208321a27be2f27eb62098