### PR TITLE
Remove announcements page and link dashboard to class board

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This value is required for secure cookie management.
 
 ## Usage
 
-- From the Dashboard, use **View all class announcements** to jump to the full classroom announcements feed.
+- From the Dashboard, use **View class board** to jump to the class notes & Q&A section.
 
 ### Vocab Sheet Format
 


### PR DESCRIPTION
## Summary
- Remove Announcements from classroom navigation and delete its page and CSV helpers.
- Replace dashboard announcement shortcut with `View class board` button that jumps to “Class Notes & Q&A”.
- Update README and sidebar tips to reference the class board.

## Testing
- `ruff check a1sprechen.py README.md` *(fails: existing lint errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc02396e68832195a56706d433e9c6