### PR TITLE
Gracefully handle Streamlit cache decorator changes

### DIFF
--- a/tests/test_config_import.py
+++ b/tests/test_config_import.py
@@ -1,0 +1,5 @@
+from src.config import get_cookie_manager
+
+
+def test_get_cookie_manager_importable():
+    assert callable(get_cookie_manager)


### PR DESCRIPTION
## Summary
- Use whichever Streamlit cache decorator is available and fall back gracefully
- Update comments about caching API changes
- Add smoke test importing `get_cookie_manager`

## Testing
- `ruff check src/config.py tests/test_config_import.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd92a359408321814045c6b34cf571