### PR TITLE
feat: add skip link for login pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,19 @@ button:focus-visible, input:focus-visible, textarea:focus-visible {
   outline-offset: 2px;
 }
 .err { color: var(--error); font-size: 0.9rem; }
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 0;
+      background: #fff;
+      color: #000;
+      padding: 8px 12px;
+      z-index: 100;
+      border-radius: 4px;
+    }
+    .skip-link:focus {
+      top: 8px;
+    }
 /* Disabled button state */
 button[disabled] { opacity: .6; cursor: not-allowed; }
 :root{
@@ -251,12 +264,13 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
   <link rel="icon" href="/logo.svg" type="image/svg+xml" />
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <div class="brand-header" style="display:flex;align-items:center;gap:12px;padding:16px 20px">
     <img src="/logo.svg" alt="Falowen logo" width="120" height="32" />
   </div>
 
   <div class="decorations" aria-hidden="true"></div>
-  <div class="shell">
+  <main id="main-content" class="shell">
 
     <header class="header">
       <div class="brand">
@@ -355,7 +369,7 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
         <p class="legal">By continuing, you agree to our <a href="#" style="color:var(--accent); text-decoration:none; font-weight:600">Terms</a> and <a href="#" style="color:var(--accent); text-decoration:none; font-weight:600">Privacy Policy</a>.</p>
       </aside>
     </div>
-    </div>
+  </main>
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
 
           <script>

--- a/templates/falowen_login.html
+++ b/templates/falowen_login.html
@@ -28,6 +28,8 @@
         linear-gradient(180deg, var(--bg) 0%, #0b1324 100%);
       -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
     }
+    .skip-link{position:absolute;top:-40px;left:0;background:#fff;color:#000;padding:8px 12px;z-index:100;border-radius:4px}
+    .skip-link:focus{top:8px}
     .decorations::before,.decorations::after{
       content:"";position:fixed;inset:auto auto 10% -120px;width:380px;height:380px;
       background:radial-gradient(circle at 30% 30%, rgba(14,165,233,0.45), transparent 60%),
@@ -70,8 +72,9 @@
   </style>
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <div class="decorations" aria-hidden="true"></div>
-  <div class="shell">
+  <main id="main-content" class="shell">
     <header class="header">
       <div class="brand">
         <div class="badge">F</div>
@@ -127,7 +130,7 @@
         </div>
       </section>
     </div>
-  </div>
+  </main>
   <script>
     window.addEventListener("load", () => {
       fetch("/auth/refresh", { credentials: "include" }).catch(console.error);


### PR DESCRIPTION
## Summary
- add visually-hidden "Skip to main content" links
- wrap login pages with `<main id="main-content">`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdbdf0a4988321a68f3af76919ac87