### PR TITLE
Ensure sidebar visible by default

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -50,8 +50,10 @@ register_health_route(app)
 
 ICON_PATH = Path(__file__).parent / "static/icons/falowen-512.png"
 
-# Determine desired sidebar state and apply it early so users can recover the menu
-_sb_state = st.session_state.get("sidebar_state", "expanded")
+# Ensure the sidebar starts visible on first load and remember user's choice
+if "sidebar_state" not in st.session_state:
+    st.session_state["sidebar_state"] = "expanded"
+_sb_state = st.session_state["sidebar_state"]
 
 st.set_page_config(
     page_title="Falowen – Your German Conversation Partner",


### PR DESCRIPTION
## Summary
- Guarantee Streamlit sidebar starts expanded by setting default state on first load

## Testing
- `pytest`
- `ruff check a1sprechen.py` *(fails: E402 Module level import not at top of file, F401 unused imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdca04216c8321a9d11703e13fa739