### PR TITLE
Notify students when a level is completed

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -649,6 +649,7 @@ def render_results_and_resources_tab() -> None:
         summary = get_assignment_summary(code_key, level)
         skipped_assignments = summary.get("missed", [])
         next_assignment = summary.get("next")
+        completed_level = not skipped_assignments and next_assignment is None
 
         if skipped_assignments:
             st.markdown(
@@ -679,7 +680,13 @@ def render_results_and_resources_tab() -> None:
                 f"**Instruction:** {next_assignment.get('instruction','')}"
             )
         else:
-            st.success("🎉 You’re up to date!")
+            if completed_level:
+                st.success(
+                    "🎉 Congratulations! You’ve completed "
+                    f"{level}. Your completion certificate will be emailed to you."
+                )
+            else:
+                st.success("🎉 You’re up to date!")
 
     elif rr_page == "Downloads":
         st.subheader("Downloads")


### PR DESCRIPTION
## Summary
- Detect when a student has finished all assignments in a level
- Display a certificate notice after the final assignment is completed

## Testing
- `ruff check src/assignment_ui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca8dd54408321a62de08ac2c1e553