### PR TITLE
Unify returning login area implementation

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -586,8 +586,6 @@ def render_returning_login_area() -> bool:
     return False
 
 
-# --- One-time branded Google button (kept exactly once on the page)
-
 # --- Small explanatory banner shown above the tabs
 def render_signup_request_banner():
     if not st.session_state.get("_signup_banner_css_done"):
@@ -651,43 +649,6 @@ def render_google_oauth(return_url: bool = True) -> Optional[str]:
     }
     auth_url = "https://accounts.google.com/o/oauth2/v2/auth?" + urllib.parse.urlencode(params)
     return auth_url
-
-# --- One-time branded Google button (shows ONCE under "Returning user login")
-# ------------------------------------------------------------------------------
-# Returning login (no extra Google button here anymore)
-# ------------------------------------------------------------------------------
-def render_returning_login_area() -> bool:
-    with st.form("returning_login_form", clear_on_submit=False):
-        login_id  = st.text_input("Email or Student Code")
-        login_pass= st.text_input("Password", type="password")
-        submitted = st.form_submit_button("Log in")
-
-    if submitted and render_login_form(login_id, login_pass):
-        return True
-
-    # Forgot password toggle below the form
-    col_a, col_b = st.columns([0.5, 0.5])
-    with col_a:
-        if st.button("Forgot password?"):
-            st.session_state["show_reset_panel"] = True
-    if st.session_state.get("show_reset_panel"):
-        render_forgot_password_panel()
-
-    return False
-
-def render_returning_login_form():
-    """Simplified returning-user login form used in tests."""
-    with st.form("returning_login_form", clear_on_submit=False):
-        login_id = st.text_input("Email or Student Code")
-        login_pass = st.text_input("Password", type="password")
-        submitted = st.form_submit_button("Log in")
-        forgot = st.form_submit_button("Forgot password?")
-    if submitted:
-        render_login_form(login_id, login_pass)
-    if forgot:
-        # In reality this would trigger sending a reset email.
-        send_reset_email("test@example.com", "reset-link")
-    return False
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_forgot_password_link.py
+++ b/tests/test_forgot_password_link.py
@@ -7,17 +7,17 @@ def load_returning_login_func():
     source = path.read_text()
     tree = ast.parse(source)
     for node in tree.body:
-        if isinstance(node, ast.FunctionDef) and node.name == "render_returning_login_form":
+        if isinstance(node, ast.FunctionDef) and node.name == "render_returning_login_area":
             return node
-    raise AssertionError("render_returning_login_form not found")
+    raise AssertionError("render_returning_login_area not found")
 
 
 def test_forgot_password_button_present():
     func = load_returning_login_func()
     found = False
     for node in ast.walk(func):
-        if isinstance(node, ast.Call):
-            if isinstance(node.func, ast.Attribute) and node.func.attr == "form_submit_button":
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in {"form_submit_button", "button"}:
                 for arg in node.args:
                     if isinstance(arg, ast.Constant) and "Forgot password" in str(arg.value):
                         found = True
@@ -25,12 +25,12 @@ def test_forgot_password_button_present():
     assert found, "Forgot password button missing"
 
 
-def test_send_reset_email_used():
+def test_calls_forgot_password_panel():
     func = load_returning_login_func()
     found = False
     for node in ast.walk(func):
-        if isinstance(node, ast.Call):
-            if isinstance(node.func, ast.Name) and node.func.id == "send_reset_email":
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id == "render_forgot_password_panel":
                 found = True
                 break
-    assert found, "send_reset_email not called in render_returning_login_form"
+    assert found, "render_forgot_password_panel not called in render_returning_login_area"


### PR DESCRIPTION
## Summary
- Remove duplicate returning login forms and stub
- Consolidate returning login area with forgot-password panel
- Align forgot password tests with unified implementation

## Testing
- `pytest tests/test_forgot_password_link.py tests/test_render_falowen_login.py -q`
- `pytest tests/test_forgot_password_link.py tests/test_render_falowen_login.py tests/test_logout_rerenders_google_button.py -q` *(fails: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68bad6a5048c832181dd09446c7b31da