### PR TITLE
Implement JWT-backed auth tokens with refresh rotation

### DIFF
--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -1,0 +1,62 @@
+from importlib import reload
+import sys
+from pathlib import Path
+
+import jwt
+from flask import Flask
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import auth
+
+
+def create_app():
+    reload(auth)
+    app = Flask(__name__)
+    app.register_blueprint(auth.auth_bp)
+    return app
+
+
+def test_login_issues_tokens():
+    app = create_app()
+    client = app.test_client()
+
+    # invalid credentials rejected
+    bad = client.post("/auth/login", json={"user_id": "u", "password": "bad"})
+    assert bad.status_code == 401
+
+    resp = client.post("/auth/login", json={"user_id": "u", "password": "pw"})
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert "access_token" in data and "refresh_token" in data
+
+    decoded = jwt.decode(data["access_token"], auth.JWT_SECRET, algorithms=[auth.JWT_ALG])
+    assert decoded["sub"] == "u"
+
+
+def test_refresh_rotates_and_rejects_old():
+    app = create_app()
+    client = app.test_client()
+
+    login = client.post("/auth/login", json={"user_id": "u", "password": "pw"}).get_json()
+    old_refresh = login["refresh_token"]
+
+    r1 = client.post("/auth/refresh", json={"refresh_token": old_refresh}).get_json()
+    new_refresh = r1["refresh_token"]
+    assert new_refresh != old_refresh
+
+    r2 = client.post("/auth/refresh", json={"refresh_token": old_refresh})
+    assert r2.status_code == 401
+
+
+def test_logout_revokes_refresh_token():
+    app = create_app()
+    client = app.test_client()
+
+    login_resp = client.post("/auth/login", json={"user_id": "u", "password": "pw"})
+    cookie = login_resp.headers["Set-Cookie"]
+
+    logout_resp = client.post("/auth/logout", headers={"Cookie": cookie})
+    assert logout_resp.status_code == 204
+
+    refresh_resp = client.get("/auth/refresh", headers={"Cookie": cookie})
+    assert refresh_resp.status_code == 401

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -3,13 +3,18 @@ from email.utils import parsedate_to_datetime
 import time
 
 from flask import Flask
+from importlib import reload
+import sys
+from pathlib import Path
 
-from auth import auth_bp, MAX_AGE
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import auth
 
 
 def create_app():
+    reload(auth)
     app = Flask(__name__)
-    app.register_blueprint(auth_bp)
+    app.register_blueprint(auth.auth_bp)
     return app
 
 
@@ -23,7 +28,7 @@ def test_refresh_extends_cookie_expiry():
     app = create_app()
     client = app.test_client()
 
-    login_resp = client.post("/auth/login", json={"user_id": "u"})
+    login_resp = client.post("/auth/login", json={"user_id": "u", "password": "pw"})
     first_expires, cookie_header = _cookie_expires(login_resp)
 
     time.sleep(1)
@@ -36,4 +41,4 @@ def test_refresh_extends_cookie_expiry():
 
     assert second_expires > first_expires
     assert third_expires > second_expires
-    assert f"max-age={MAX_AGE}" in refresh_resp2.headers["Set-Cookie"].lower()
+    assert f"max-age={auth.MAX_AGE}" in refresh_resp2.headers["Set-Cookie"].lower()


### PR DESCRIPTION
## Summary
- Replace auth token stubs with JWT-based access and refresh tokens backed by an in-memory user store
- Validate login credentials and rotate refresh tokens while revoking invalid ones
- Add tests for login, refresh rotation, and logout token revocation

## Testing
- `ruff check auth.py tests/test_auth_flow.py tests/test_auth_refresh.py`
- `pytest tests/test_auth_flow.py tests/test_auth_refresh.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb418da1488321b27c6e4ef2d98048