### PR TITLE
Disable offline retry button while checking connection

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -32,11 +32,18 @@
       tipEl.textContent = online ? 'Verbunden – Seite lädt gleich neu …' : 'WLAN/Mobilfunk prüfen oder später erneut versuchen.';
       if (online) setTimeout(() => location.reload(), 700);
     }
+    const retryText = retryBtn.textContent;
     retryBtn.addEventListener('click', async () => {
+      retryBtn.disabled = true;
+      retryBtn.textContent = '⏳';
       try {
         const res = await fetch('/manifest.webmanifest', { cache: 'no-store' });
         if (res.ok) location.reload(); else setStatus();
       } catch { setStatus(); }
+      finally {
+        retryBtn.textContent = retryText;
+        retryBtn.disabled = false;
+      }
     });
     addEventListener('online', setStatus);
     addEventListener('offline', setStatus);


### PR DESCRIPTION
## Summary
- disable the offline retry button before attempting a fetch
- show a simple spinner and re-enable the button after the network check

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdc10657d48321b63e46376ad57218