### PR TITLE
Add toast helper utilities

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -88,6 +88,7 @@ from src.contracts import (
 )
 from src.services.contracts import contract_active
 from src.utils.currency import format_cedis
+from src.utils.toasts import toast_ok
 from src.firestore_utils import (
     _draft_doc_ref,
     load_chat_draft_from_db,
@@ -5953,7 +5954,7 @@ if tab == "Schreiben Trainer":
 
         if st.button("\U0001f4be Save Draft", key=f"save_draft_btn_{student_code}"):
             save_now(draft_key, student_code)
-            st.toast("Draft saved!", icon="\U0001f4be")
+            toast_ok("Draft saved!")
         st.caption("Auto-saves every few seconds or click 'Save Draft' to save now.")
 
         def clear_feedback_and_start_new():
@@ -6491,7 +6492,7 @@ if tab == "Schreiben Trainer":
 
             if st.button("\U0001f4be Save Draft", key=f"save_prompt_draft_btn_{student_code}"):
                 save_now(draft_key, student_code)
-                st.toast("Draft saved!", icon="\U0001f4be")
+                toast_ok("Draft saved!")
             st.caption("Auto-saves every few seconds or click 'Save Draft' to save now.")
 
             saved_at = st.session_state.get(f"{draft_key}_saved_at")
@@ -6617,7 +6618,7 @@ if tab == "Schreiben Trainer":
             if col_save.button("\U0001f4be Save Draft", key=ns("save_letter_draft_btn")):
                 st.session_state[letter_draft_key] = letter_draft
                 save_now(letter_draft_key, student_code)
-                st.toast("Draft saved!", icon="\U0001f4be")
+                toast_ok("Draft saved!")
 
             if send:
                 user_input = st.session_state[draft_key].strip()

--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -1,0 +1,23 @@
+import streamlit as st
+
+
+def toast_ok(msg: str) -> None:
+    """Show a success toast message.
+
+    Parameters
+    ----------
+    msg:
+        The message to display.
+    """
+    st.toast(msg, icon="✅")
+
+
+def toast_err(msg: str) -> None:
+    """Show an error toast message.
+
+    Parameters
+    ----------
+    msg:
+        The message to display.
+    """
+    st.toast(msg, icon="❌")

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+import types
+
+from src.utils import toasts
+
+
+def test_toast_ok(monkeypatch):
+    mock_st = types.SimpleNamespace(toast=MagicMock())
+    monkeypatch.setattr(toasts, "st", mock_st)
+    toasts.toast_ok("hello")
+    mock_st.toast.assert_called_once_with("hello", icon="✅")
+
+
+def test_toast_err(monkeypatch):
+    mock_st = types.SimpleNamespace(toast=MagicMock())
+    monkeypatch.setattr(toasts, "st", mock_st)
+    toasts.toast_err("oops")
+    mock_st.toast.assert_called_once_with("oops", icon="❌")


### PR DESCRIPTION
## Summary
- provide `toast_ok` and `toast_err` helpers wrapping `st.toast`
- use `toast_ok` in draft save actions in main app
- cover new helpers with unit tests

## Testing
- `pytest tests/test_toasts.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdc3335cc08321a2ebbce3a56fe5df