### PR TITLE
Track exam progress and drop used topic

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5757,9 +5757,11 @@ if tab == "Exams Mode & Custom Chat":
                     st.session_state["falowen_stage"]           = 4
                     st.session_state["falowen_messages"]        = []
                     st.session_state["custom_topic_intro_done"] = False
-                    st.session_state["remaining_topics"]        = filtered.copy()
+                    st.session_state["remaining_topics"]        = [t for t in filtered if t != chosen]
                     random.shuffle(st.session_state["remaining_topics"])
                     st.session_state["used_topics"]             = []
+                    student_code = st.session_state.get("student_code")
+                    save_exam_progress(student_code, [{"level": level, "teil": teil, "topic": topic}])
                     st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
 
 


### PR DESCRIPTION
## Summary
- record exam progress after starting practice
- exclude the chosen topic from remaining topics when beginning practice

## Testing
- `python -m flake8 a1sprechen.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b9864964208321ae8b926726acb55e