### PR TITLE
Fix login UI placeholder in a1sprechen

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -176,9 +176,7 @@ if session:
     data = session.get("data")
 else:
     # show login UI
-    ...
-
-    ...
+    st.write("TODO: implement login UI")  # TODO: implement login UI
 
 # ------------------------------------------------------------------------------
 # Google OAuth (Gmail sign-in) — single-source, no duplicate buttons


### PR DESCRIPTION
## Summary
- remove stray Ellipsis in login branch
- add placeholder message for login UI implementation

## Testing
- `python -m py_compile a1sprechen.py`
- `pytest -q` *(fails: ImportError: cannot import name '_SessionStore' from 'src.auth')*

------
https://chatgpt.com/codex/tasks/task_e_68bac55d8c708321a0a03589ae375d5d