### PR TITLE
Handle root-level attendance records

### DIFF
--- a/src/attendance_utils.py
+++ b/src/attendance_utils.py
@@ -43,7 +43,14 @@ def load_attendance_records(
         count = 0
         for snap in sessions_ref.stream():
             data = snap.to_dict() or {}
-            attendees = data.get("attendees", {}) or {}
+            if "attendees" in data:
+                attendees = data.get("attendees") or {}
+            else:
+                attendees = {
+                    k: v
+                    for k, v in data.items()
+                    if isinstance(k, str) and len(k) == 3 and k.isalpha()
+                }
             present = False
             if isinstance(attendees, dict):
                 present = student_code in attendees

--- a/tests/test_attendance_utils.py
+++ b/tests/test_attendance_utils.py
@@ -41,6 +41,49 @@ def test_load_attendance_records_counts_sessions(monkeypatch):
     assert records[1]["session"] == "s2" and records[1]["present"] is False
 
 
+def test_load_attendance_records_root_attendees(monkeypatch):
+    class DummySnap:
+        def __init__(self, doc_id, data):
+            self.id = doc_id
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    class DummySessions:
+        def stream(self):
+            return [
+                DummySnap("s1", {"abc": 1, "xyz": 1, "date": "2024-01-01"})
+            ]
+
+    class DummyClass:
+        def collection(self, name):
+            assert name == "sessions"
+            return DummySessions()
+
+    class DummyAttendance:
+        def document(self, name):
+            assert name == "C1"
+            return DummyClass()
+
+    class DummyDB:
+        def collection(self, name):
+            assert name == "attendance"
+            return DummyAttendance()
+
+    monkeypatch.setattr(attendance_utils, "db", DummyDB())
+    records, count, hours = attendance_utils.load_attendance_records("abc", "C1")
+    assert count == 1
+    assert hours == 1.0
+    assert records == [{"session": "s1", "present": True}]
+
+    # Metadata fields like ``date`` should not be treated as student codes
+    records2, count2, hours2 = attendance_utils.load_attendance_records("date", "C1")
+    assert count2 == 0
+    assert hours2 == 0.0
+    assert records2 == [{"session": "s1", "present": False}]
+
+
 def test_load_attendance_records_handles_error(monkeypatch):
     class DummyDB:
         def collection(self, name):


### PR DESCRIPTION
## Summary
- Handle attendance documents that store student codes directly at the root
- Ignore metadata fields while collecting attendee codes
- Test root-level session documents with metadata

## Testing
- `ruff check src/attendance_utils.py tests/test_attendance_utils.py`
- `PYTHONPATH=. pytest tests/test_attendance_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc3229b9508321bb073a455076f27d