### PR TITLE
feat: keep unicode in PDF cleanup

### DIFF
--- a/tests/test_clean_for_pdf.py
+++ b/tests/test_clean_for_pdf.py
@@ -1,11 +1,15 @@
 from src.assignment_ui import clean_for_pdf
 
 
-def test_clean_for_pdf_handles_non_latin1():
-    text = "Score ✓ and emoji 😊"
+def test_clean_for_pdf_preserves_unicode_and_strips_control_chars():
+    # Include a combining character, newline, NULL byte and emoji.  The first
+    # two should be normalised and the control character removed; characters
+    # outside the Basic Multilingual Plane like the emoji are dropped.
+    text = "a\u0308ß\nBad\x00Char😊"
     cleaned = clean_for_pdf(text)
-    # Should encode to Latin-1 without raising an exception
-    cleaned.encode("latin-1")
-    # Non-Latin-1 characters should be replaced
-    assert cleaned == "Score ? and emoji ?"
+    # Normalisation turns "a\u0308" into "ä" and newlines become spaces; the
+    # NULL byte and emoji are removed entirely.
+    assert cleaned == "äß BadChar"
+    # Returned string should be valid UTF-8 with international characters
+    cleaned.encode("utf-8")
 


### PR DESCRIPTION
## Summary
- keep Unicode characters when sanitising text for PDFs
- drop unsupported emoji and control characters during PDF cleanup
- add regression test for Unicode preservation in PDF text cleaning

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd5f2994448321a964e3dafa3f4fc5