### PR TITLE
Remove duplicate returning user login heading

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -250,7 +250,6 @@ def login_page():
     render_falowen_login(auth_url, show_google_in_hero=False)
 
     # 3) Returning user section (Google CTA below the form)
-    st.markdown("### Returning user login")
     login_success = render_returning_login_area()
     render_google_brand_button_once(auth_url, center=True)
     if login_success:


### PR DESCRIPTION
## Summary
- Remove extra "Returning user login" heading from `login_page` so `render_returning_login_area()` renders the section header.

## Testing
- `pytest`
- `ruff check a1sprechen.py src/ui/auth.py` *(fails: 107 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc2ae6d04832193b8d201c507ae37