### PR TITLE
test: verify map attendee hours

### DIFF
--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -254,17 +254,27 @@ def fetch_attendance_summary(student_code: str, class_name: str) -> tuple[int, f
                 attendees = data.get("attendees") or {}
             else:
                 attendees = data
-            if isinstance(attendees, dict) and student_code in attendees:
-                count += 1
-                try:
-                    hours += float(attendees.get(student_code, 0) or 0)
-                except Exception:
-                    pass
+            if isinstance(attendees, dict):
+                entry = attendees.get(student_code)
+                if isinstance(entry, dict) and "present" in entry:
+                    if bool(entry.get("present")):
+                        count += 1
+                        try:
+                            hours += float(entry.get("hours", 1) or 0)
+                        except Exception:
+                            pass
+                elif student_code in attendees:
+                    count += 1
+                    try:
+                        hours += float(attendees.get(student_code, 0) or 0)
+                    except Exception:
+                        pass
             elif isinstance(attendees, list):
                 for item in attendees:
                     if (
                         isinstance(item, dict)
                         and item.get("code") == student_code
+                        and bool(item.get("present", True))
                     ):
                         count += 1
                         try:

--- a/tests/test_attendance_utils.py
+++ b/tests/test_attendance_utils.py
@@ -170,6 +170,52 @@ def test_load_attendance_records_dict_attendee(monkeypatch):
     assert records == [{"session": "s1", "present": True}]
 
 
+def test_load_attendance_records_dict_attendee_with_hours(monkeypatch):
+    class DummySnap:
+        def __init__(self, doc_id, data):
+            self.id = doc_id
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    class DummySessions:
+        def stream(self):
+            return [
+                DummySnap(
+                    "s1",
+                    {
+                        "felixa2": {
+                            "present": True,
+                            "hours": 1.5,
+                            "name": "Felix Asadu (Tutor)",
+                        }
+                    },
+                )
+            ]
+
+    class DummyClass:
+        def collection(self, name):
+            assert name == "sessions"
+            return DummySessions()
+
+    class DummyAttendance:
+        def document(self, name):
+            assert name == "C1"
+            return DummyClass()
+
+    class DummyDB:
+        def collection(self, name):
+            assert name == "attendance"
+            return DummyAttendance()
+
+    monkeypatch.setattr(attendance_utils, "db", DummyDB())
+    records, count, hours = attendance_utils.load_attendance_records("felixa2", "C1")
+    assert count == 1
+    assert abs(hours - 1.5) < 1e-6
+    assert records == [{"session": "s1", "present": True}]
+
+
 def test_load_attendance_records_handles_error(monkeypatch):
     class DummyDB:
         def collection(self, name):

--- a/tests/test_firestore_utils.py
+++ b/tests/test_firestore_utils.py
@@ -177,3 +177,40 @@ def test_fetch_attendance_summary_only_student_codes(monkeypatch):
     count, hours = fetch_attendance_summary("abc", "C1")
     assert count == 2
     assert abs(hours - 3.0) < 1e-6
+
+
+def test_fetch_attendance_summary_dict_attendee(monkeypatch):
+    class DummySnap:
+        def __init__(self, attendees):
+            self._attendees = attendees
+
+        def to_dict(self):
+            return {"attendees": self._attendees}
+
+    class DummySessions:
+        def stream(self):
+            return [
+                DummySnap({"felixa2": {"present": True}}),
+                DummySnap({"felixa2": {"present": True, "hours": 1.5}}),
+                DummySnap({"felixa2": {"present": False}}),
+            ]
+
+    class DummyClass:
+        def collection(self, name):
+            assert name == "sessions"
+            return DummySessions()
+
+    class DummyAttendance:
+        def document(self, name):
+            assert name == "C1"
+            return DummyClass()
+
+    class DummyDB:
+        def collection(self, name):
+            assert name == "attendance"
+            return DummyAttendance()
+
+    monkeypatch.setattr(firestore_utils, "db", DummyDB())
+    count, hours = fetch_attendance_summary("felixa2", "C1")
+    assert count == 2
+    assert abs(hours - 2.5) < 1e-6


### PR DESCRIPTION
## Summary
- test attendance utils when attendee records include hours
- test firestore utils for attendance dict entries
- handle "present" and "hours" in fetch_attendance_summary

## Testing
- `ruff check src/firestore_utils.py tests/test_attendance_utils.py tests/test_firestore_utils.py`
- `PYTHONPATH=. pytest tests/test_attendance_utils.py tests/test_firestore_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc3a3307408321bfc52045808daaf7