### PR TITLE
Cap schedule at final assignment and ignore Goethe lessons

### DIFF
--- a/tests/test_assignment_summary_filters.py
+++ b/tests/test_assignment_summary_filters.py
@@ -1,0 +1,50 @@
+import pandas as pd
+
+from src import assignment_ui
+
+
+def test_next_assignment_skips_goethe_and_final_cap(monkeypatch):
+    schedule = [
+        {"day": 1, "chapter": "1.0", "assignment": True, "topic": "Ch1"},
+        {"day": 2, "chapter": "1.5", "assignment": True, "topic": "Goethe practice"},
+        {"day": 3, "chapter": "14.2", "assignment": True, "topic": "Beyond"},
+        {"day": 4, "chapter": "2.0", "assignment": True, "topic": "Ch2"},
+    ]
+    df = pd.DataFrame(
+        {
+            "studentcode": ["s1"],
+            "assignment": ["1.0"],
+            "level": ["A1"],
+            "score": ["90"],
+            "date": ["2024-01-01"],
+        }
+    )
+    monkeypatch.setattr(assignment_ui, "load_assignment_scores", lambda: df)
+    monkeypatch.setattr(assignment_ui, "_get_level_schedules", lambda: {"A1": schedule})
+
+    summary = assignment_ui.get_assignment_summary("s1", "A1")
+    assert summary["missed"] == []
+    assert summary["next"]["day"] == 4
+
+
+def test_missed_assignments_skip_goethe(monkeypatch):
+    schedule = [
+        {"day": 1, "chapter": "1.0", "assignment": True, "topic": "Goethe intro"},
+        {"day": 2, "chapter": "2.0", "assignment": True, "topic": "Ch2"},
+        {"day": 3, "chapter": "3.0", "assignment": True, "topic": "Ch3"},
+    ]
+    df = pd.DataFrame(
+        {
+            "studentcode": ["s1"],
+            "assignment": ["2.0"],
+            "level": ["A1"],
+            "score": ["90"],
+            "date": ["2024-01-01"],
+        }
+    )
+    monkeypatch.setattr(assignment_ui, "load_assignment_scores", lambda: df)
+    monkeypatch.setattr(assignment_ui, "_get_level_schedules", lambda: {"A1": schedule})
+
+    summary = assignment_ui.get_assignment_summary("s1", "A1")
+    assert summary["missed"] == []
+    assert summary["next"]["day"] == 3


### PR DESCRIPTION
## Summary
- Limit assignment schedule per level via final chapter mapping
- Skip lessons mentioning Goethe or beyond the level's last assignment when computing missed/next tasks
- Add tests covering Goethe filtering and final assignment cap

## Testing
- `ruff check src/assignment_ui.py tests/test_assignment_summary_filters.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca88ec5688321a731aa5b6b49a258