### PR TITLE
Support root-level attendance in Firestore summaries

### DIFF
--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -250,7 +250,10 @@ def fetch_attendance_summary(student_code: str, class_name: str) -> tuple[int, f
         hours = 0.0
         for snap in sessions_ref.stream():
             data = snap.to_dict() or {}
-            attendees = data.get("attendees", {}) or {}
+            if "attendees" in data:
+                attendees = data.get("attendees") or {}
+            else:
+                attendees = data
             if isinstance(attendees, dict) and student_code in attendees:
                 count += 1
                 try:

--- a/tests/test_firestore_utils.py
+++ b/tests/test_firestore_utils.py
@@ -105,3 +105,39 @@ def test_fetch_attendance_summary_counts_sessions(monkeypatch):
     count, hours = fetch_attendance_summary("abc", "C1")
     assert count == 2
     assert abs(hours - 2.0) < 1e-6
+
+
+def test_fetch_attendance_summary_root_attendees(monkeypatch):
+    class DummySnap:
+        def __init__(self, data):
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    class DummySessions:
+        def stream(self):
+            return [
+                DummySnap({"abc": True, "xyz": True}),
+                DummySnap({"abc": 2, "date": "2024-01-01"}),
+            ]
+
+    class DummyClass:
+        def collection(self, name):
+            assert name == "sessions"
+            return DummySessions()
+
+    class DummyAttendance:
+        def document(self, name):
+            assert name == "C1"
+            return DummyClass()
+
+    class DummyDB:
+        def collection(self, name):
+            assert name == "attendance"
+            return DummyAttendance()
+
+    monkeypatch.setattr(firestore_utils, "db", DummyDB())
+    count, hours = fetch_attendance_summary("abc", "C1")
+    assert count == 2
+    assert abs(hours - 3.0) < 1e-6


### PR DESCRIPTION
## Summary
- Handle session documents where student codes are stored at the root instead of under `attendees`
- Cover root-level attendance format in tests, including boolean and hour values

## Testing
- `ruff check src/firestore_utils.py tests/test_firestore_utils.py`
- `PYTHONPATH=. pytest tests/test_firestore_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc32dfcd2c832192fe182c1b5fb8fe