### PR TITLE
Add Day 0 tutorial entries to advanced schedules

### DIFF
--- a/src/schedule.py
+++ b/src/schedule.py
@@ -488,6 +488,37 @@ def get_a1_schedule():
 
 def get_a2_schedule():
     return [
+        # DAY 0 – Tutorial
+        {
+            "day": 0,
+            "chapter": "Tutorial",
+            "assignment": False,
+            "topic": "Tutorial – Course Overview",
+            "goal": (
+                "Welcome to the A2 German course! This first chapter is a guided tour "
+                "showing how the course works. Your name is automatically pulled from your "
+                "profile, so every page greets you personally."
+            ),
+            "instruction": (
+                "**Daily Focus Options**\n"
+                "- *Lesen & Hören*\n"
+                "- *Schreiben & Sprechen*\n\n"
+                "**Chapter Structure**\n"
+                "- Goal\n"
+                "- Instructions\n"
+                "- Recorded Lectures\n"
+                "- Grammar Notes\n"
+                "- Workbook Exercises\n\n"
+                "**Tabs in the Course Interface**\n"
+                "- Overview\n"
+                "- Assignments\n"
+                "- Submit\n\n"
+                "**Submitting Work**\n"
+                "1. Use the level selector at the top.\n"
+                "2. Upload your work via the **Submit** tab.\n"
+                "3. Receive email or Telegram notifications when your work is reviewed.\n"
+            ),
+        },
         # DAY 1
         {
             "day": 1,
@@ -881,6 +912,37 @@ def get_a2_schedule():
 #
 def get_b1_schedule():
     return [
+        # TAG 0 – Tutorial
+        {
+            "day": 0,
+            "chapter": "Tutorial",
+            "assignment": False,
+            "topic": "Tutorial – Course Overview",
+            "goal": (
+                "Welcome to the B1 German course! This first chapter is a guided tour "
+                "showing how the course works. Your name is automatically pulled from your "
+                "profile, so every page greets you personally."
+            ),
+            "instruction": (
+                "**Daily Focus Options**\n"
+                "- *Lesen & Hören*\n"
+                "- *Schreiben & Sprechen*\n\n"
+                "**Chapter Structure**\n"
+                "- Goal\n"
+                "- Instructions\n"
+                "- Recorded Lectures\n"
+                "- Grammar Notes\n"
+                "- Workbook Exercises\n\n"
+                "**Tabs in the Course Interface**\n"
+                "- Overview\n"
+                "- Assignments\n"
+                "- Submit\n\n"
+                "**Submitting Work**\n"
+                "1. Use the level selector at the top.\n"
+                "2. Upload your work via the **Submit** tab.\n"
+                "3. Receive email or Telegram notifications when your work is reviewed.\n"
+            ),
+        },
         # TAG 1
         {
             "day": 1,
@@ -1261,6 +1323,36 @@ def get_b1_schedule():
 
 def get_b2_schedule():
     return [
+        {
+            "day": 0,
+            "chapter": "Tutorial",
+            "assignment": False,
+            "topic": "Tutorial – Course Overview",
+            "goal": (
+                "Welcome to the B2 German course! This first chapter is a guided tour "
+                "showing how the course works. Your name is automatically pulled from your "
+                "profile, so every page greets you personally."
+            ),
+            "instruction": (
+                "**Daily Focus Options**\n"
+                "- *Lesen & Hören*\n"
+                "- *Schreiben & Sprechen*\n\n"
+                "**Chapter Structure**\n"
+                "- Goal\n"
+                "- Instructions\n"
+                "- Recorded Lectures\n"
+                "- Grammar Notes\n"
+                "- Workbook Exercises\n\n"
+                "**Tabs in the Course Interface**\n"
+                "- Overview\n"
+                "- Assignments\n"
+                "- Submit\n\n"
+                "**Submitting Work**\n"
+                "1. Use the level selector at the top.\n"
+                "2. Upload your work via the **Submit** tab.\n"
+                "3. Receive email or Telegram notifications when your work is reviewed.\n"
+            ),
+        },
         {
             "day": 1,
             "topic": "Persönliche Identität und Selbstverständnis",


### PR DESCRIPTION
## Summary
- Add Day 0 "Tutorial – Course Overview" entries to A2, B1, and B2 schedules
- Ensure tutorial text and metadata match A1 Day 0 and mark as non-assignment
- Verified schedule loader exposes new Day 0 for all levels

## Testing
- `ruff check src/schedule.py`
- `pytest -q`
- `python - <<'PY'
from src.schedule import load_level_schedules
s = load_level_schedules()
for lvl in ['A2','B1','B2']:
    first = s[lvl][0]
    print(lvl, first['day'], first['topic'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bc55a5f5a883219a11d31e125d74fa