### PR TITLE
Add AI-assisted reply correction

### DIFF
--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -217,6 +217,24 @@ def save_ai_answer(post_id: str, ai_text: str, flagged: bool = False) -> None:
         logging.warning("Failed to save AI answer for %s: %s", post_id, exc)
 
 
+def save_ai_response(post_id: str, ai_text: str, flagged: bool = False) -> None:
+    """Attach an AI-generated reply suggestion to the post."""
+
+    ref = _qa_doc_ref(post_id)
+    if ref is None:
+        return
+    payload = {
+        "ai_response_suggestion": ai_text,
+        "ai_response_created_at": firestore.SERVER_TIMESTAMP,
+    }
+    if flagged:
+        payload["flagged"] = True
+    try:
+        ref.set(payload, merge=True)
+    except Exception as exc:  # pragma: no cover - runtime depends on Firestore
+        logging.warning("Failed to save AI response for %s: %s", post_id, exc)
+
+
 def save_response(post_id: str, text: str, responder_code: str) -> None:
     """Persist a response for a post.
 

--- a/tests/test_firestore_utils_failures.py
+++ b/tests/test_firestore_utils_failures.py
@@ -134,6 +134,25 @@ def test_save_ai_answer_logs_warning_on_failure(monkeypatch, caplog):
     assert any("Failed to save AI answer" in r.message for r in caplog.records)
 
 
+def test_save_ai_response_logs_warning_on_failure(monkeypatch, caplog):
+    class DummyRef:
+        def set(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    class DummyDB:
+        def collection(self, *args, **kwargs):
+            return self
+
+        def document(self, *args, **kwargs):
+            return DummyRef()
+
+    monkeypatch.setattr(firestore_utils, "db", DummyDB())
+
+    with caplog.at_level(logging.WARNING):
+        firestore_utils.save_ai_response("id", "text")
+    assert any("Failed to save AI response" in r.message for r in caplog.records)
+
+
 def test_save_response_logs_warning_on_failure(monkeypatch, caplog):
     class DummyRef:
         def set(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- add "Correct with AI" button to comment replies that uses OpenAI to proofread and prefill drafts
- introduce `save_ai_response` helper for persisting AI reply suggestions
- cover new helper and failure cases with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baeecc86ec832196935cb3075ddcbd