### PR TITLE
Use Unicode font for PDFs

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -7228,12 +7228,13 @@ if tab == "Schreiben Trainer":
                 import os
 
                 def sanitize_text(text):
-                    return text.encode('latin-1', errors='replace').decode('latin-1')
+                    return text
 
                 # PDF
                 pdf = FPDF()
+                pdf.add_font("DejaVu", "", "font/DejaVuSans.ttf", uni=True)
                 pdf.add_page()
-                pdf.set_font("Arial", size=12)
+                pdf.set_font("DejaVu", size=12)
                 improved_letter = st.session_state.get(f"{student_code}_final_improved_letter", "")
                 improved_feedback = st.session_state[f"{student_code}_delta_compare_feedback"]
                 pdf.multi_cell(0, 10, f"Your Improved Letter:\n\n{sanitize_text(improved_letter)}\n\nFeedback from Herr Felix:\n\n{sanitize_text(improved_feedback)}")

--- a/src/pdf_handling.py
+++ b/src/pdf_handling.py
@@ -115,15 +115,13 @@ def generate_chat_pdf(messages: List[Dict[str, Any]]) -> bytes:
     if FPDF is None:  # pragma: no cover - dependency missing
         return b""
 
-    def safe_latin1(text: str) -> str:
-        return text.encode("latin1", "replace").decode("latin1")
-
     pdf = FPDF()
+    pdf.add_font("DejaVu", "", "./font/DejaVuSans.ttf", uni=True)
     pdf.add_page()
-    pdf.set_font("Arial", size=12)
+    pdf.set_font("DejaVu", size=12)
     for m in messages:
         who = "Herr Felix" if m.get("role") == "assistant" else "Student"
-        pdf.multi_cell(0, 8, safe_latin1(f"{who}: {m.get('content','')}"))
+        pdf.multi_cell(0, 8, f"{who}: {m.get('content','')}")
         pdf.ln(1)
     return pdf.output(dest="S").encode("latin1", "replace")
 


### PR DESCRIPTION
## Summary
- embed DejaVu Sans as a Unicode font when generating PDFs
- stop stripping non-Latin-1 characters in PDF content
- ensure chat PDF generation uses the same Unicode font

## Testing
- `ruff check a1sprechen.py src/pdf_handling.py` *(fails: E402, E712, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb471b0a8483219ce348674277ea43