### PR TITLE
Fix Slack notifier to handle multiple parts

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -3315,12 +3315,14 @@ if tab == "My Course":
         IS_ADMIN = (student_code in ADMINS)
 
         # ---------- slack helper (use global notify_slack if present; else env/secrets) ----------
-        def _notify_slack(text: str):
+        def _notify_slack(*parts: str):
+            text = "".join(parts)
             try:
                 fn = globals().get("notify_slack")
                 if callable(fn):
                     try:
-                        fn(text); return
+                        fn(text)
+                        return
                     except Exception:
                         pass
                 url = (os.getenv("SLACK_WEBHOOK_URL") or


### PR DESCRIPTION
## Summary
- Allow `_notify_slack` to accept any number of string parts
- Join provided parts before posting to Slack

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b87f52e4d88321ba574dea46dc649c