### PR TITLE
Allow class board to render after QA

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4505,7 +4505,7 @@ if tab == "My Course":
                         save_teacher_answer(doc.id, ans)
                         st.success("Answer saved.")
                     st.divider()
-            st.stop()
+            # Allow fall-through so class board renders after Q&A
             board_base = db.collection("class_board").document(class_name).collection("posts")
 
 


### PR DESCRIPTION
## Summary
- Remove premature `st.stop()` in Q&A section so class board logic executes after rendering Q&A UI

## Testing
- `pytest`
- `ruff check a1sprechen.py` *(fails: 106 errors, existing style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bae3e163148321998a209d0efb461d