### PR TITLE
Use requests to load vocab sheet with timeout

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -618,7 +618,12 @@ def _load_full_vocab_sheet_cached():
     SHEET_ID = "1I1yAnqzSh3DPjwWRh9cdRSfzNSPsi7o4r5Taj9Y36NU"
     csv_url = f"https://docs.google.com/spreadsheets/d/{SHEET_ID}/export?format=csv&gid=0"
     try:
-        df = pd.read_csv(csv_url, dtype=str)
+        resp = requests.get(csv_url, timeout=8)
+        resp.raise_for_status()
+        df = pd.read_csv(io.StringIO(resp.text), dtype=str)
+    except requests.RequestException as e:
+        st.error(f"Could not load vocab sheet: {e}")
+        return pd.DataFrame(columns=["level", "german", "english", "example"])
     except Exception:
         st.error("Could not load vocab sheet.")
         return pd.DataFrame(columns=["level", "german", "english", "example"])

--- a/tests/test_vocab_sheet_timeout.py
+++ b/tests/test_vocab_sheet_timeout.py
@@ -1,0 +1,40 @@
+import ast
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import requests
+import io
+
+
+def _get_vocab_loader():
+    source = Path('a1sprechen.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    func_node = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == '_load_full_vocab_sheet_cached')
+    func_src = ast.get_source_segment(source, func_node)
+
+    st_mod = types.SimpleNamespace(
+        cache_data=lambda *a, **k: (lambda f: f),
+        error=MagicMock(),
+        session_state={},
+    )
+
+    module = types.ModuleType('tmp')
+    module.pd = pd
+    module.requests = requests
+    module.io = io
+    module.st = st_mod
+
+    exec(func_src, module.__dict__)
+    return module, st_mod
+
+
+def test_load_vocab_sheet_timeout(monkeypatch):
+    module, st_mod = _get_vocab_loader()
+    monkeypatch.setattr(module.requests, 'get', MagicMock(side_effect=requests.Timeout('boom')))
+    df = module._load_full_vocab_sheet_cached()
+    assert df.empty
+    assert list(df.columns) == ['level', 'german', 'english', 'example']
+    st_mod.error.assert_called_once()
+    assert 'Could not load vocab sheet' in st_mod.error.call_args[0][0]


### PR DESCRIPTION
## Summary
- load vocab sheet via requests with timeout for better error handling
- add unit test verifying timeout fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdc62da2988321b6f08b1e2dbab99a