### PR TITLE
Improve touch responsiveness for UI dots

### DIFF
--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -28,7 +28,7 @@ def _load_vocab_sheet(sheet_id: str = VOCAB_SHEET_ID) -> Optional[pd.DataFrame]:
     url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv"
     try:
         return pd.read_csv(url)
-    except Exception as exc:  # pragma: no cover - network or parsing issues
+    except Exception:  # pragma: no cover - network or parsing issues
         logging.exception("Failed to load vocabulary sheet")
         return None
 
@@ -139,7 +139,7 @@ def render_vocab_lookup(key: str) -> None:
             if audio_url:
                 try:  # pragma: no cover - best effort on mobile browsers
                     st.audio(audio_url)
-                except Exception as exc:
+                except Exception:
                     logging.exception("Failed to play audio")
 
 
@@ -251,7 +251,7 @@ def render_reviews() -> None:
 
       .rev-dots{ display:flex; gap:6px; justify-content:center; margin-top:10px; }
       .rev-dot{
-        width:8px; height:8px; border-radius:999px; background:#cbd5e1; border:none; padding:0; cursor:pointer;
+        width:8px; height:8px; border-radius:999px; background:#cbd5e1; border:none; padding:0; cursor:pointer; touch-action:manipulation;
       }
       .rev-dot[aria-current="true"]{ background:#25317e; }
       .fade{ opacity:0; transform:translateY(4px); transition:opacity .28s ease, transform .28s ease; }
@@ -288,6 +288,13 @@ def render_reviews() -> None:
         });
       }
 
+      function bindQuick(el, handler){
+        el.addEventListener("click", handler);
+        el.addEventListener("pointerdown", (e)=>{
+          if(e.pointerType !== "mouse"){ e.preventDefault(); handler(); }
+        });
+      }
+
       function setDots(){
         dots.innerHTML = "";
         DATA.forEach((_, idx) => {
@@ -295,7 +302,7 @@ def render_reviews() -> None:
           b.className = "rev-dot";
           b.setAttribute("aria-label", "Go to review " + (idx+1));
           if(idx === i) b.setAttribute("aria-current","true");
-          b.addEventListener("click", () => { i = idx; show(true); restart(); });
+          bindQuick(b, () => { i = idx; show(true); restart(); });
           dots.appendChild(b);
         });
       }
@@ -329,8 +336,8 @@ def render_reviews() -> None:
       function stop(){ if(timer){ clearInterval(timer); timer = null; } }
       function restart(){ stop(); start(); }
 
-      nextBtn.addEventListener("click", () => { next(); restart(); });
-      prevBtn.addEventListener("click", () => { prev(); restart(); });
+      bindQuick(nextBtn, () => { next(); restart(); });
+      bindQuick(prevBtn, () => { prev(); restart(); });
       wrap.addEventListener("mouseenter", () => { hovered = true; });
       wrap.addEventListener("mouseleave", () => { hovered = false; });
 

--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -156,7 +156,7 @@ def render_announcements(announcements: list) -> None:
       .ann-actions{margin-top:8px}
       .ann-actions a{color:var(--link);text-decoration:none;font-weight:700}
       .ann-dots{display:flex;gap:12px;justify-content:center;margin-top:12px}
-      .ann-dot{width:11px;height:11px;border-radius:999px;background:#9ca3af;opacity:.9;transform:scale(.95);border:none;cursor:pointer;}
+      .ann-dot{width:11px;height:11px;border-radius:999px;background:#9ca3af;opacity:.9;transform:scale(.95);border:none;cursor:pointer;touch-action:manipulation;}
       .ann-dot[aria-current="true"]{background:var(--brand);opacity:1;transform:scale(1.22);box-shadow:0 0 0 4px var(--ring)}
     </style>
     <div class="page-wrap">
@@ -188,8 +188,13 @@ def render_announcements(announcements: list) -> None:
           actionEl.textContent=''; actionEl.appendChild(link); actionEl.style.display=''; } else { actionEl.textContent=''; actionEl.style.display='none'; }
         setActiveDot(idx);
       }
+      function bindQuick(el, handler){
+        el.addEventListener('click', handler);
+        el.addEventListener('pointerdown', (e)=>{ if(e.pointerType!=='mouse'){ e.preventDefault(); handler(); }});
+      }
+
       data.forEach((_, idx)=>{ const b=document.createElement('button'); b.className='ann-dot'; b.type='button'; b.setAttribute('role','tab');
-        b.setAttribute('aria-label','Slide '+(idx+1)); b.setAttribute('tabindex','0'); b.addEventListener('click', ()=>{ i=idx; render(i); });
+        b.setAttribute('aria-label','Slide '+(idx+1)); b.setAttribute('tabindex','0'); bindQuick(b, ()=>{ i=idx; render(i); });
         b.addEventListener('keydown', (e)=>{ if(e.key==='Enter'||e.key===' '||e.key==='Spacebar'){ e.preventDefault(); i=idx; render(i); }});
         dotsWrap.appendChild(b); });
       render(i);


### PR DESCRIPTION
## Summary
- Add `pointerdown` handlers alongside `click` for review navigation dots and buttons
- Attach the same quick-click behavior to announcement carousel dots
- Set `touch-action: manipulation` on `.rev-dot` and `.ann-dot` to remove mobile delay

## Testing
- `ruff check src/ui_components.py src/ui_widgets.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdbf7a40408321bc31d1ed7d46ce3d