### PR TITLE
Add session refresh endpoint

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -168,6 +168,17 @@ except Exception:
 if session:
     st.session_state["student_code"] = session["student_code"]
     st.session_state["session_token"] = session["session_token"]
+else:
+    # Ensure stale cookies are cleared if session restoration fails
+    try:
+        clear_session(cm)
+    except Exception:
+        pass
+    try:
+        cm.pop("student_code", None)
+        cm.pop("session_token", None)
+    except Exception:
+        pass
 
 # ------------------------------------------------------------------------------
 # Google OAuth (Gmail sign-in) — single-source, no duplicate buttons

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -1,57 +1,90 @@
+"""Tests for the /auth/refresh endpoint in falowen.sessions."""
+
 from http.cookies import SimpleCookie
-from email.utils import parsedate_to_datetime
-import time
+import importlib
+import sys
+import types
 
 from flask import Flask
 
-from auth import (
-    auth_bp,
-    MAX_AGE,
-    REFRESH_COOKIE,
-    COOKIE_PATH,
-    COOKIE_SAMESITE,
-)
 
+def _create_app(monkeypatch):
+    """Create a Flask app with the sessions blueprint registered.
 
-def create_app():
+    External dependencies used by ``falowen.sessions`` are stubbed so the
+    module can be imported without hitting network services.
+    """
+
+    firebase_admin_stub = types.ModuleType("firebase_admin")
+    firebase_admin_stub._apps = []
+    firebase_admin_stub.initialize_app = lambda *a, **k: None
+    credentials_stub = types.ModuleType("firebase_admin.credentials")
+    credentials_stub.Certificate = lambda *a, **k: None
+    firestore_stub = types.ModuleType("firebase_admin.firestore")
+    firestore_stub.client = lambda: object()
+    firebase_admin_stub.credentials = credentials_stub
+    firebase_admin_stub.firestore = firestore_stub
+
+    monkeypatch.setitem(sys.modules, "firebase_admin", firebase_admin_stub)
+    monkeypatch.setitem(sys.modules, "firebase_admin.credentials", credentials_stub)
+    monkeypatch.setitem(sys.modules, "firebase_admin.firestore", firestore_stub)
+
+    streamlit_stub = types.ModuleType("streamlit")
+    streamlit_stub.secrets = {"firebase": {}}
+    streamlit_stub.error = lambda *a, **k: None
+    streamlit_stub.session_state = {}
+    monkeypatch.setitem(sys.modules, "streamlit", streamlit_stub)
+
+    sys.modules.pop("falowen.sessions", None)
+    sessions = importlib.import_module("falowen.sessions")
+    # Ensure module entry is restored after test
+    monkeypatch.setitem(sys.modules, "falowen.sessions", sessions)
+
     app = Flask(__name__)
-    app.register_blueprint(auth_bp)
-    return app
+    app.register_blueprint(sessions.auth_bp)
+    return app, sessions
 
 
-def _cookie_attrs(resp):
-    cookie = SimpleCookie()
-    cookie.load(resp.headers["Set-Cookie"])
-    morsel = cookie[REFRESH_COOKIE]
-    return (
-        parsedate_to_datetime(morsel["expires"]),
-        morsel["path"],
-        morsel["samesite"],
-        morsel.OutputString(),
-    )
-
-
-def test_refresh_extends_cookie_expiry():
-    app = create_app()
+def test_refresh_rotates_token_and_sets_cookie(monkeypatch):
+    app, sessions = _create_app(monkeypatch)
     client = app.test_client()
 
-    login_resp = client.post("/auth/login", json={"user_id": "u"})
-    first_expires, path, samesite, cookie_header = _cookie_attrs(login_resp)
-    assert path == COOKIE_PATH
-    assert samesite == COOKIE_SAMESITE
+    calls: dict[str, str] = {}
 
-    time.sleep(1)
-    refresh_resp1 = client.get("/auth/refresh", headers={"Cookie": cookie_header})
-    second_expires, path, samesite, cookie_header2 = _cookie_attrs(refresh_resp1)
-    assert path == COOKIE_PATH
-    assert samesite == COOKIE_SAMESITE
+    def validate(tok, ua_hash=""):
+        calls["validate"] = tok
+        return {"student_code": "abc"}
 
-    time.sleep(1)
-    refresh_resp2 = client.get("/auth/refresh", headers={"Cookie": cookie_header2})
-    third_expires, path, samesite, _ = _cookie_attrs(refresh_resp2)
-    assert path == COOKIE_PATH
-    assert samesite == COOKIE_SAMESITE
+    def rotate(tok):
+        calls["rotate"] = tok
+        return "newtoken"
 
-    assert second_expires > first_expires
-    assert third_expires > second_expires
-    assert f"max-age={MAX_AGE}" in refresh_resp2.headers["Set-Cookie"].lower()
+    monkeypatch.setattr(sessions, "validate_session_token", validate)
+    monkeypatch.setattr(sessions, "refresh_or_rotate_session_token", rotate)
+
+    resp = client.post("/auth/refresh", json={"refresh_token": "oldtoken"})
+    assert resp.status_code == 200
+
+    data = resp.get_json()
+    assert data["refresh_token"] == "newtoken"
+    assert "access_token" in data
+
+    cookie = SimpleCookie()
+    cookie.load(resp.headers["Set-Cookie"])
+    morsel = cookie["session_token"]
+    assert morsel.value == "newtoken"
+    assert morsel["path"] == "/"
+    assert morsel["samesite"] == "Strict"
+    header = morsel.OutputString()
+    assert "HttpOnly" in header and "Secure" in header
+
+    assert calls["validate"] == "oldtoken"
+    assert calls["rotate"] == "oldtoken"
+
+
+def test_refresh_missing_token(monkeypatch):
+    app, sessions = _create_app(monkeypatch)
+    client = app.test_client()
+
+    resp = client.post("/auth/refresh", json={})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add `/auth/refresh` Flask endpoint that validates, rotates and sets session tokens
- harden cookie utilities and expose in-memory `_SessionStore`
- clear stale cookies when session restoration fails
- cover refresh flow and cookie behaviour with tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bad251c2588321a2f327c684318400