### PR TITLE
refactor: centralize clean_for_pdf helper

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -17,8 +17,8 @@ from fpdf import FPDF
 
 from .assignment import linkify_html, _clean_link, _is_http_url
 from .schedule import get_level_schedules as _get_level_schedules
-# ``load_school_logo`` is defined below; only import QR helper here.
-from .pdf_utils import make_qr_code
+# ``load_school_logo`` is defined below; import shared PDF helpers here.
+from .pdf_utils import make_qr_code, clean_for_pdf
 from .data_loading import load_student_data
 from .attendance_utils import load_attendance_records
 from .utils.currency import format_cedis
@@ -74,31 +74,6 @@ def score_label_fmt(score, *, plain: bool = False) -> str:
     if s >= 60:
         return "Sufficient ✔️" if not plain else "Sufficient"
     return "Needs Improvement ❗" if not plain else "Needs Improvement"
-
-
-def clean_for_pdf(text: str) -> str:
-    """Return ``text`` normalised and stripped of non-printable chars.
-
-    The previous implementation attempted to coerce all output to the
-    Latin-1 charset which caused characters like ``ä`` or ``ß`` to be
-    replaced with ``?``.  The updated version keeps the text in Unicode,
-    merely normalising it and dropping only characters that are not
-    printable so that PDF generation remains stable while user supplied
-    international text — including emoji — stays intact.
-    """
-
-    import unicodedata as _ud
-
-    if not isinstance(text, str):
-        text = str(text)
-    # Normalise to a canonical composed form so combined characters such as
-    # ``a\u0308`` become ``ä``.
-    text = _ud.normalize("NFKC", text)
-    # Replace line breaks with spaces to keep layout predictable.
-    text = text.replace("\n", " ").replace("\r", " ")
-    # Filter out any remaining non-printable characters.
-    text = "".join(ch for ch in text if ch.isprintable())
-    return text
 
 
 def load_school_logo() -> str:

--- a/src/pdf_handling.py
+++ b/src/pdf_handling.py
@@ -5,31 +5,13 @@ from __future__ import annotations
 import io
 from typing import Any, Dict, List
 
-import unicodedata as _ud
+from .pdf_utils import clean_for_pdf
 
 try:  # pragma: no cover - optional dependency
     from fpdf import FPDF
 except Exception:  # pragma: no cover
     FPDF = None  # type: ignore
 
-
-def clean_for_pdf(text: str) -> str:
-    """Return ``text`` normalised and stripped of non-printable characters.
-
-    ``fpdf`` can handle Unicode strings when provided with a suitable font.
-    This helper therefore no longer forces the text into Latin-1, keeping
-    characters such as ``ä`` or ``ß`` intact. The function simply normalises
-    the text and filters out any non-printable characters so that the layout
-    remains predictable while preserving all Unicode characters, including
-    emoji.
-    """
-
-    if not isinstance(text, str):
-        text = str(text)
-    text = _ud.normalize("NFKC", text)
-    text = text.replace("\n", " ").replace("\r", " ")
-    text = "".join(ch for ch in text if ch.isprintable())
-    return text
 
 def extract_text_from_pdf(pdf_bytes: bytes) -> str:
     """Return text extracted from PDF bytes using best-effort parsers."""

--- a/src/pdf_utils.py
+++ b/src/pdf_utils.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 import requests
+import unicodedata as _ud
 
 try:  # pragma: no cover - optional dependency
     import qrcode
@@ -29,6 +30,24 @@ LOGO_URL = "https://i.imgur.com/iFiehrp.png"
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 LOCAL_LOGO = PROJECT_ROOT / "logo.png"
 CACHE_LOGO = Path("/tmp/school_logo.png")
+
+
+def clean_for_pdf(text: str) -> str:
+    """Return ``text`` normalised and stripped of non-printable characters.
+
+    ``fpdf`` can handle Unicode strings when provided with a suitable font.
+    This helper therefore keeps the text in Unicode, normalising it and
+    removing only characters that are not printable so that PDF generation
+    remains stable while user supplied international text — including
+    emoji — stays intact.
+    """
+
+    if not isinstance(text, str):
+        text = str(text)
+    text = _ud.normalize("NFKC", text)
+    text = text.replace("\n", " ").replace("\r", " ")
+    text = "".join(ch for ch in text if ch.isprintable())
+    return text
 
 
 def make_qr_code(data: str) -> bytes:
@@ -78,4 +97,4 @@ def load_school_logo() -> Optional[str]:
         return None
 
 
-__all__ = ["make_qr_code", "load_school_logo"]
+__all__ = ["clean_for_pdf", "make_qr_code", "load_school_logo"]

--- a/tests/test_attendance_pdf_unicode.py
+++ b/tests/test_attendance_pdf_unicode.py
@@ -2,7 +2,7 @@ import zlib
 
 from fpdf import FPDF
 
-from src.assignment_ui import clean_for_pdf
+from src.pdf_utils import clean_for_pdf
 
 
 def test_attendance_pdf_preserves_unicode_and_emoji():

--- a/tests/test_clean_for_pdf.py
+++ b/tests/test_clean_for_pdf.py
@@ -1,4 +1,4 @@
-from src.assignment_ui import clean_for_pdf
+from src.pdf_utils import clean_for_pdf
 
 
 def test_clean_for_pdf_preserves_unicode_and_strips_control_chars():

--- a/tests/test_results_pdf_unicode.py
+++ b/tests/test_results_pdf_unicode.py
@@ -2,7 +2,7 @@ import zlib
 
 from fpdf import FPDF
 
-from src.assignment_ui import clean_for_pdf
+from src.pdf_utils import clean_for_pdf
 
 
 def test_pdf_cells_preserve_unicode():


### PR DESCRIPTION
## Summary
- add shared `clean_for_pdf` helper in `pdf_utils`
- use `clean_for_pdf` from `pdf_utils` in assignment and pdf handling modules
- update tests to import the unified helper

## Testing
- `ruff check src tests` *(fails: unused imports across repository)*
- `ruff check src/pdf_utils.py src/assignment_ui.py src/pdf_handling.py tests/test_attendance_pdf_unicode.py tests/test_clean_for_pdf.py tests/test_results_pdf_unicode.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6747d1048321a4a2f433270716a7