### PR TITLE
Enhance answer matching with fuzzy similarity

### DIFF
--- a/tests/test_is_correct_answer.py
+++ b/tests/test_is_correct_answer.py
@@ -21,3 +21,9 @@ def test_is_correct_answer_handles_case_and_spaces():
     assert fn(" Hallo ", "hallo")
     assert fn("HALLO", "hallo")
     assert not fn("Tschüss", "hallo")
+
+
+def test_is_correct_answer_articles_and_similarity():
+    fn = _load_is_correct_answer()
+    assert fn("the intersection", "intersection")
+    assert not fn("roundabout", "intersection")


### PR DESCRIPTION
## Summary
- Improve `is_correct_answer` with normalization, article stripping, and fuzzy similarity via `SequenceMatcher`
- Extend tests for article handling and mismatched answers

## Testing
- `ruff check tests/test_is_correct_answer.py`
- `pytest tests/test_is_correct_answer.py`


------
https://chatgpt.com/codex/tasks/task_e_68bda82cfd5c8321bfffb4dd949aef6e