### PR TITLE
Remove welcome video sidebar block

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -875,10 +875,6 @@ def render_sidebar_published():
             """
         )
 
-    with st.sidebar.expander("🎥 Welcome / video tutorials", expanded=False):
-        render_level_welcome_video(st.session_state.get("student_level"))
-        st.caption("More tutorials will appear here as they’re published.")
-
     st.sidebar.divider()
 
     st.sidebar.markdown("## Support")


### PR DESCRIPTION
## Summary
- Remove sidebar expander with welcome video and caption to simplify the layout.

## Testing
- `ruff check a1sprechen.py` *(fails: E402 module level import not at top, etc.)*
- `pytest -q` *(fails: schedule module tests do not match expected topics)*

------
https://chatgpt.com/codex/tasks/task_e_68bc63a22294832187b43c472876cb53