### PR TITLE
Add instructional note under new post subheader

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4563,6 +4563,9 @@ if tab == "My Course":
                 return "\n\n".join(paragraphs)
 
             st.subheader("➕ Add a new post")
+            st.info(
+                "Contribute to the forum. Scroll down to reply to a question or ask your own."
+            )
             if st.session_state.get("__clear_q_form"):
                 st.session_state.pop("__clear_q_form", None)
                 st.session_state["q_topic"] = ""


### PR DESCRIPTION
## Summary
- Display an informational message below the "➕ Add a new post" subheader guiding users on how to participate in the forum.

## Testing
- `ruff check a1sprechen.py` *(fails: 107 errors, pre-existing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bafb194e088321861afb23646bb0fb