### PR TITLE
Fix Slack notifier to handle multiple parts and improve question box visibility

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -3315,12 +3315,14 @@ if tab == "My Course":
         IS_ADMIN = (student_code in ADMINS)
 
         # ---------- slack helper (use global notify_slack if present; else env/secrets) ----------
-        def _notify_slack(text: str):
+        def _notify_slack(*parts: str):
+            text = "".join(parts)
             try:
                 fn = globals().get("notify_slack")
                 if callable(fn):
                     try:
-                        fn(text); return
+                        fn(text)
+                        return
                     except Exception:
                         pass
                 url = (os.getenv("SLACK_WEBHOOK_URL") or
@@ -4521,8 +4523,8 @@ if tab == "My Course":
                 """
                 <style>
                 textarea[aria-label="Your content"] {
-                    background-color: #233d2b;
-                    color: #fff;
+                    background-color: #f1f5f9;
+                    color: #0f172a;
                     font-family: 'Chalkboard', 'Chalkduster', 'Comic Sans MS', cursive;
                 }
                 </style>


### PR DESCRIPTION
## Summary
- Allow `_notify_slack` to accept any number of string parts
- Join provided parts before posting to Slack
- Lighten question text box so students can see it before typing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b87f52e4d88321ba574dea46dc649c