### PR TITLE
Add level-based admin mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,19 @@ The iOS app proactively refreshes its session cookie. Safari's Intelligent
 Tracking Prevention shortens cookie lifetimes to about a week when they aren't
 updated. A daily refresh ensures the cookie expiry is extended well before the
 platform can discard it.
+
+## Level-Based Admin Mapping
+
+Administrative access is determined by combining the `roles.admins` list from
+Streamlit secrets with the `ADMINS_BY_LEVEL` dictionary in `a1sprechen.py`. Each
+entry maps a CEFR level to a set of teacher codes:
+
+```python
+ADMINS_BY_LEVEL = {
+    "A1": {"felixa177"},
+    "A2": {"felixa2"},
+    # Extend with additional levels or codes as needed
+}
+```
+
+Update this mapping whenever new levels or teachers require admin access.

--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -160,6 +160,13 @@ GOOGLE_CLIENT_ID     = st.secrets.get("GOOGLE_CLIENT_ID", "180240695202-3v682khd
 GOOGLE_CLIENT_SECRET = st.secrets.get("GOOGLE_CLIENT_SECRET", "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")
 REDIRECT_URI         = st.secrets.get("GOOGLE_REDIRECT_URI", "https://www.falowen.app/")
 
+# Mapping of CEFR levels to teacher codes that should receive admin rights.
+# Extend this dictionary as new levels or teachers are added.
+ADMINS_BY_LEVEL = {
+    "A1": {"felixa177"},
+    "A2": {"felixa2"},
+}
+
 def _get_qp():
     try:
         return qp_get()
@@ -3357,7 +3364,8 @@ if tab == "My Course":
             ADMINS = set(st.secrets["roles"]["admins"])
         except Exception:
             pass
-        IS_ADMIN = (student_code in ADMINS)
+        ADMINS |= ADMINS_BY_LEVEL.get(student_level, set())
+        IS_ADMIN = student_code in ADMINS
 
         # ---------- slack helper (use global notify_slack if present; else env/secrets) ----------
         def _notify_slack(*parts: str):


### PR DESCRIPTION
## Summary
- add `ADMINS_BY_LEVEL` to map CEFR levels to teacher admin codes
- merge level-based admins with configured `roles.admins` secret
- document level-based admin mapping in README for easy extension

## Testing
- `ruff check a1sprechen.py README.md` *(fails: E402, E701, E702 etc. pre-existing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae6d7af148321b89e09278d434a15