### PR TITLE
Refactor cookie manager handling

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -177,6 +177,7 @@ from src.pdf_handling import (
 # Cookie manager
 # ------------------------------------------------------------------------------
 cookie_manager = get_cookie_manager()
+st.session_state["cookie_manager"] = cookie_manager
 
 # ------------------------------------------------------------------------------
 # Google OAuth (Gmail sign-in) — single-source, no duplicate buttons


### PR DESCRIPTION
## Summary
- Remove module-level cookie manager in `src/ui/auth`
- Read cookie manager from `st.session_state` and guard cookie operations
- Store global cookie manager instance in Streamlit session state for reuse

## Testing
- `ruff check src/ui/auth.py`
- `ruff check a1sprechen.py | head -n 5` (fails: existing warnings)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8f1511a083219ec825dd8763a33a