### PR TITLE
Handle case-insensitive attendance lookup

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -983,7 +983,8 @@ if tab == "Dashboard":
         
     st.divider()
     # ---------- 3) Motivation mini-cards (streak / vocab / leaderboard) ----------
-    _student_code = (st.session_state.get("student_code", "") or "").strip().lower()
+    _student_code_raw = (st.session_state.get("student_code", "") or "").strip()
+    _student_code = _student_code_raw.lower()
     _df_assign = load_assignment_scores()
     _df_assign["date"] = pd.to_datetime(_df_assign["date"], errors="coerce").dt.date
     _mask_student = _df_assign["studentcode"].str.lower().str.strip() == _student_code
@@ -1067,8 +1068,10 @@ if tab == "Dashboard":
         _next_sub = ""
     _class_name = str(safe_get(student_row, "ClassName", "")).strip()
     _att_sessions, _att_hours = (0, 0.0)
-    if _class_name and _student_code:
-        _att_sessions, _att_hours = fetch_attendance_summary(_student_code, _class_name)
+    if _class_name and _student_code_raw:
+        _att_sessions, _att_hours = fetch_attendance_summary(
+            _student_code_raw, _class_name
+        )
     _attendance_chip = (
         f"<span class='pill pill-purple'>{_att_sessions} sessions • {_att_hours:.1f}h</span>"
     )

--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -331,6 +331,7 @@ def fetch_attendance_summary(student_code: str, class_name: str) -> tuple[int, f
             .document(class_name)
             .collection("sessions")
         )
+        student_code_norm = student_code.strip().lower()
         count = 0
         hours = 0.0
         for snap in sessions_ref.stream():
@@ -342,7 +343,10 @@ def fetch_attendance_summary(student_code: str, class_name: str) -> tuple[int, f
             else:
                 attendees = data
             if isinstance(attendees, dict):
-                entry = attendees.get(student_code)
+                attendees_norm = {
+                    str(k).strip().lower(): v for k, v in attendees.items()
+                }
+                entry = attendees_norm.get(student_code_norm)
                 if isinstance(entry, dict) and "present" in entry:
                     if bool(entry.get("present")):
                         count += 1
@@ -350,17 +354,18 @@ def fetch_attendance_summary(student_code: str, class_name: str) -> tuple[int, f
                             hours += float(entry.get("hours", 1) or 0)
                         except Exception:
                             pass
-                elif student_code in attendees:
+                elif student_code_norm in attendees_norm:
                     count += 1
                     try:
-                        hours += float(attendees.get(student_code, 0) or 0)
+                        hours += float(attendees_norm.get(student_code_norm, 0) or 0)
                     except Exception:
                         pass
             elif isinstance(attendees, list):
                 for item in attendees:
                     if (
                         isinstance(item, dict)
-                        and item.get("code") == student_code
+                        and str(item.get("code", "")).strip().lower()
+                        == student_code_norm
                         and bool(item.get("present", True))
                     ):
                         count += 1


### PR DESCRIPTION
## Summary
- Pass raw student codes to attendance summary instead of forcing lowercase
- Normalize student codes within `fetch_attendance_summary` for case-insensitive matching
- Add regression test for mixed-case student codes

## Testing
- ⚠️ `ruff check a1sprechen.py src/firestore_utils.py tests/test_firestore_utils.py` (fails: Module level import not at top of file, unused imports, and other lint errors)
- ✅ `ruff check src/firestore_utils.py tests/test_firestore_utils.py`
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdc801c9348321a2422329c66aab7f