### PR TITLE
Wrap vocab practice input and button in Streamlit form

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5461,8 +5461,14 @@ if tab == "Vocab Trainer":
                 unsafe_allow_html=True
             )
 
-            usr = st.text_input(f"{word} = ?", key=f"vt_input_{idx}", placeholder="Type your answer here...")
-            if usr and st.button("Check", key=f"vt_check_{idx}"):
+            with st.form(key=f"vt_form_{idx}"):
+                usr = st.text_input(
+                    f"{word} = ?",
+                    key=f"vt_input_{idx}",
+                    placeholder="Type your answer here...",
+                )
+                submitted = st.form_submit_button("Check")
+            if submitted:
                 st.session_state.vt_history.append(("user", usr))
                 if is_correct_answer(usr, answer):
                     st.session_state.vt_score += 1


### PR DESCRIPTION
## Summary
- Wrap Vocab Practice text input and check button in a Streamlit form
- Submit typed answer and button action together using `st.form_submit_button`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdaa3f00c88321931aaf1bdc991667