### PR TITLE
Add shared global styles and apply to Google button

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,27 @@ ADMINS_BY_LEVEL = {
 ```
 
 Update this mapping whenever new levels or teachers require admin access.
+
+## Styling
+
+Global CSS variables and layout helpers live in `src/styles.py`. These styles are
+loaded at app start and expose reusable class names such as `flex-center`,
+`btn`, and `btn-google`.
+
+To style a new widget, call the classes in your HTML snippet:
+
+```python
+from src.styles import inject_global_styles  # already called in a1sprechen.py
+
+st.markdown(
+    """
+    <div class="flex-center">
+      <button class="btn">Example</button>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
+```
+
+Extend `src/styles.py` with additional variables or classes and reuse them across
+components.

--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -34,6 +34,7 @@ from docx import Document
 from google.cloud.firestore_v1 import FieldFilter
 from firebase_admin import firestore  # Firebase
 from openai import OpenAI
+from src.styles import inject_global_styles
 
 from flask import Flask
 from auth import auth_bp
@@ -59,6 +60,9 @@ st.set_page_config(
     layout="wide",
     initial_sidebar_state="expanded",
 )
+
+# Load global CSS classes and variables
+inject_global_styles()
 
 
 if st.session_state.pop("needs_rerun", False):

--- a/src/styles.py
+++ b/src/styles.py
@@ -1,0 +1,54 @@
+"""Global styling helpers for Streamlit UI components."""
+from __future__ import annotations
+
+import streamlit as st
+
+# Shared CSS variables and utility classes
+GLOBAL_CSS = """
+:root {
+  --google-blue: #1a73e8;
+  --text-light: #ffffff;
+}
+
+.flex-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.g-btn-wrap {
+  margin: 12px 0;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.btn-google {
+  background: var(--google-blue);
+  color: var(--text-light);
+  box-shadow: 0 2px 8px rgba(26,115,232,.25);
+  padding: 10px 18px;
+  font-size: 15px;
+}
+
+.google-logo {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+}
+
+.no-decoration {
+  text-decoration: none;
+}
+"""
+
+def inject_global_styles() -> None:
+    """Inject shared CSS variables and classes into the app."""
+    st.markdown(f"<style>{GLOBAL_CSS}</style>", unsafe_allow_html=True)

--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -14,15 +14,10 @@ def render_google_button_once(auth_url: str, key: str = "primary") -> None:
         return
     st.session_state[ss_key] = True
     btn_html = f"""
-    <div style="display:flex;justify-content:center;margin:12px 0;">
-      <a href="{auth_url}" style="text-decoration:none;">
-        <button aria-label="Continue with Google"
-          style="
-            display:inline-flex;align-items:center;gap:10px;
-            background:#1a73e8;color:#fff;border:none;border-radius:8px;
-            padding:10px 18px;cursor:pointer;font-weight:700;font-size:15px;
-            box-shadow:0 2px 8px rgba(26,115,232,.25);">
-          <span style="display:inline-flex;width:18px;height:18px;">
+    <div class="flex-center g-btn-wrap">
+      <a href="{auth_url}" class="no-decoration">
+        <button aria-label="Continue with Google" class="btn btn-google">
+          <span class="google-logo">
             <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48' width='18' height='18'>
               <path fill='#FFC107' d='M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12
               s5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24
@@ -41,6 +36,7 @@ def render_google_button_once(auth_url: str, key: str = "primary") -> None:
     </div>
     """
     st.markdown(btn_html, unsafe_allow_html=True)
+
 
 
 def render_google_signin_once(auth_url: str, full_width: bool = True) -> None:


### PR DESCRIPTION
## Summary
- add `src/styles.py` with reusable CSS classes
- load global styles on app startup
- refactor Google sign-in button to use shared stylesheet
- document how to reuse styling helpers

## Testing
- `pytest -q`
- `ruff check .` *(fails: 109 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd282a9a483218045da1fe598de1e