### PR TITLE
Warn when using fallback cookie password

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Deployment
 
-Set the cookie encryption password either in Streamlit secrets or via an environment variable:
+Set the cookie encryption password either in Streamlit secrets or via an environment variable. The password **must be a long, random value** (32+ characters) – short phrases are insecure:
 
 ```
 [secrets]
@@ -24,7 +24,7 @@ or
 export COOKIE_PASSWORD=<strong-secret>
 ```
 
-This value is required for secure cookie management.
+This value is required for secure cookie management. If it is omitted the app falls back to a built-in password intended only for tests and logs a warning. Never rely on the fallback in production.
 
 ## Usage
 

--- a/src/config.py
+++ b/src/config.py
@@ -71,7 +71,7 @@ def get_cookie_manager() -> EncryptedCookieManager:
         or _FALLBACK_COOKIE_PASSWORD
     )
 
-    if cookie_password == _FALLBACK_COOKIE_PASSWORD and os.getenv("DEBUG", "0") == "1":
+    if cookie_password == _FALLBACK_COOKIE_PASSWORD:
         logging.warning(
             "Using built-in fallback cookie password (set `cookie_password` or `COOKIE_PASSWORD` for production)."
         )

--- a/tests/test_cookie_password_warning.py
+++ b/tests/test_cookie_password_warning.py
@@ -1,0 +1,20 @@
+import importlib
+import logging
+
+
+def test_warning_emitted_when_fallback_cookie_password_used(monkeypatch, caplog):
+    # Ensure environment and secrets do not provide a password
+    monkeypatch.delenv("COOKIE_PASSWORD", raising=False)
+    monkeypatch.delenv("FALOWEN_COOKIE_FALLBACK", raising=False)
+
+    # Reload module to reset cached state
+    config = importlib.reload(importlib.import_module("src.config"))
+    monkeypatch.setattr(config.st, "secrets", {})
+
+    with caplog.at_level(logging.WARNING):
+        config.get_cookie_manager()
+
+    assert any(
+        "Using built-in fallback cookie password" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- always log a warning if the built-in cookie password fallback is used
- document the need for a strong `cookie_password`/`COOKIE_PASSWORD`
- add a test verifying the warning behavior

## Testing
- `ruff check src/config.py tests/test_cookie_password_warning.py`
- `pytest tests/test_cookie_password_warning.py tests/test_config_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9471864c83218f7b9a37498113d4