### PR TITLE
Add attendance announcement

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -999,6 +999,7 @@ announcements = [
     {"title": "Download Receipts & Results", "body": "Grab your receipt, results, and enrollment letter under **My Results & Resources**.", "tag": "New"},
     {"title": "Account Deletion Requests", "body": "You can now request account deletion from your account settings.", "tag": "Info"},
     {"title": "Refresh Session Fix", "body": "Frequent refresh session prompts have been resolved for smoother navigation.", "tag": "Update"},
+    {"title": "Attendance Now Being Marked", "body": "Find attendance under My Course ➜ Classroom/Attendance. Telegram notifications are available.", "tag": "New"},
 ]
 
 st.markdown("---")


### PR DESCRIPTION
## Summary
- announce attendance tracking with link to My Course ➜ Classroom/Attendance

## Testing
- `ruff check a1sprechen.py` *(fails: E402 Module level import not at top of file... etc)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6ad48c5c83218ca43129d1162639