### PR TITLE
Add Telegram notifications sidebar expander

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -855,6 +855,15 @@ def render_sidebar_published():
             """
         )
 
+    with st.sidebar.expander("🔔 Telegram notifications", expanded=False):
+        st.markdown(
+            """
+- [Open the Falowen bot](https://t.me/falowenbot) and tap **Start**  
+- Register: `/register <student_code>` (e.g. `/register kwame202`)  
+- To deactivate: send `/stop`  
+            """
+        )
+
     with st.sidebar.expander("🎥 Welcome / video tutorials", expanded=False):
         render_level_welcome_video(st.session_state.get("student_level"))
         st.caption("More tutorials will appear here as they’re published.")


### PR DESCRIPTION
## Summary
- add Telegram notification how-to section in sidebar

## Testing
- `ruff check a1sprechen.py | tail -n 20` *(fails: Found 92 errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc4319414883218581b0220e8dc383