### PR TITLE
Allow authenticated Q&A responses

### DIFF
--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -216,24 +216,12 @@ def save_ai_answer(post_id: str, ai_text: str, flagged: bool = False) -> None:
         logging.warning("Failed to save AI answer for %s: %s", post_id, exc)
 
 
-def save_teacher_answer(post_id: str, teacher_text: str) -> None:
-    """Persist the teacher's response for a question."""
+def save_response(post_id: str, text: str, responder_code: str) -> None:
+    """Persist a response for a question.
 
-    ref = _qa_doc_ref(post_id)
-    if ref is None:
-        return
-    payload = {
-        "teacher_answer": teacher_text,
-        "teacher_created_at": firestore.SERVER_TIMESTAMP,
-    }
-    try:
-        ref.set(payload, merge=True)
-    except Exception as exc:  # pragma: no cover - runtime depends on Firestore
-        logging.warning("Failed to save teacher answer for %s: %s", post_id, exc)
-
-
-def save_response(post_id: str, student_code: str, response_text: str) -> None:
-    """Persist a peer response for a question."""
+    The response is appended to the ``responses`` array on the post and
+    includes the ``responder_code`` and server timestamp.
+    """
 
     ref = _qa_doc_ref(post_id)
     if ref is None:
@@ -241,8 +229,8 @@ def save_response(post_id: str, student_code: str, response_text: str) -> None:
     payload = {
         "responses": firestore.ArrayUnion([
             {
-                "student_code": student_code,
-                "response": response_text,
+                "responder_code": responder_code,
+                "text": text,
                 "created_at": firestore.SERVER_TIMESTAMP,
             }
         ])

--- a/tests/test_firestore_utils.py
+++ b/tests/test_firestore_utils.py
@@ -1,5 +1,9 @@
 from src import firestore_utils
-from src.firestore_utils import _extract_level_and_lesson, save_question
+from src.firestore_utils import (
+    _extract_level_and_lesson,
+    save_question,
+    save_response,
+)
 
 
 def test_extract_level_and_lesson_with_prefix():
@@ -17,3 +21,30 @@ def test_extract_level_and_lesson_without_prefix():
 def test_save_question_returns_none_without_db(monkeypatch):
     monkeypatch.setattr(firestore_utils, "db", None, raising=False)
     assert save_question("code", "hi") is None
+
+
+def test_save_response_stores_responder_code(monkeypatch):
+    class DummyRef:
+        def __init__(self):
+            self.payload = None
+
+        def set(self, payload, merge=True):
+            self.payload = payload
+
+    class DummyDB:
+        def __init__(self):
+            self.ref = DummyRef()
+
+        def collection(self, *args, **kwargs):
+            return self
+
+        def document(self, *args, **kwargs):
+            return self.ref
+
+    dummy_db = DummyDB()
+    monkeypatch.setattr(firestore_utils, "db", dummy_db)
+    monkeypatch.setattr(firestore_utils.firestore, "ArrayUnion", lambda x: x)
+    save_response("id", "hello", "XYZ")
+    resp = dummy_db.ref.payload["responses"][0]
+    assert resp["responder_code"] == "XYZ"
+    assert resp["text"] == "hello"

--- a/tests/test_firestore_utils_failures.py
+++ b/tests/test_firestore_utils_failures.py
@@ -134,25 +134,6 @@ def test_save_ai_answer_logs_warning_on_failure(monkeypatch, caplog):
     assert any("Failed to save AI answer" in r.message for r in caplog.records)
 
 
-def test_save_teacher_answer_logs_warning_on_failure(monkeypatch, caplog):
-    class DummyRef:
-        def set(self, *args, **kwargs):
-            raise RuntimeError("boom")
-
-    class DummyDB:
-        def collection(self, *args, **kwargs):
-            return self
-
-        def document(self, *args, **kwargs):
-            return DummyRef()
-
-    monkeypatch.setattr(firestore_utils, "db", DummyDB())
-
-    with caplog.at_level(logging.WARNING):
-        firestore_utils.save_teacher_answer("id", "text")
-    assert any("Failed to save teacher answer" in r.message for r in caplog.records)
-
-
 def test_save_response_logs_warning_on_failure(monkeypatch, caplog):
     class DummyRef:
         def set(self, *args, **kwargs):
@@ -168,5 +149,5 @@ def test_save_response_logs_warning_on_failure(monkeypatch, caplog):
     monkeypatch.setattr(firestore_utils, "db", DummyDB())
 
     with caplog.at_level(logging.WARNING):
-        firestore_utils.save_response("id", "code", "text")
+        firestore_utils.save_response("id", "text", "code")
     assert any("Failed to save response" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- generalize Firestore Q&A helper to store response text with responder code and timestamp
- list open questions for all students with option to hide your own posts
- allow any logged-in user to respond to questions

## Testing
- `python -m pytest -q`
- `ruff check .` *(fails: Multiple style errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68bae7c73b0c8321b460427a90403ad2