### PR TITLE
Use save_cookies helper in login flows

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -300,10 +300,7 @@ def _handle_google_oauth(code: str, state: str) -> None:
         set_student_code_cookie(cookie_manager, student_row["StudentCode"], expires=datetime.now(UTC) + timedelta(days=180))
         persist_session_client(sess_token, student_row["StudentCode"])
         set_session_token_cookie(cookie_manager, sess_token, expires=datetime.now(UTC) + timedelta(days=30))
-        try:
-            cookie_manager.save()
-        except Exception:
-            logging.exception("Cookie save failed")
+        save_cookies(cookie_manager)
 
         qp_clear()
         st.success(f"Welcome, {student_row['Name']}!")
@@ -535,10 +532,7 @@ def render_login_form(login_id: str, login_pass: str) -> bool:
     set_student_code_cookie(cookie_manager, student_row["StudentCode"], expires=datetime.now(UTC) + timedelta(days=180))
     persist_session_client(sess_token, student_row["StudentCode"])
     set_session_token_cookie(cookie_manager, sess_token, expires=datetime.now(UTC) + timedelta(days=30))
-    try:
-        cookie_manager.save()
-    except Exception:
-        logging.exception("Cookie save failed")
+    save_cookies(cookie_manager)
 
     st.success(f"Welcome, {student_row['Name']}!")
     st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1


### PR DESCRIPTION
## Summary
- Replace manual cookie saving in Google OAuth with `save_cookies`
- Replace manual cookie saving in login form with `save_cookies`

## Testing
- `ruff check a1sprechen.py`
- `pytest -q` *(fails: ImportError: cannot import name '_SessionStore')*

------
https://chatgpt.com/codex/tasks/task_e_68babbb22e30832195f715253d9ae8df