### PR TITLE
Include class name in class board Firestore paths

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2224,13 +2224,20 @@ def fetch_latest(level: str, code: str, lesson_key: str) -> Optional[Dict[str, A
 # -------------------------
 def post_message(
     level: str,
+    class_name: str,
     code: str,
     name: str,
     content: str,
     reply_to: Optional[str] = None,
 ) -> None:
-    """Post a message to the class board."""
-    posts_ref = db.collection("class_board").document(level).collection("posts")
+    """Post a message to the class board for a specific class."""
+    posts_ref = (
+        db.collection("class_board")
+        .document(level)
+        .collection("classes")
+        .document(class_name)
+        .collection("posts")
+    )
     posts_ref.add(
         {
             "student_code": code,
@@ -4096,7 +4103,13 @@ if tab == "My Course":
 
         # ===================== Class Board =====================
         elif classroom_section == "Class Notes & Q&A":
-            board_base = db.collection("class_board").document(class_name).collection("posts")
+            board_base = (
+                db.collection("class_board")
+                .document(student_level)
+                .collection("classes")
+                .document(class_name)
+                .collection("posts")
+            )
 
 
             _new7, _unans, _total = 0, 0, 0

--- a/scripts/migrate_qna_to_board.py
+++ b/scripts/migrate_qna_to_board.py
@@ -12,6 +12,7 @@ def migrate():
     ops = 0
     for class_doc in qna_ref.stream():
         class_name = class_doc.id
+        level = class_name.split()[0]
         questions_ref = class_doc.reference.collection("questions")
         for qdoc in questions_ref.stream():
             qdata = qdoc.to_dict() or {}
@@ -27,6 +28,8 @@ def migrate():
 
             post_ref = (
                 db.collection("class_board")
+                .document(level)
+                .collection("classes")
                 .document(class_name)
                 .collection("posts")
                 .document(qdoc.id)

--- a/tests/test_class_board_isolation.py
+++ b/tests/test_class_board_isolation.py
@@ -1,0 +1,85 @@
+import ast
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def load_post_message(dummy_db):
+    with open('a1sprechen.py', 'r', encoding='utf-8') as f:
+        src = f.read()
+    mod = ast.parse(src)
+    funcs = [node for node in mod.body if isinstance(node, ast.FunctionDef) and node.name == 'post_message']
+    module_ast = ast.Module(body=funcs, type_ignores=[])
+    code = compile(module_ast, 'a1sprechen.py', 'exec')
+    glb = {'db': dummy_db, '_dt': datetime, '_timezone': timezone, 'Optional': Optional}
+    exec(code, glb)
+    return glb['post_message']
+
+
+class DummySnap:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
+class DummyCollection:
+    def __init__(self, storage, path):
+        self.storage = storage
+        self.path = path
+
+    def document(self, name):
+        return DummyDocument(self.storage, self.path + (name,))
+
+    def collection(self, name):
+        return DummyCollection(self.storage, self.path + (name,))
+
+    def add(self, data):
+        self.storage.setdefault(self.path, []).append(data)
+
+    def stream(self):
+        for item in self.storage.get(self.path, []):
+            yield DummySnap(item)
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def limit(self, *args, **kwargs):
+        return self
+
+
+class DummyDocument:
+    def __init__(self, storage, path):
+        self.storage = storage
+        self.path = path
+
+    def collection(self, name):
+        return DummyCollection(self.storage, self.path + (name,))
+
+    def set(self, data):
+        self.storage.setdefault(self.path, []).append(data)
+
+
+class DummyDB:
+    def __init__(self):
+        self.storage = {}
+
+    def collection(self, name):
+        return DummyCollection(self.storage, (name,))
+
+
+def test_posts_isolated_by_class():
+    db = DummyDB()
+    post_message = load_post_message(db)
+
+    post_message('A1', 'ClassA', 'c1', 'Alice', 'Hello')
+    post_message('A1', 'ClassB', 'c2', 'Bob', 'Hi')
+
+    coll_a = db.collection('class_board').document('A1').collection('classes').document('ClassA').collection('posts')
+    coll_b = db.collection('class_board').document('A1').collection('classes').document('ClassB').collection('posts')
+
+    posts_a = [s.to_dict() for s in coll_a.stream()]
+    posts_b = [s.to_dict() for s in coll_b.stream()]
+
+    assert len(posts_a) == 1 and posts_a[0]['student_name'] == 'Alice'
+    assert len(posts_b) == 1 and posts_b[0]['student_name'] == 'Bob'


### PR DESCRIPTION
## Summary
- nest class board posts under level and class name in Firestore
- adjust class board retrieval and migration script for nested paths
- add test ensuring posts for different classes at same level stay separate

## Testing
- `pytest` *(fails: test_get_a2_schedule_has_day0, test_get_b1_schedule_has_day0, test_get_b2_schedule_has_day0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5e87637083219f83cf8de89acb30