### PR TITLE
Use timezone-aware datetime in board notifications

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -17,7 +17,7 @@ import urllib.parse
 import urllib.parse as _urllib
 from urllib.parse import urlsplit, parse_qs, urlparse
 from datetime import date, timedelta, timezone as _timezone, UTC
-from datetime import datetime
+from datetime import datetime, timezone
 from datetime import datetime as _dt
 from uuid import uuid4
 from pathlib import Path
@@ -775,10 +775,10 @@ def login_page():
     </div>
     """, unsafe_allow_html=True)
 
-    from datetime import datetime as _dt_now
+    from datetime import datetime as _dt_now, timezone
     st.markdown(f"""
     <div class="page-wrap" style="text-align:center;color:#64748b; margin-bottom:16px;">
-      © {_dt_now.utcnow().year} Learn Language Education Academy • Accra, Ghana<br>
+      © {_dt_now.now(timezone.utc).year} Learn Language Education Academy • Accra, Ghana<br>
       Need help? <a href="mailto:learngermanghana@gmail.com">Email</a> •
       <a href="https://api.whatsapp.com/send?phone=233205706589" target="_blank" rel="noopener">WhatsApp</a>
     </div>
@@ -4417,7 +4417,7 @@ if tab == "My Course":
                                                 _notify_slack(
                                                     f"✏️ *Announcement reply edited* — {class_name}\n"
                                                     f"*By:* {student_name} ({student_code})\n"
-                                                    f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC\n"
+                                                    f"*When:* {_dt.now(timezone.utc).strftime('%Y-%m-%d %H:%M')} UTC\n"
                                                     f"*Preview:* {new_txt[:180]}{'…' if len(new_txt)>180 else ''}"
                                                 )
                                                 st.success("Reply updated.")
@@ -4572,7 +4572,7 @@ if tab == "My Course":
                         "content": formatted_q,
                         "asked_by_name": student_name,
                         "asked_by_code": student_code,
-                        "timestamp": _dt.utcnow(),
+                        "timestamp": _dt.now(timezone.utc),
                         "topic": (topic or "").strip(),
                     }
                     board_base.document(q_id).set(payload)
@@ -4581,7 +4581,7 @@ if tab == "My Course":
                     _notify_slack(
                         f"📝 *New Class Board post* — {class_name}{topic_tag}\n",
                         f"*From:* {student_name} ({student_code})\n",
-                        f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC\n",
+                                                    f"*When:* {_dt.now(timezone.utc).strftime('%Y-%m-%d %H:%M')} UTC\n",
                         f"*Content:* {preview}"
                     )
                     st.session_state["__clear_q_form"] = True
@@ -4700,7 +4700,7 @@ if tab == "My Course":
                                 _notify_slack(
                                     f"🗑️ *Class Board post deleted* — {class_name}\n"
                                     f"*By:* {student_name} ({student_code}) • QID: {q_id}\n"
-                                    f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC"
+                                    f"*When:* {_dt.now(timezone.utc).strftime('%Y-%m-%d %H:%M')} UTC"
                                 )
                                 st.success("Post deleted.")
                                 st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
@@ -4730,7 +4730,7 @@ if tab == "My Course":
                                     _notify_slack(
                                         f"✏️ *Class Board post edited* — {class_name}\n",
                                         f"*By:* {student_name} ({student_code}) • QID: {q_id}\n",
-                                        f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC\n",
+                                        f"*When:* {_dt.now(timezone.utc).strftime('%Y-%m-%d %H:%M')} UTC\n",
                                         f"*New:* {(formatted_edit[:180] + '…') if len(formatted_edit) > 180 else formatted_edit}",
                                     )
                                     st.session_state[f"q_editing_{q_id}"] = False


### PR DESCRIPTION
## Summary
- import `timezone` and use `_dt.now(timezone.utc)` instead of `utcnow`
- ensure footer and Slack/board timestamps stay in UTC

## Testing
- `ruff check a1sprechen.py` *(fails: many existing lint errors)*
- `flake8 a1sprechen.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bad896c0988321a2bbe08a52030a37