### PR TITLE
Add B2 course completion day

### DIFF
--- a/src/schedule.py
+++ b/src/schedule.py
@@ -1666,6 +1666,24 @@ def get_b2_schedule():
             "grammarbook_link": "",
             "workbook_link": "",
             "grammar_topic": ""
+        },
+        {
+            "day": 29,
+            "topic": "Congratulations!",
+            "chapter": "6.4",
+            "assignment": False,
+            "goal": "Celebrate your achievement and plan your next steps.",
+            "instruction": (
+                "Congratulations on finishing your B2 course. You worked hard and made great progress. "
+                "The school will confirm your results and send your completion certificate to your email. "
+                "Kindly communicate with us what you would like to do next by emailing learngermanghana@gmail.com. "
+                "You can prepare for the B2 exams or progress to C1. We wish you continued success in your journey. "
+                "Use Exams Mode, Custom Chat, the Vocabulary Trainer, and the Schreiben Trainer for complete exam prep. "
+                "The Schreiben Trainer includes pre-filled questions on typical topics. "
+                "Exams Mode links to past Goethe questions; only the Hörverstehen audio is missing, so use YouTube for listening practice. "
+                "You'll keep access to your tutor until your contract officially ends. "
+                "If you enjoyed the course, please leave us a positive review on [Google](https://g.page/r/YOUR_REVIEW_ID/review)."
+            ),
         }
     ]
 


### PR DESCRIPTION
## Summary
- Add new day 29 entry to B2 schedule celebrating course completion and outlining next steps toward C1 or B2 exams

## Testing
- `ruff check src/schedule.py`
- `pytest tests/test_schedule_module.py -q` *(fails: assertions for day 0 topics in A2/B1/B2 schedules)*

------
https://chatgpt.com/codex/tasks/task_e_68bc59fddab08321a4cfbc0e32127744