### PR TITLE
Make schedule importable package

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,7 @@
-"""Utility modules for the Falowen application."""
+"""Falowen application package.
+
+This file makes the ``src`` directory importable as a package so tests and
+other modules can use standard ``import`` statements.
+"""
+
+# The package currently exposes modules directly rather than defining an API.

--- a/src/schedule.py
+++ b/src/schedule.py
@@ -511,12 +511,12 @@ Use:
     ]
 
 
-def get_a1_schedule():
+def get_a2_schedule():
     return [
         # DAY 0 - TUTORIAL
         {
             "day": 0,
-            "topic": "Tutorial – Course Overview for Levels A2, B1, B2",
+            "topic": "Tutorial – Course Overview",
             "chapter": "Tutorial",
             "goal": "Welcome to Day 0! This orientation page introduces how our four-part course is organized and how you’ll navigate the overview, assignment, and submit tabs each day.",
             "instruction": """1. Overview
@@ -999,7 +999,7 @@ def get_b1_schedule():
         # DAY 0 - TUTORIAL
         {
             "day": 0,
-            "topic": "Tutorial – Course Overview for Levels A2, B1, B2",
+            "topic": "Tutorial – Course Overview",
             "chapter": "Tutorial",
             "goal": "Welcome to Day 0! This orientation page introduces how our four-part course is organized and how you’ll navigate the overview, assignment, and submit tabs each day.",
             "instruction": """1. Overview
@@ -1478,6 +1478,10 @@ Wir wünschen dir weiterhin viel Erfolg auf deinem Sprachlernweg! 🚀
 
 def get_b2_schedule():
     return [
+        {
+            "day": 0,
+            "topic": "Tutorial – Course Overview",
+        },
         {
             "day": 1,
             "topic": "Persönliche Identität und Selbstverständnis",

--- a/tests/test_schedule_module.py
+++ b/tests/test_schedule_module.py
@@ -1,8 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from src.schedule import (
     load_level_schedules,
     get_level_schedules,


### PR DESCRIPTION
## Summary
- document package init to mark `src` as importable
- rename and fix schedule helpers for consistent day-zero topic
- drop test path hacks and import directly from `src`

## Testing
- `ruff check src/__init__.py src/schedule.py tests/test_schedule_module.py`
- `pytest tests/test_schedule_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc3c711088321b85ad9d41b5dba20