### PR TITLE
Use toast notification for login helpers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -342,7 +342,7 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
 
           <div class="row">
             <label class="inline"><input type="checkbox" name="remember" /> Remember me</label>
-            <a href="#" onclick="alert('Password reset flow coming soon.'); return false;">Forgot password?</a>
+            <a href="#" id="forgotPassword">Forgot password?</a>
           </div>
 
           <button class="btn btn-primary" type="submit" id="loginBtn">
@@ -350,48 +350,71 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
             Sign In
           </button>
 
-          <button class="btn btn-ghost" type="button" onclick="alert('SSO coming soon')">Sign in with Google</button>
+          <button class="btn btn-ghost" type="button" id="googleSignin">Sign in with Google</button>
         </form>
         <p class="legal">By continuing, you agree to our <a href="#" style="color:var(--accent); text-decoration:none; font-weight:600">Terms</a> and <a href="#" style="color:var(--accent); text-decoration:none; font-weight:600">Privacy Policy</a>.</p>
       </aside>
     </div>
-  </div>
+    </div>
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
 
-  <script>
-    // Password toggle
-    const pass = document.getElementById('password');
-    const toggle = document.getElementById('togglePass');
-    const eyeOpen = document.getElementById('eyeOpen');
-    const eyeClosed = document.getElementById('eyeClosed');
-    toggle?.addEventListener('click', () => {
-      const isHidden = pass.type === 'password';
-      pass.type = isHidden ? 'text' : 'password';
-      eyeOpen.style.display = isHidden ? 'none' : '';
-      eyeClosed.style.display = isHidden ? '' : 'none';
-    });
-  
-// Accessibility-friendly submit handling
-const loginBtn = document.getElementById('loginBtn');
-if (loginBtn) {
-  loginBtn.addEventListener('click', () => {
-    const form = loginBtn.closest('form') || document;
-    if (!loginBtn.hasAttribute('data-busy')) {
-      loginBtn.setAttribute('data-busy', '1');
-      loginBtn.disabled = true;
-      const prevText = loginBtn.innerText;
-      loginBtn.setAttribute('data-prev', prevText);
-      loginBtn.innerText = 'Signing in…';
-      // Re-enable after 8s safety timeout in case of network issues
-      setTimeout(() => {
-        if (loginBtn.disabled) {
-          loginBtn.disabled = false;
-          loginBtn.innerText = loginBtn.getAttribute('data-prev') || 'Sign in';
-          loginBtn.removeAttribute('data-busy');
+          <script>
+        // Password toggle
+        const pass = document.getElementById('password');
+        const toggle = document.getElementById('togglePass');
+        const eyeOpen = document.getElementById('eyeOpen');
+        const eyeClosed = document.getElementById('eyeClosed');
+        toggle?.addEventListener('click', () => {
+          const isHidden = pass.type === 'password';
+          pass.type = isHidden ? 'text' : 'password';
+          eyeOpen.style.display = isHidden ? 'none' : '';
+          eyeClosed.style.display = isHidden ? '' : 'none';
+        });
+
+        // Accessibility-friendly submit handling
+        const loginBtn = document.getElementById('loginBtn');
+        if (loginBtn) {
+          loginBtn.addEventListener('click', () => {
+            const form = loginBtn.closest('form') || document;
+            if (!loginBtn.hasAttribute('data-busy')) {
+              loginBtn.setAttribute('data-busy', '1');
+              loginBtn.disabled = true;
+              const prevText = loginBtn.innerText;
+              loginBtn.setAttribute('data-prev', prevText);
+              loginBtn.innerText = 'Signing in…';
+              // Re-enable after 8s safety timeout in case of network issues
+              setTimeout(() => {
+                if (loginBtn.disabled) {
+                  loginBtn.disabled = false;
+                    loginBtn.innerText = loginBtn.getAttribute('data-prev') || 'Sign in';
+                  loginBtn.removeAttribute('data-busy');
+                }
+              }, 8000);
+            }
+          });
         }
-      }, 8000);
-    }
-  });
-}
-</script>
+
+        const toast = document.getElementById('toast');
+        function showToast(message) {
+          if (!toast) return;
+          toast.textContent = message;
+          toast.classList.add('show');
+          setTimeout(() => {
+            toast.classList.remove('show');
+            toast.textContent = '';
+          }, 3000);
+        }
+
+        const forgot = document.getElementById('forgotPassword');
+        forgot?.addEventListener('click', (e) => {
+          e.preventDefault();
+          showToast('Password reset flow coming soon.');
+        });
+
+        const google = document.getElementById('googleSignin');
+        google?.addEventListener('click', () => {
+          showToast('SSO coming soon');
+        });
+      </script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -271,3 +271,20 @@ html[lang="de"] a:hover, html[lang="de"] button:hover { transform: translateY(-1
 html[lang="de"] .muted { margin-top: 10px; font-size: .92rem; color: var(--sub); }
 html[lang="de"] .status { margin-top: 12px; font-size: .92rem; }
 html[lang="de"] .tips { margin-top: 12px; font-size: .9rem; color: var(--sub); }
+
+.toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: var(--card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  box-shadow: var(--shadow);
+  display: none;
+}
+
+.toast.show {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- Remove inline click handlers in login form
- Add toast component and JavaScript listeners for password reset and Google SSO
- Style toast element

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68bdbb6f82048321a623eedd88ae9b75