### PR TITLE
Import MutableMapping and Any in auth module

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -1,5 +1,7 @@
 import os
 from datetime import datetime, timedelta, timezone
+from collections.abc import MutableMapping
+from typing import Any
 
 # --- Cookie defaults --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add missing MutableMapping and Any imports to src/auth.py

## Testing
- `python -m py_compile src/auth.py`
- `pytest -q` *(fails: ImportError: cannot import name 'SimpleCookieManager' from 'src.auth')*

------
https://chatgpt.com/codex/tasks/task_e_68ba19e4943c832193669bf3fafcf9ce