### PR TITLE
Handle attendance stored under students key

### DIFF
--- a/tests/test_firestore_utils.py
+++ b/tests/test_firestore_utils.py
@@ -44,6 +44,21 @@ def test_format_record_normalizes_and_extracts_hours(monkeypatch):
     record, hours = format_record("doc1", data, "abc")
     assert record == {"session": "FOO", "present": True}
     assert abs(hours - 1.5) < 1e-6
+
+
+def test_format_record_students_mapping(monkeypatch):
+    monkeypatch.setattr(
+        firestore_utils,
+        "normalize_label",
+        lambda s: s.upper(),
+    )
+    data = {
+        "students": {"abc": {"present": True, "hours": 2}},
+        "label": "foo",
+    }
+    record, hours = format_record("doc1", data, "abc")
+    assert record == {"session": "FOO", "present": True}
+    assert abs(hours - 2.0) < 1e-6
 def test_save_response_stores_responder_code(monkeypatch):
     class DummyRef:
         def __init__(self):
@@ -104,6 +119,43 @@ def test_fetch_attendance_summary_counts_sessions(monkeypatch):
 
         def to_dict(self):
             return {"attendees": self._attendees}
+
+    class DummySessions:
+        def stream(self):
+            return [
+                DummySnap({"abc": 1.5, "xyz": 2}),
+                DummySnap({"xyz": 1}),
+                DummySnap({"abc": 0.5}),
+            ]
+
+    class DummyClass:
+        def collection(self, name):
+            assert name == "sessions"
+            return DummySessions()
+
+    class DummyAttendance:
+        def document(self, name):
+            assert name == "C1"
+            return DummyClass()
+
+    class DummyDB:
+        def collection(self, name):
+            assert name == "attendance"
+            return DummyAttendance()
+
+    monkeypatch.setattr(firestore_utils, "db", DummyDB())
+    count, hours = fetch_attendance_summary("abc", "C1")
+    assert count == 2
+    assert abs(hours - 2.0) < 1e-6
+
+
+def test_fetch_attendance_summary_students_mapping(monkeypatch):
+    class DummySnap:
+        def __init__(self, students):
+            self._students = students
+
+        def to_dict(self):
+            return {"students": self._students}
 
     class DummySessions:
         def stream(self):


### PR DESCRIPTION
## Summary
- Support attendance documents that use a `students` mapping alongside `attendees`
- Clarify docstrings and comments about accepted attendance structures
- Test attendance utilities against session data using the `students` key

## Testing
- `PYTHONPATH=. pytest tests/test_firestore_utils.py tests/test_attendance_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc46fb46bc8321891e0ccee4acd137