### PR TITLE
Add B1 course completion day

### DIFF
--- a/src/schedule.py
+++ b/src/schedule.py
@@ -1321,6 +1321,25 @@ def get_b1_schedule():
             "grammarbook_link": "",
             "workbook_link": "https://drive.google.com/file/d/1iBeZHMDq_FnusY4kkRwRQvyOfm51-COU/view?usp=sharing"
         },
+        # TAG 29
+        {
+            "day": 29,
+            "topic": "Congratulations!",
+            "chapter": "10.29",
+            "assignment": False,
+            "goal": "Celebrate your achievement and plan your next steps.",
+            "instruction": (
+                "Congratulations on finishing your B1 course. You worked hard and made great progress. "
+                "The school will confirm your results and send your completion certificate to your email. "
+                "Kindly communicate with us what you would like to do next by emailing learngermanghana@gmail.com. "
+                "You can prepare for the B1 exams or progress to B2. We wish you continued success in your journey. "
+                "Use Exams Mode, Custom Chat, the Vocabulary Trainer, and the Schreiben Trainer for complete exam prep. "
+                "The Schreiben Trainer includes pre-filled questions on typical topics. "
+                "Exams Mode links to past Goethe questions; only the Hörverstehen audio is missing, so use YouTube for listening practice. "
+                "You'll keep access to your tutor until your contract officially ends. "
+                "If you enjoyed the course, please leave us a positive review on [Google](https://g.page/r/YOUR_REVIEW_ID/review)."
+            ),
+        },
     ]
 
 


### PR DESCRIPTION
## Summary
- Append day 29 celebratory entry to the B1 schedule, encouraging exam prep or progressing to B2

## Testing
- `ruff check src/schedule.py`
- `pytest` *(fails: test_get_a2_schedule_has_day0, test_get_b1_schedule_has_day0, test_get_b2_schedule_has_day0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc59fd1e008321a53c1e122f5fe992