### PR TITLE
Reindex dictionary filters

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5539,10 +5539,13 @@ if tab == "Vocab Trainer":
 
             mask = (g_contains | e_contains) if match_mode=="Contains" else (g_starts | e_starts) if match_mode=="Starts with" else (g_exact | e_exact)
             if mask.any():
-                df_view = df_view[mask].copy().reset_index(drop=True)
-                exact_mask  = (g_exact | e_exact)
-                starts_mask = (g_starts | e_starts)
-                top_row = df_view[exact_mask].iloc[0] if exact_mask.any() else df_view[starts_mask].iloc[0] if starts_mask.any() else df_view.iloc[0]
+                exact_mask = (g_exact | e_exact) & mask
+                starts_mask = (g_starts | e_starts) & mask
+                df_view = df_view[mask].reset_index(drop=True)
+                exact_mask = exact_mask[mask].reset_index(drop=True)
+                starts_mask = starts_mask[mask].reset_index(drop=True)
+                if not df_view.empty:
+                    top_row = df_view[exact_mask].iloc[0] if exact_mask.any() else df_view[starts_mask].iloc[0] if starts_mask.any() else df_view.iloc[0]
             else:
                 vocab_all = df_view["German"].astype(str).unique().tolist()
                 suggestions = difflib.get_close_matches(q, vocab_all, n=5, cutoff=0.72)


### PR DESCRIPTION
## Summary
- Recompute exact and start match masks after filtering dictionary entries
- Reindex masks to align with filtered view and guard top row lookup on empty results

## Testing
- `ruff check a1sprechen.py` *(fails: Module level import not at top of file, found 107 errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda67b0ed083218852daa5414bd101