### PR TITLE
feat: reuse loaded assignment scores

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1029,7 +1029,7 @@ if tab == "Dashboard":
         _rank_text = "Complete 3+ assignments to be ranked"
         _lead_chip = "<span class='pill pill-amber'>Not ranked yet</span>"
 
-    _summary = get_assignment_summary(_student_code, _level)
+    _summary = get_assignment_summary(_student_code, _level, _df_assign)
     _missed_list = _summary.get("missed", [])
     _next_lesson = _summary.get("next")
 

--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -159,7 +159,11 @@ def _get_current_student() -> Tuple[str, str, str]:
     return code, name, level
 
 
-def get_assignment_summary(student_code: str, level: str) -> dict:
+def get_assignment_summary(
+    student_code: str,
+    level: str,
+    scores_df: pd.DataFrame | None = None,
+) -> dict:
     """Return missed assignments and next recommendation for a student.
 
     Parameters
@@ -168,6 +172,9 @@ def get_assignment_summary(student_code: str, level: str) -> dict:
         The student's unique code.
     level: str
         The level to check (e.g., "A1").
+    scores_df: pandas.DataFrame, optional
+        Pre-loaded assignment scores. When omitted, ``load_assignment_scores`` is
+        used to fetch the data.
 
     Returns
     -------
@@ -176,10 +183,13 @@ def get_assignment_summary(student_code: str, level: str) -> dict:
         or ``None``).
     """
 
-    try:
-        df = load_assignment_scores()
-    except Exception:
-        return {"missed": [], "next": None}
+    if scores_df is None:
+        try:
+            df = load_assignment_scores()
+        except Exception:
+            return {"missed": [], "next": None}
+    else:
+        df = scores_df
 
     if df.empty or not {"studentcode", "assignment", "level"}.issubset(df.columns):
         return {"missed": [], "next": None}

--- a/tests/test_assignment_summary_filters.py
+++ b/tests/test_assignment_summary_filters.py
@@ -19,10 +19,9 @@ def test_next_assignment_skips_goethe_and_final_cap(monkeypatch):
             "date": ["2024-01-01"],
         }
     )
-    monkeypatch.setattr(assignment_ui, "load_assignment_scores", lambda: df)
     monkeypatch.setattr(assignment_ui, "_get_level_schedules", lambda: {"A1": schedule})
 
-    summary = assignment_ui.get_assignment_summary("s1", "A1")
+    summary = assignment_ui.get_assignment_summary("s1", "A1", df)
     assert summary["missed"] == []
     assert summary["next"]["day"] == 4
 
@@ -42,9 +41,8 @@ def test_missed_assignments_skip_goethe(monkeypatch):
             "date": ["2024-01-01"],
         }
     )
-    monkeypatch.setattr(assignment_ui, "load_assignment_scores", lambda: df)
     monkeypatch.setattr(assignment_ui, "_get_level_schedules", lambda: {"A1": schedule})
 
-    summary = assignment_ui.get_assignment_summary("s1", "A1")
+    summary = assignment_ui.get_assignment_summary("s1", "A1", df)
     assert summary["missed"] == []
     assert summary["next"]["day"] == 3


### PR DESCRIPTION
## Summary
- allow `get_assignment_summary` to accept preloaded score DataFrames
- pass existing assignment scores in `a1sprechen` to avoid redundant loads
- update assignment summary tests to use the new parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdc4e72b508321a6624dfb8e95d8c0