### PR TITLE
Use DejaVu font for PDF generation

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -312,6 +312,8 @@ def generate_enrollment_letter_pdf(
     pdf = FPDF()
     pdf.add_page()
     pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_font("DejaVu", "", "font/DejaVuSans.ttf", uni=True)
+    pdf.add_font("DejaVu", "B", "font/DejaVuSans.ttf", uni=True)
 
     # Insert letterhead at the top of the page
     try:  # pragma: no cover - network use is best effort
@@ -347,9 +349,9 @@ def generate_enrollment_letter_pdf(
         pass
 
     pdf.set_y(40)
-    pdf.set_font("Helvetica", "B", 16)
+    pdf.set_font("DejaVu", "B", 16)
     pdf.cell(0, 10, clean_for_pdf("Learn Language Education Academy"), ln=1, align="C")
-    pdf.set_font("Helvetica", size=10)
+    pdf.set_font("DejaVu", size=10)
     pdf.cell(
         0,
         6,
@@ -360,7 +362,7 @@ def generate_enrollment_letter_pdf(
     pdf.cell(0, 6, clean_for_pdf("Business Reg No: BN173410224"), ln=1, align="C")
     pdf.ln(10)
 
-    pdf.set_font("Helvetica", size=12)
+    pdf.set_font("DejaVu", size=12)
     body_lines = [
         "To Whom It May Concern,",
         f"{student_name} is officially enrolled in {student_level} at Learn Language Education Academy.",
@@ -417,6 +419,7 @@ def generate_receipt_pdf(
         os.path.join(os.path.dirname(__file__), "..", "font", "DejaVuSans.ttf")
     )
     pdf.add_font("DejaVu", "", font_path, uni=True)
+    pdf.add_font("DejaVu", "B", font_path, uni=True)
 
     logo = load_school_logo()
     if logo:
@@ -426,9 +429,9 @@ def generate_receipt_pdf(
         except Exception:
             pdf.ln(5)
 
-    pdf.set_font("Helvetica", "B", 16)
+    pdf.set_font("DejaVu", "B", 16)
     pdf.cell(0, 10, clean_for_pdf("Payment Receipt"), ln=1, align="C")
-    pdf.set_font("Helvetica", size=10)
+    pdf.set_font("DejaVu", size=10)
     pdf.cell(
         0,
         6,

--- a/tests/test_enrollment_letter_pdf.py
+++ b/tests/test_enrollment_letter_pdf.py
@@ -33,3 +33,32 @@ def test_generate_enrollment_letter_pdf_returns_bytes(monkeypatch):
     assert len(pdf_bytes) > 0
     # Letterhead and watermark images should each trigger a download
     assert call_count["count"] == 2
+
+
+def test_generate_enrollment_letter_pdf_handles_unicode(monkeypatch):
+    class DummyResp:
+        content = PNG_BYTES
+
+        def raise_for_status(self):
+            return None
+
+    qr_calls = []
+
+    def fake_get(url, timeout=0):
+        return DummyResp()
+
+    def fake_qr(data):
+        qr_calls.append(data)
+        return PNG_BYTES
+
+    monkeypatch.setattr("src.assignment_ui.requests.get", fake_get)
+    monkeypatch.setattr("src.assignment_ui.make_qr_code", fake_qr)
+
+    name = "Jörg Müller"
+    level = "B2 – Fortgeschrittene"
+    pdf_bytes = generate_enrollment_letter_pdf(
+        name, level, "2024-01-01", "2024-06-30"
+    )
+    assert isinstance(pdf_bytes, (bytes, bytearray))
+    assert len(pdf_bytes) > 0
+    assert qr_calls == [f"{name}|{level}|2024-01-01|2024-06-30"]


### PR DESCRIPTION
## Summary
- Register and use DejaVu font for enrollment letters and receipts to support Unicode
- Replace all Helvetica font settings with DejaVu
- Add test ensuring Unicode names and levels render and encode into QR code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd6366b2008321b33c3d35a0fe3ed1