### PR TITLE
Handle unsupported characters in chat PDF generation

### DIFF
--- a/tests/test_chat_pdf_unicode.py
+++ b/tests/test_chat_pdf_unicode.py
@@ -1,0 +1,14 @@
+import pytest
+
+from src.pdf_handling import FPDF, generate_chat_pdf
+
+
+@pytest.mark.skipif(FPDF is None, reason="fpdf not installed")
+def test_generate_chat_pdf_handles_unicode_and_emoji():
+    messages = [
+        {"role": "assistant", "content": "Hello 😊"},
+        {"role": "user", "content": "Numbers: ①②③"},
+    ]
+    pdf_bytes = generate_chat_pdf(messages)
+    assert isinstance(pdf_bytes, bytes)
+    assert len(pdf_bytes) > 0


### PR DESCRIPTION
## Summary
- Sanitize chat messages before writing to PDF
- Retry PDF generation without unsupported characters to avoid IndexError
- Test chat PDF generation with emoji and unusual characters

## Testing
- `ruff check src/pdf_handling.py tests/test_chat_pdf_unicode.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdcdda5428832194efcecb704f156a