### PR TITLE
chore: unify brand colors

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,5 +1,6 @@
 [theme]
-base = "light"       
+# Falowen brand colors
+base = "light"
 primaryColor = "#25317e"
 backgroundColor = "#f3f7fb"
 secondaryBackgroundColor = "#eef3fc"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # A1Sprechen
 
+## Brand Colors
+
+| Name       | Hex       |
+|------------|-----------|
+| Background | `#f3f7fb` |
+| Text       | `#1a2340` |
+| Primary    | `#25317e` |
+| Accent     | `#6366f1` |
+
 ## Deployment
 
 Set the cookie encryption password either in Streamlit secrets or via an environment variable:

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" content="#0ea5e9" />
+  <meta name="theme-color" content="#25317e" />
   <title>Falowen Login</title>
   <!-- Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -11,31 +11,19 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root {
-      --bg: #0b1220;
-      --bg2: #0e172a;
-      --card: rgba(255,255,255,0.08);
+      --bg: #f3f7fb;
+      --bg2: #eef3fc;
+      --card: #ffffff;
       --card-opaque: #ffffff;
-      --text: #0f172a;
+      --text: #1a2340;
       --muted: #6b7280;
-      --border: rgba(255,255,255,0.14);
-      --primary: #0ea5e9; /* sky-500 */
-      --primary-600: #0284c7;
-      --primary-700: #0369a1;
-      --accent: #6366f1; /* indigo-500 */
+      --border: rgba(26,35,64,0.10);
+      --primary: #25317e;
+      --primary-600: #1f2868;
+      --primary-700: #182052;
+      --accent: #6366f1;
       --success: #22c55e;
-      --shadow: 0 10px 30px rgba(2,132,199,0.18), 0 2px 10px rgba(0,0,0,0.2);
-    }
-    @media (prefers-color-scheme: light) {
-      :root {
-        --bg: #f6f8fb;
-        --bg2: #eef2ff;
-        --card: #ffffff;
-        --card-opaque: #ffffff;
-        --text: #0f172a;
-        --muted: #64748b;
-        --border: rgba(15, 23, 42, 0.08);
-        --shadow: 0 12px 30px rgba(2,132,199,0.10), 0 2px 8px rgba(2,6,23,0.06);
-      }
+      --shadow: 0 10px 30px rgba(37,49,126,0.18), 0 2px 10px rgba(0,0,0,0.2);
     }
 
     /* Reset-ish */

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,8 +3,8 @@
   "short_name": "Falowen",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#0b5fff",
+  "background_color": "#f3f7fb",
+  "theme_color": "#25317e",
   "icons": [
     {"src": "/static/icons/falowen-192.png","sizes":"192x192","type":"image/png"},
     {"src": "/static/icons/falowen-512.png","sizes":"512x512","type":"image/png"}

--- a/public/offline.html
+++ b/public/offline.html
@@ -6,26 +6,28 @@
   <title>Falowen – Offline</title>
   <meta name="robots" content="noindex" />
   <meta name="theme-color" content="#25317e" />
-  <meta name="color-scheme" content="light dark" />
+  <meta name="color-scheme" content="light" />
   <style>
     :root {
-      --bg:#f8fafc; --card:#fff; --text:#0f172a; --sub:#475569;
-      --brand:#25317e; --btn:#2563eb; --btnText:#fff; --ring:#93c5fd;
-      --ghost-bg:#eef2ff; --ghost-text:#1e40af; --border:#e5e7eb;
-    }
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --bg:#0b1220; --card:#0f172a; --text:#e5e7eb; --sub:#9aa5b1;
-        --brand:#8da2ff; --btn:#3b82f6; --btnText:#fff; --ring:#60a5fa;
-        --ghost-bg:#1e293b; --ghost-text:#c7d2fe; --border:#1f2937;
-      }
+      --bg:#f3f7fb;
+      --card:#ffffff;
+      --text:#1a2340;
+      --sub:#475569;
+      --primary:#25317e;
+      --accent:#6366f1;
+      --btn:var(--primary);
+      --btnText:#ffffff;
+      --ring:#93c5fd;
+      --ghost-bg:#eef3fc;
+      --ghost-text:var(--primary);
+      --border:#e5e7eb;
     }
     * { box-sizing:border-box }
     body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
       background:var(--bg); color:var(--text); display:grid; min-height:100dvh; place-items:center; }
     .wrap { width:min(560px, 92vw); background:var(--card); padding:24px;
       border:1px solid var(--border); border-radius:14px; text-align:center; box-shadow: 0 8px 30px rgba(0,0,0,.06); }
-    h1 { margin:10px 0 6px; color:var(--brand); font-size:1.6rem; }
+    h1 { margin:10px 0 6px; color:var(--primary); font-size:1.6rem; }
     p { margin:6px 0; color:var(--sub); }
     .emoji { font-size:48px; line-height:1; }
     .actions { display:flex; gap:10px; justify-content:center; margin-top:14px; flex-wrap:wrap; }


### PR DESCRIPTION
## Summary
- consolidate brand colors across Streamlit config and public pages
- align offline page and manifest with unified palette
- document final colors in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd27ade188321a24c970604597614