### PR TITLE
Refactor logout cookie manager handling

### DIFF
--- a/src/logout.py
+++ b/src/logout.py
@@ -7,18 +7,21 @@ from typing import Any, Callable
 import streamlit as st
 
 from falowen.sessions import destroy_session_token
-from src.auth import clear_session
+from src.auth import clear_session, create_cookie_manager
 
 
 def do_logout(
-    cookie_manager: Any,
+    cookie_manager: Any | None = None,
     *,
     st_module: Any = st,
     destroy_token: Callable[[str], None] = destroy_session_token,
     clear_session_fn: Callable[[Any], None] = clear_session,
+    create_cookie_manager_fn: Callable[[], Any] = create_cookie_manager,
     logger: Any = logging,
 ) -> None:
     """Clear session information and cookies for the current user."""
+    if cookie_manager is None:
+        cookie_manager = create_cookie_manager_fn()
     try:
         prev_token = st_module.session_state.get("session_token", "")
         if prev_token:

--- a/tests/test_logout_uses_cookie_manager_creation.py
+++ b/tests/test_logout_uses_cookie_manager_creation.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock
+import types
+
+from src.logout import do_logout
+
+
+def test_logout_creates_cookie_manager_and_clears_without_save():
+    cm = types.SimpleNamespace(save=MagicMock())
+    create_cm = MagicMock(return_value=cm)
+    clear_session = MagicMock()
+    mock_st = types.SimpleNamespace(session_state={}, success=MagicMock())
+
+    do_logout(
+        None,
+        st_module=mock_st,
+        destroy_token=MagicMock(),
+        clear_session_fn=clear_session,
+        create_cookie_manager_fn=create_cm,
+        logger=types.SimpleNamespace(exception=MagicMock()),
+    )
+
+    create_cm.assert_called_once_with()
+    clear_session.assert_called_once_with(cm)
+    cm.save.assert_not_called()


### PR DESCRIPTION
## Summary
- create cookie manager lazily in `do_logout` when one isn't provided
- add regression test ensuring logout clears session without saving

## Testing
- `pytest -q` *(fails: ImportError: cannot import name '_SessionStore' from 'src.auth')*
- `PYTHONPATH=. pytest tests/test_logout_clears_ann_flag.py -q`
- `PYTHONPATH=. pytest tests/test_logout_rerenders_google_button.py -q`
- `PYTHONPATH=. pytest tests/test_logout_uses_cookie_manager_creation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9909cbfc8321b0b9f96bef7c7b59