### PR TITLE
Add missing FPDF import for PDF generation

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4915,6 +4915,8 @@ if tab == "My Course":
                 )
 
                 # --- PDF Download (all notes, Unicode/emoji ready!) ---
+                from fpdf import FPDF
+
                 class PDF(FPDF):
                     def header(self):
                         self.set_font('DejaVu', '', 16)


### PR DESCRIPTION
## Summary
- import `FPDF` before declaring local `PDF` subclass in `a1sprechen.py`

## Testing
- `python - <<'PY'
from fpdf import FPDF
print('FPDF imported', FPDF)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b97bb614dc8321a20f9968af66b4f2