### PR TITLE
chore: remove custom topic feature

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5146,7 +5146,7 @@ def back_step():
         "falowen_messages",
         "falowen_loaded_key", "falowen_conv_key",
         "falowen_chat_draft_key", "custom_topic_intro_done",
-        "falowen_turn_count", "falowen_custom_topic",
+        "falowen_turn_count",
     ]:
         st.session_state.pop(key, None)
     if draft_key:
@@ -5543,7 +5543,6 @@ default_state = {
     "falowen_teil": None,
     "falowen_messages": [],
     "falowen_turn_count": 0,
-    "falowen_custom_topic": "",
     "custom_topic_intro_done": False,
     "custom_chat_level": None,
     "falowen_exam_topic": None,
@@ -5589,7 +5588,6 @@ if tab == "Exams Mode & Custom Chat":
         )
         if st.button("Next ➡️", key="falowen_next_mode"):
             st.session_state["falowen_mode"] = mode
-            st.session_state["falowen_custom_topic"] = ""
             st.session_state["falowen_stage"] = 99 if mode == "Pronunciation & Speaking Checker" else 2
             if mode == "Pronunciation & Speaking Checker":
                 st.session_state["falowen_stage"] = 99
@@ -5615,16 +5613,12 @@ if tab == "Exams Mode & Custom Chat":
     if st.session_state["falowen_stage"] == 2 and not st.session_state.get("falowen_level"):
         st.subheader("Step 2: Choose Your Level")
         level = st.radio("Select your level:", ["A1","A2","B1","B2","C1"], key="falowen_level_center")
-        if st.session_state["falowen_mode"] == "Custom Chat":
-            st.text_input("What topic would you like to discuss?", key="falowen_custom_topic")
-
         col1, col2 = st.columns(2)
         with col1:
             if st.button("⬅️ Back", key="falowen_back1"):
                 st.session_state["falowen_stage"] = 1
                 st.session_state["falowen_messages"] = []
                 st.session_state["_falowen_loaded"] = False
-                st.session_state["falowen_custom_topic"] = ""
                 st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
         with col2:
             if st.button("Next ➡️", key="falowen_next_level"):
@@ -5785,10 +5779,6 @@ if tab == "Exams Mode & Custom Chat":
         is_exam = (mode == "Exams Mode")
         student_code = st.session_state.get("student_code", "demo")
 
-        if not is_exam and not st.session_state.get("falowen_custom_topic"):
-            st.text_input("What topic would you like to discuss?", key="falowen_custom_topic")
-            st.stop()
-        
         # === Load messages & draft PER (student_code + mode/level/teil) ===
         conv_key = f"{mode}_{level}_{(teil or 'custom')}"
         draft_key = _wkey("chat_draft")
@@ -5819,11 +5809,9 @@ if tab == "Exams Mode & Custom Chat":
             if is_exam:
                 instruction = build_exam_instruction(level, teil)
             else:
-                topic = st.session_state.get("falowen_custom_topic")
-                if topic:
-                    instruction = f"Hallo! 👋 Lass uns über {topic} sprechen."
-                else:
-                    instruction = "Hallo! 👋 What would you like to talk about? Give me details of what you want so I can understand."
+                instruction = (
+                    "Hallo! 👋 What would you like to talk about? Give me details of what you want so I can understand."
+                )
             st.session_state["falowen_messages"].append({"role": "assistant", "content": instruction})
             try:
                 doc = db.collection("falowen_chats").document(student_code)
@@ -5845,9 +5833,8 @@ if tab == "Exams Mode & Custom Chat":
             else:
                 system_prompt = base_prompt
         else:
-            topic = st.session_state.get("falowen_custom_topic")
             base_prompt = build_custom_chat_prompt(level, student_code)
-            system_prompt = f"Topic: {topic}. {base_prompt}" if topic else base_prompt
+            system_prompt = base_prompt
 
         # Always-visible recorder button
         RECORDER_BASE = "https://script.google.com/macros/s/AKfycbzMIhHuWKqM2ODaOCgtS7uZCikiZJRBhpqv2p6OyBmK1yAVba8HlmVC1zgTcGWSTfrsHA/exec"
@@ -6026,7 +6013,7 @@ if tab == "Exams Mode & Custom Chat":
                         "falowen_stage","falowen_mode","falowen_level","falowen_teil",
                         "falowen_messages","custom_topic_intro_done","falowen_exam_topic",
                         "falowen_exam_keyword",
-                        "_falowen_loaded","falowen_loaded_key","falowen_custom_topic"
+                        "_falowen_loaded","falowen_loaded_key"
                     ]:
                         st.session_state.pop(k, None)
                     st.session_state["falowen_stage"] = 1


### PR DESCRIPTION
## Summary
- remove custom chat topic state and prompts
- simplify chat greeting and system prompt

## Testing
- `ruff check a1sprechen.py` *(fails: Found 159 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b995128d988321accd3422d5e23234