### PR TITLE
Remove Next Topic feature and cleanup session state

### DIFF
--- a/tests/test_back_step.py
+++ b/tests/test_back_step.py
@@ -25,8 +25,6 @@ def test_back_step_clears_chat_state():
         'falowen_teil': 'T1',
         'falowen_exam_topic': 'topic',
         'falowen_exam_keyword': 'key',
-        'remaining_topics': ['a'],
-        'used_topics': ['b'],
         'falowen_messages': ['hi'],
         'falowen_loaded_key': 'lk',
         'falowen_conv_key': 'conv',
@@ -49,7 +47,7 @@ def test_back_step_clears_chat_state():
     for key in [
         'falowen_mode', 'falowen_level', 'falowen_teil',
         'falowen_exam_topic', 'falowen_exam_keyword',
-        'remaining_topics', 'used_topics', 'falowen_messages',
+        'falowen_messages',
         'falowen_loaded_key', 'falowen_conv_key',
         'falowen_chat_draft_key', 'custom_topic_intro_done',
         'falowen_turn_count', draft_key, *_draft_state_keys(draft_key)


### PR DESCRIPTION
## Summary
- remove "Next Topic" button and associated state management
- drop unused topic-tracking keys from chat setup and teardown
- adjust back_step test after removing topic-tracking state

## Testing
- `python -m py_compile a1sprechen.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b992f864b88321b4505ce9fb33e4c6