### PR TITLE
Handle exam topic load failures gracefully

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5164,8 +5164,15 @@ exam_csv_url = f"https://docs.google.com/spreadsheets/d/{exam_sheet_id}/gviz/tq?
 
 @st.cache_data(ttl=3600)
 def _load_exam_topics_cached():
-    df = pd.read_csv(exam_csv_url)
-    for col in ['Level', 'Teil', 'Topic/Prompt', 'Keyword/Subtopic']:
+    expected_cols = ['Level', 'Teil', 'Topic/Prompt', 'Keyword/Subtopic']
+    try:
+        df = pd.read_csv(exam_csv_url)
+    except Exception as e:
+        logging.exception("Failed to load exam topics")
+        st.error("Unable to load exam topics. Please try again later.")
+        return pd.DataFrame(columns=expected_cols)
+
+    for col in expected_cols:
         if col not in df.columns:
             df[col] = ""
     # strip


### PR DESCRIPTION
## Summary
- Wrap exam topic CSV load in try/except
- Log failures and show Streamlit error
- Return empty DataFrame with required columns when loading fails

## Testing
- `ruff check a1sprechen.py` *(fails: Found 159 errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9849b5c4083219ee786b33775a659