### PR TITLE
Add Google sign-in button to login hero

### DIFF
--- a/src/ui/login.py
+++ b/src/ui/login.py
@@ -128,6 +128,30 @@ def render_falowen_login(
         st.error("Falowen login template missing or unreadable.")
         logging.exception("Failed to load Falowen login HTML")
         return
+
+    if show_google_in_hero and google_auth_url:
+        from types import SimpleNamespace
+        from .. import ui_widgets
+
+        captured: dict[str, str] = {}
+
+        def _capture(markup: str, **_: object) -> None:
+            captured["html"] = markup
+
+        original_components = ui_widgets.components
+        ui_widgets.components = SimpleNamespace(html=_capture)
+        try:  # capture button HTML without rendering a separate component
+            ui_widgets.render_google_signin_once(google_auth_url, full_width=True)
+        finally:
+            ui_widgets.components = original_components
+        btn_html = captured.get("html")
+        if btn_html:
+            marker = '<p class="cta">👇 Scroll to sign in or create your account.</p>'
+            if marker in html:
+                html = html.replace(marker, f"{marker}\n        {btn_html}")
+            else:
+                html = html.replace("<section class=\"hero card\" data-animate>", f"<section class=\"hero card\" data-animate>{btn_html}")
+
     components.html(html, height=720, scrolling=True)
 
 __all__ = [

--- a/tests/test_render_falowen_login.py
+++ b/tests/test_render_falowen_login.py
@@ -19,9 +19,13 @@ def login_mod(monkeypatch):
     monkeypatch.setitem(sys.modules, "streamlit", st_mod)
     monkeypatch.setitem(sys.modules, "streamlit.components", components_mod)
     monkeypatch.setitem(sys.modules, "streamlit.components.v1", components_v1)
+    uiw = importlib.import_module("src.ui_widgets")
+    monkeypatch.setattr(uiw, "st", st_mod)
+    monkeypatch.setattr(uiw, "components", components_v1)
     mod = importlib.reload(importlib.import_module("src.ui.login"))
     mod.st = st_mod
     mod.components = components_v1
+    mod.ui_widgets = uiw
     return mod
 
 
@@ -69,3 +73,35 @@ def test_unicode_decode_error_raises_runtime_error(login_mod, monkeypatch):
     login_mod.load_falowen_login_html.cache_clear()
     with pytest.raises(RuntimeError, match="valid UTF-8"):
         login_mod.load_falowen_login_html()
+
+
+def test_google_button_injected_when_requested(login_mod, monkeypatch):
+    sample_html = (
+        '<section class="hero card" data-animate>'
+        '<h2>Welcome</h2>'
+        '<p class="cta">👇 Scroll to sign in or create your account.</p>'
+        '<div class="features"></div>'
+        '</section>'
+    )
+    monkeypatch.setattr(pathlib.Path, "read_text", lambda self, encoding="utf-8": sample_html)
+    login_mod.load_falowen_login_html.cache_clear()
+
+    captured = {}
+    login_mod.components.html = MagicMock(side_effect=lambda html, **kw: captured.update({"html": html}))
+
+    monkeypatch.setattr(
+        login_mod.ui_widgets,
+        "render_google_signin_once",
+        MagicMock(wraps=login_mod.ui_widgets.render_google_signin_once),
+    )
+    login_mod.render_falowen_login("https://auth.example", show_google_in_hero=True)
+
+    login_mod.ui_widgets.render_google_signin_once.assert_called_once_with(
+        "https://auth.example", full_width=True
+    )
+    out = captured.get("html", "")
+    assert "Continue with Google" in out
+    cta = out.index("create your account.")
+    btn = out.index("Continue with Google")
+    features = out.index('<div class="features">')
+    assert cta < btn < features


### PR DESCRIPTION
## Summary
- Inject a Google sign-in button into the Falowen login hero when requested
- Test and verify Google button insertion in login hero

## Testing
- `ruff check src/ui/login.py tests/test_render_falowen_login.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd98e801a48321856253add9f271d2