### PR TITLE
Add test verifying Falowen login template path

### DIFF
--- a/tests/test_falowen_login_template_path.py
+++ b/tests/test_falowen_login_template_path.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from src.ui.login import load_falowen_login_html
+
+
+def test_loads_real_template(monkeypatch):
+    """Ensure the real Falowen login template is used."""
+    # Use repository root as working directory so the function resolves the real template path
+    repo_root = Path(__file__).resolve().parent.parent
+    monkeypatch.chdir(repo_root)
+
+    load_falowen_login_html.cache_clear()
+    html = load_falowen_login_html()
+
+    assert "<h1>Falowen</h1>" in html
+    assert "Welcome to Falowen" in html
+    assert "class=\"features\"" in html


### PR DESCRIPTION
## Summary
- add test confirming `load_falowen_login_html` reads the real login template
- ensure the function works with repository root as working directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8d79d0148321b849c55f01183d07