### PR TITLE
refactor: remove deprecated class notes q&a feed

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -84,7 +84,6 @@ from src.firestore_utils import (
     load_draft_meta_from_db,
     save_chat_draft_to_db,
     save_draft_to_db,
-    save_post,
     save_ai_response,
 )
 from src.ui_components import (
@@ -4455,55 +4454,8 @@ if tab == "My Course":
                     render_announcement(row, is_pinned=False)
 
 
-        # ===================== Class Notes & Q&A =====================
+        # ===================== Class Board =====================
         elif classroom_section == "Class Notes & Q&A":
-            st.subheader("Class Notes & Q&A")
-            post_text = st.text_area("Share notes or ask a question", key="qa_post")
-            if st.button("Submit", key="qa_submit") and post_text.strip():
-                is_question = post_text.strip().endswith("?")
-                post_id = save_post(student_code, post_text, is_question)
-                if post_id:
-                    st.session_state["_qa_feed"] = [
-                        {
-                            "student_code": student_code,
-                            "text": post_text,
-                            "ai_suggestion": "",
-                            "responses": [],
-                            "is_question": is_question,
-                        }
-                    ] + st.session_state.get("_qa_feed", [])
-                    st.session_state["qa_post"] = ""
-            if "_qa_feed" not in st.session_state:
-                try:
-                    if db is None:
-                        raw_docs = []
-                    else:
-                        try:
-                            from firebase_admin import firestore as fbfs
-                            direction_desc = getattr(fbfs.Query, "DESCENDING", "DESCENDING")
-                            raw_docs = list(
-                                db.collection("qa_posts")
-                                .order_by("created_at", direction=direction_desc)
-                                .stream()
-                            )
-                        except Exception:
-                            raw_docs = list(
-                                db.collection("qa_posts")
-                                .order_by("created_at", direction="DESCENDING")
-                                .stream()
-                            )
-                except Exception:
-                    raw_docs = []
-                st.session_state["_qa_feed"] = [doc.to_dict() or {} for doc in raw_docs]
-            for data in st.session_state.get("_qa_feed", []):
-                _txt = data.get("text") or data.get("question", "")
-                st.markdown(f"**{data.get('student_code', '')}**: {_txt}")
-                ai_txt = data.get("ai_suggestion")
-                if ai_txt:
-                    st.markdown(f"*AI suggestion:* {ai_txt}")
-                for r in data.get("responses") or []:
-                    st.success(f"{r.get('responder_code', '')}: {r.get('text', '')}")
-                st.divider()
             board_base = db.collection("class_board").document(class_name).collection("posts")
 
 
@@ -4590,7 +4542,7 @@ if tab == "My Course":
                     margin-bottom:12px;
                     box-shadow:0 2px 6px rgba(0,0,0,0.08);
                     display:flex;align-items:center;justify-content:space-between;">
-                    <div style="font-weight:700;font-size:1.15rem;">💬 Class Notes & Q&A {_badge_html}</div>
+                    <div style="font-weight:700;font-size:1.15rem;">💬 Class Board {_badge_html}</div>
                     <div style="font-size:0.92rem;opacity:.9;">Share a post • Comment with classmates</div>
                 </div>
                 ''',

--- a/tests/test_firestore_utils.py
+++ b/tests/test_firestore_utils.py
@@ -1,7 +1,6 @@
 from src import firestore_utils
 from src.firestore_utils import (
     _extract_level_and_lesson,
-    save_post,
     save_response,
     save_ai_response,
 )
@@ -17,45 +16,6 @@ def test_extract_level_and_lesson_without_prefix():
     level, lesson = _extract_level_and_lesson("C1_day2_ch1")
     assert level == "C1"
     assert lesson == "C1_day2_ch1"
-
-
-def test_save_post_returns_none_without_db(monkeypatch):
-    monkeypatch.setattr(firestore_utils, "db", None, raising=False)
-    assert save_post("code", "hi", True) is None
-
-
-def test_save_post_stores_is_question(monkeypatch):
-    class DummyRef:
-        def __init__(self):
-            self.payload = None
-            self.id = "dummy"
-
-        def set(self, payload):
-            self.payload = payload
-
-    class DummyCollection:
-        def __init__(self):
-            self.ref = DummyRef()
-
-        def document(self):
-            return self.ref
-
-    class DummyDB:
-        def __init__(self):
-            self.coll = DummyCollection()
-
-        def collection(self, *args, **kwargs):
-            return self.coll
-
-    dummy_db = DummyDB()
-    monkeypatch.setattr(firestore_utils, "db", dummy_db)
-    monkeypatch.setattr(firestore_utils.firestore, "SERVER_TIMESTAMP", 0, raising=False)
-    post_id = save_post("code", "hello?", True)
-    assert post_id == "dummy"
-    assert dummy_db.coll.ref.payload["is_question"] is True
-    assert dummy_db.coll.ref.payload["text"] == "hello?"
-
-
 def test_save_response_stores_responder_code(monkeypatch):
     class DummyRef:
         def __init__(self):

--- a/tests/test_firestore_utils_failures.py
+++ b/tests/test_firestore_utils_failures.py
@@ -95,26 +95,6 @@ def test_load_draft_meta_from_db_logs_error_on_failure(monkeypatch, caplog):
     assert all("code/draft_X" in msg for msg in messages)
 
 
-def test_save_post_logs_warning_on_failure(monkeypatch, caplog):
-    class DummyRef:
-        def set(self, *args, **kwargs):
-            raise RuntimeError("boom")
-
-    class DummyCollection:
-        def document(self, *args, **kwargs):
-            return DummyRef()
-
-    class DummyDB:
-        def collection(self, *args, **kwargs):
-            return DummyCollection()
-
-    monkeypatch.setattr(firestore_utils, "db", DummyDB())
-
-    with caplog.at_level(logging.WARNING):
-        firestore_utils.save_post("code", "hi", True)
-    assert any("Failed to save post" in r.message for r in caplog.records)
-
-
 def test_save_ai_answer_logs_warning_on_failure(monkeypatch, caplog):
     class DummyRef:
         def set(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- drop Class Notes & Q&A feed and related state handling
- remove unused Firestore helper `save_post`
- prune tests that covered the deleted feature

## Testing
- `pytest -q`
- `ruff check a1sprechen.py src/firestore_utils.py tests/test_firestore_utils.py tests/test_firestore_utils_failures.py` *(fails: Module level import not at top of file, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68baf550769c8321bc7742e063c84682