### PR TITLE
Add day 0 schedule tests for A2, B1, and B2

### DIFF
--- a/tests/test_schedule_module.py
+++ b/tests/test_schedule_module.py
@@ -1,7 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from src.schedule import (
     load_level_schedules,
     get_level_schedules,
     get_a1_schedule,
+    get_a2_schedule,
+    get_b1_schedule,
+    get_b2_schedule,
 )
 
 
@@ -16,3 +24,21 @@ def test_get_level_schedules_matches_load():
 
 def test_get_a1_schedule_is_list():
     assert isinstance(get_a1_schedule(), list)
+
+
+def test_get_a2_schedule_has_day0():
+    schedule = get_a2_schedule()
+    assert schedule[0]["day"] == 0
+    assert schedule[0]["topic"] == "Small Talk 1.1 (Exercise)"
+
+
+def test_get_b1_schedule_has_day0():
+    schedule = get_b1_schedule()
+    assert schedule[0]["day"] == 0
+    assert schedule[0]["topic"] == "Traumwelten (Übung) 1.1"
+
+
+def test_get_b2_schedule_has_day0():
+    schedule = get_b2_schedule()
+    assert schedule[0]["day"] == 0
+    assert schedule[0]["topic"] == "Persönliche Identität und Selbstverständnis"


### PR DESCRIPTION
## Summary
- extend schedule tests to include day 0 expectations for A2, B1, and B2 levels

## Testing
- `pytest tests/test_schedule_module.py -q` *(fails: assert 1 == 0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc55a6f7a88321a0aadd3dc39c4fdf