### PR TITLE
Fix syntax errors in schedule module

### DIFF
--- a/src/schedule.py
+++ b/src/schedule.py
@@ -950,8 +950,6 @@ Good luck and viel Erfolg on your language journey!
         },
         # DAY 28
         {
-        # DAY 28
-        {
             "day": 28,
             "topic": "Über die Zukunft sprechen 10.28",
             "chapter": "10.28",
@@ -1474,7 +1472,6 @@ Wir wünschen dir weiterhin viel Erfolg auf deinem Sprachlernweg! 🚀
                 "workbook_link": None
             }
         },
-    ]
     ]
 
 


### PR DESCRIPTION
## Summary
- Remove extraneous placeholder in Day 28 entry of the schedule
- Drop stray closing bracket left after the B1 schedule list

## Testing
- `python -m py_compile src/schedule.py`
- `pytest` *(fails: ImportError: cannot import name 'get_a2_schedule' from 'src.schedule')*

------
https://chatgpt.com/codex/tasks/task_e_68bcc02fb8608321baad43537dd44481