### PR TITLE
Add peer response section for unanswered questions

### DIFF
--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -230,3 +230,25 @@ def save_teacher_answer(post_id: str, teacher_text: str) -> None:
         ref.set(payload, merge=True)
     except Exception as exc:  # pragma: no cover - runtime depends on Firestore
         logging.warning("Failed to save teacher answer for %s: %s", post_id, exc)
+
+
+def save_response(post_id: str, student_code: str, response_text: str) -> None:
+    """Persist a peer response for a question."""
+
+    ref = _qa_doc_ref(post_id)
+    if ref is None:
+        return
+    payload = {
+        "responses": firestore.ArrayUnion([
+            {
+                "student_code": student_code,
+                "response": response_text,
+                "created_at": firestore.SERVER_TIMESTAMP,
+            }
+        ])
+    }
+    try:
+        ref.set(payload, merge=True)
+    except Exception as exc:  # pragma: no cover - runtime depends on Firestore
+        logging.warning("Failed to save response for %s: %s", post_id, exc)
+

--- a/tests/test_firestore_utils_failures.py
+++ b/tests/test_firestore_utils_failures.py
@@ -151,3 +151,22 @@ def test_save_teacher_answer_logs_warning_on_failure(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         firestore_utils.save_teacher_answer("id", "text")
     assert any("Failed to save teacher answer" in r.message for r in caplog.records)
+
+
+def test_save_response_logs_warning_on_failure(monkeypatch, caplog):
+    class DummyRef:
+        def set(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    class DummyDB:
+        def collection(self, *args, **kwargs):
+            return self
+
+        def document(self, *args, **kwargs):
+            return DummyRef()
+
+    monkeypatch.setattr(firestore_utils, "db", DummyDB())
+
+    with caplog.at_level(logging.WARNING):
+        firestore_utils.save_response("id", "code", "text")
+    assert any("Failed to save response" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- List unanswered or flagged classmate questions in the Q&A section
- Save peer responses with new `save_response` helper
- Cover Firestore save failures for responses in tests

## Testing
- `ruff check src/firestore_utils.py tests/test_firestore_utils_failures.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae4236e40832180d0c34f314ef00f