### PR TITLE
fix: resolve login template from repo root

### DIFF
--- a/src/ui/login.py
+++ b/src/ui/login.py
@@ -99,7 +99,11 @@ def inject_notice_css() -> None:
 @lru_cache(maxsize=1)
 def load_falowen_login_html() -> str:
     """Load and sanitize the Falowen login hero HTML template."""
-    path = Path(__file__).resolve().parent.parent / "templates" / "falowen_login.html"
+    path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "templates"
+        / "falowen_login.html"
+    )
     try:
         html = path.read_text(encoding="utf-8")
     except UnicodeDecodeError as exc:  # pragma: no cover - malformed file


### PR DESCRIPTION
## Summary
- load login HTML from repository-level templates directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd8c972c5483219d02c3d231c7d1f6