### PR TITLE
Streamline notes and Q&A posting

### DIFF
--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -178,28 +178,29 @@ def _qa_doc_ref(post_id: str):
     return db.collection("qa_posts").document(post_id)
 
 
-def save_question(code: str, question: str) -> Optional[str]:
-    """Persist a new question and return the document ID."""
+def save_post(code: str, text: str, is_question: bool) -> Optional[str]:
+    """Persist a new note or question and return the document ID."""
 
     if db is None:
         return None
     ref = db.collection("qa_posts").document()
     payload = {
-        "question": question or "",
+        "text": text or "",
         "student_code": code,
         "created_at": firestore.SERVER_TIMESTAMP,
         "flagged": False,
+        "is_question": is_question,
     }
     try:
         ref.set(payload)
         return ref.id
     except Exception as exc:  # pragma: no cover - runtime depends on Firestore
-        logging.warning("Failed to save question for %s: %s", code, exc)
+        logging.warning("Failed to save post for %s: %s", code, exc)
         return None
 
 
 def save_ai_answer(post_id: str, ai_text: str, flagged: bool = False) -> None:
-    """Attach an AI-generated suggestion to the question."""
+    """Attach an AI-generated suggestion to the post."""
 
     ref = _qa_doc_ref(post_id)
     if ref is None:
@@ -217,7 +218,7 @@ def save_ai_answer(post_id: str, ai_text: str, flagged: bool = False) -> None:
 
 
 def save_response(post_id: str, text: str, responder_code: str) -> None:
-    """Persist a response for a question.
+    """Persist a response for a post.
 
     The response is appended to the ``responses`` array on the post and
     includes the ``responder_code`` and server timestamp.

--- a/tests/test_firestore_utils.py
+++ b/tests/test_firestore_utils.py
@@ -1,7 +1,7 @@
 from src import firestore_utils
 from src.firestore_utils import (
     _extract_level_and_lesson,
-    save_question,
+    save_post,
     save_response,
 )
 
@@ -18,9 +18,41 @@ def test_extract_level_and_lesson_without_prefix():
     assert lesson == "C1_day2_ch1"
 
 
-def test_save_question_returns_none_without_db(monkeypatch):
+def test_save_post_returns_none_without_db(monkeypatch):
     monkeypatch.setattr(firestore_utils, "db", None, raising=False)
-    assert save_question("code", "hi") is None
+    assert save_post("code", "hi", True) is None
+
+
+def test_save_post_stores_is_question(monkeypatch):
+    class DummyRef:
+        def __init__(self):
+            self.payload = None
+            self.id = "dummy"
+
+        def set(self, payload):
+            self.payload = payload
+
+    class DummyCollection:
+        def __init__(self):
+            self.ref = DummyRef()
+
+        def document(self):
+            return self.ref
+
+    class DummyDB:
+        def __init__(self):
+            self.coll = DummyCollection()
+
+        def collection(self, *args, **kwargs):
+            return self.coll
+
+    dummy_db = DummyDB()
+    monkeypatch.setattr(firestore_utils, "db", dummy_db)
+    monkeypatch.setattr(firestore_utils.firestore, "SERVER_TIMESTAMP", 0, raising=False)
+    post_id = save_post("code", "hello?", True)
+    assert post_id == "dummy"
+    assert dummy_db.coll.ref.payload["is_question"] is True
+    assert dummy_db.coll.ref.payload["text"] == "hello?"
 
 
 def test_save_response_stores_responder_code(monkeypatch):

--- a/tests/test_firestore_utils_failures.py
+++ b/tests/test_firestore_utils_failures.py
@@ -95,7 +95,7 @@ def test_load_draft_meta_from_db_logs_error_on_failure(monkeypatch, caplog):
     assert all("code/draft_X" in msg for msg in messages)
 
 
-def test_save_question_logs_warning_on_failure(monkeypatch, caplog):
+def test_save_post_logs_warning_on_failure(monkeypatch, caplog):
     class DummyRef:
         def set(self, *args, **kwargs):
             raise RuntimeError("boom")
@@ -111,8 +111,8 @@ def test_save_question_logs_warning_on_failure(monkeypatch, caplog):
     monkeypatch.setattr(firestore_utils, "db", DummyDB())
 
     with caplog.at_level(logging.WARNING):
-        firestore_utils.save_question("code", "hi")
-    assert any("Failed to save question" in r.message for r in caplog.records)
+        firestore_utils.save_post("code", "hi", True)
+    assert any("Failed to save post" in r.message for r in caplog.records)
 
 
 def test_save_ai_answer_logs_warning_on_failure(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- Replace question prompt with unified "Share notes or ask a question" box and display posts immediately
- Add `save_post` utility with `is_question` flag, replacing `save_question`
- Update tests for new Firestore logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baed334038832198b0de3a496960e8