### PR TITLE
Use timezone-aware timestamps for auth tokens

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,5 +1,5 @@
 # auth.py
-from datetime import datetime
+from datetime import datetime, timezone
 from flask import Blueprint, request, jsonify, make_response
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -40,10 +40,10 @@ def _set_cookie(resp, token: str):
 
 # --- Simple token stubs (replace with real JWT/DB logic) ---
 def _issue_access(user_id: str) -> str:
-    return f"access_{user_id}_{int(datetime.utcnow().timestamp())}"
+    return f"access_{user_id}_{int(datetime.now(timezone.utc).timestamp())}"
 
 def _issue_refresh(user_id: str) -> str:
-    return f"refresh_{user_id}_{int(datetime.utcnow().timestamp())}"
+    return f"refresh_{user_id}_{int(datetime.now(timezone.utc).timestamp())}"
 # ------------------------------------------------------------
 
 @auth_bp.post("/login")


### PR DESCRIPTION
## Summary
- import `timezone` in `auth` module
- issue tokens using `datetime.now(timezone.utc)` timestamps

## Testing
- `ruff check auth.py`
- `PYTHONPATH=. pytest tests/test_auth_login.py tests/test_auth_refresh.py`


------
https://chatgpt.com/codex/tasks/task_e_68bad897e49083218fff5a811f5220d0