### PR TITLE
Add attendance tracking section

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -87,6 +87,7 @@ from src.firestore_utils import (
     save_ai_response,
     fetch_attendance_summary,
 )
+from src.attendance_utils import load_attendance_records
 from src.ui_components import (
     render_assignment_reminder,
     render_link,
@@ -3323,7 +3324,7 @@ if tab == "My Course":
 
         classroom_section = st.radio(
             "Classroom section",
-            ["Calendar", "Join on Zoom", "Members", "Class Notes & Q&A"],
+            ["Calendar", "Join on Zoom", "Members", "Class Notes & Q&A", "Attendance"],
             horizontal=True,
             key="classroom_page",
             on_change=on_classroom_page_change,
@@ -3868,7 +3869,7 @@ if tab == "My Course":
 
                 st.markdown(
                     f"""
-                    **Computer or iPhone:** Download the **.ics** above and install.  
+                    **Computer or iPhone:** Download the **.ics** above and install.
                     - **Computer (Google Calendar web):** calendar.google.com → **Settings** → **Import & export** → **Import**.
                     - **iPhone (Apple Calendar):** Download the `.ics`, open it, choose notifications, then **Done**.
 
@@ -3878,6 +3879,41 @@ if tab == "My Course":
                     """,
                     unsafe_allow_html=True,
                 )
+
+        # ===================== ATTENDANCE =====================
+        elif classroom_section == "Attendance":
+            with st.container():
+                st.markdown(
+                    """
+                    <div style="
+                        padding:10px 12px;
+                        background:#f0f9ff;
+                        border:1px solid #bae6fd;
+                        border-radius:12px;
+                        margin: 6px 0 8px 0;
+                        display:flex;align-items:center;gap:8px;">
+                      <span style="font-size:1.05rem;">📊 <b>Attendance</b></span>
+                    </div>
+                    """,
+                    unsafe_allow_html=True,
+                )
+                records, sessions_attended, hours_invested = load_attendance_records(
+                    student_code, class_name
+                )
+                cols = st.columns(2)
+                cols[0].metric("Attended sessions", sessions_attended)
+                cols[1].metric("Invested hours", f"{hours_invested:.1f}")
+                if records:
+                    df_att = pd.DataFrame(records)
+                    df_att["Present"] = df_att.pop("present").map({True: "✓", False: ""})
+                    df_att.rename(columns={"session": "Session"}, inplace=True)
+                    st.dataframe(
+                        df_att,
+                        use_container_width=True,
+                        hide_index=True,
+                    )
+                else:
+                    st.info("No attendance records found yet.")
 
         # ===================== MEMBERS =====================
         elif classroom_section == "Members":

--- a/src/attendance_utils.py
+++ b/src/attendance_utils.py
@@ -1,0 +1,65 @@
+"""Utilities for retrieving classroom attendance data.
+
+This module isolates the Firestore queries needed to determine a student's
+attendance history for a class.  Keeping the logic here makes it easier to
+unit-test without touching the Streamlit UI or the large ``a1sprechen``
+module.
+"""
+
+from __future__ import annotations
+
+from typing import List, Dict, Tuple
+import logging
+
+try:  # Firestore client is optional in test environments
+    from falowen.sessions import db  # pragma: no cover - runtime side effect
+except Exception:  # pragma: no cover - Firestore may be unavailable
+    db = None  # type: ignore
+
+
+def load_attendance_records(
+    student_code: str, class_name: str
+) -> Tuple[List[Dict[str, object]], int, float]:
+    """Return a tuple ``(records, sessions, hours)`` for ``student_code``.
+
+    Each record in ``records`` is a mapping with ``{"session": <id>,
+    "present": <bool>}``.  ``sessions`` is the number of sessions attended and
+    ``hours`` is the invested time assuming **1 hour per attended session**.
+
+    If Firestore is unavailable or an error occurs the function returns
+    ``([], 0, 0.0)``.
+    """
+
+    if db is None:
+        return [], 0, 0.0
+
+    try:
+        sessions_ref = (
+            db.collection("attendance")
+            .document(class_name)
+            .collection("sessions")
+        )
+        records: List[Dict[str, object]] = []
+        count = 0
+        for snap in sessions_ref.stream():
+            data = snap.to_dict() or {}
+            attendees = data.get("attendees", {}) or {}
+            present = False
+            if isinstance(attendees, dict):
+                present = student_code in attendees
+            elif isinstance(attendees, list):
+                present = any(
+                    isinstance(item, dict) and item.get("code") == student_code
+                    for item in attendees
+                )
+            records.append({"session": getattr(snap, "id", ""), "present": present})
+            if present:
+                count += 1
+        hours = float(count)
+        return records, count, hours
+    except Exception as exc:  # pragma: no cover - runtime depends on Firestore
+        logging.exception(
+            "Failed to load attendance for %s/%s: %s", class_name, student_code, exc
+        )
+        return [], 0, 0.0
+

--- a/tests/test_attendance_utils.py
+++ b/tests/test_attendance_utils.py
@@ -1,0 +1,54 @@
+from src import attendance_utils
+
+
+def test_load_attendance_records_counts_sessions(monkeypatch):
+    class DummySnap:
+        def __init__(self, doc_id, attendees):
+            self.id = doc_id
+            self._attendees = attendees
+
+        def to_dict(self):
+            return {"attendees": self._attendees}
+
+    class DummySessions:
+        def stream(self):
+            return [
+                DummySnap("s1", {"abc": 1}),
+                DummySnap("s2", {"xyz": 1}),
+                DummySnap("s3", [{"code": "abc"}]),
+            ]
+
+    class DummyClass:
+        def collection(self, name):
+            assert name == "sessions"
+            return DummySessions()
+
+    class DummyAttendance:
+        def document(self, name):
+            assert name == "C1"
+            return DummyClass()
+
+    class DummyDB:
+        def collection(self, name):
+            assert name == "attendance"
+            return DummyAttendance()
+
+    monkeypatch.setattr(attendance_utils, "db", DummyDB())
+    records, count, hours = attendance_utils.load_attendance_records("abc", "C1")
+    assert count == 2
+    assert hours == 2.0
+    assert records[0]["session"] == "s1" and records[0]["present"] is True
+    assert records[1]["session"] == "s2" and records[1]["present"] is False
+
+
+def test_load_attendance_records_handles_error(monkeypatch):
+    class DummyDB:
+        def collection(self, name):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(attendance_utils, "db", DummyDB())
+    records, count, hours = attendance_utils.load_attendance_records("abc", "C1")
+    assert records == []
+    assert count == 0
+    assert hours == 0.0
+


### PR DESCRIPTION
## Summary
- append new "Attendance" tab to classroom navigation
- show per-session attendance stats with invested hours
- factor Firestore attendance fetch into `load_attendance_records` with tests

## Testing
- `ruff check src/attendance_utils.py tests/test_attendance_utils.py`
- `ruff check a1sprechen.py` *(fails: Found 92 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc21aec4088321855355ee6307e617