### PR TITLE
Add dividers between class board posts

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4578,7 +4578,7 @@ if tab == "My Course":
             if not questions:
                 st.info("No posts yet.")
             else:
-                for q in questions:
+                for idx, q in enumerate(questions):
                     q_id = q.get("id", "")
                     ts = q.get("timestamp")
                     ts_label = _fmt_ts(ts)
@@ -4797,6 +4797,9 @@ if tab == "My Course":
                             on_click=apply_ai_correction,
                             args=(q_id, draft_key, current_text),
                         )
+
+                    if idx < len(questions) - 1:
+                        st.divider()
 
 
     # === LEARNING NOTES SUBTAB ===


### PR DESCRIPTION
## Summary
- Separate classroom board posts with a Streamlit divider, skipping after the final post

## Testing
- `ruff check a1sprechen.py` *(fails: Found 105 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbfedf29408321b59cb609824453ff