### PR TITLE
Switch dashboard announcements to button

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1338,16 +1338,17 @@ render_announcements_once(announcements, tab == "Dashboard")
 # ===================== Dashboard =========================
 # =========================================================
 if tab == "Dashboard":
-    ann_url = (
-        "/?tab="
-        + _urllib.quote("My Course")
-        + "&coursebook_subtab="
-        + _urllib.quote("🧑‍🏫 Classroom")
-        + "&classroom_page=Announcements"
-    )
-    st.link_button(
-        "View all class announcements", ann_url, use_container_width=True
-    )
+    def _go_announcements() -> None:
+        st.session_state["nav_sel"] = "My Course"
+        st.session_state["main_tab_select"] = "My Course"
+        st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
+        st.session_state["cb_prev_subtab"] = "🧑‍🏫 Classroom"
+        st.session_state["classroom_page"] = "Announcements"
+        st.session_state["classroom_prev_page"] = "Announcements"
+        _qp_set(tab="My Course")
+        st.rerun()
+
+    st.button("View all class announcements", on_click=_go_announcements)
 
     # ---------- Helpers ----------
     def safe_get(row, key, default=""):


### PR DESCRIPTION
## Summary
- Replace dashboard announcements link with a button
- Restore `_go_announcements` navigation helper

## Testing
- `pytest -q`
- `ruff check a1sprechen.py` *(fails: Multiple statements on one line, f-string issues, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b98fa5298c8321b63a0cb7ba158f29