### PR TITLE
Centralize PDF font path

### DIFF
--- a/src/pdf_handling.py
+++ b/src/pdf_handling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+from pathlib import Path
 from typing import Any, Dict, List
 
 from .pdf_utils import clean_for_pdf
@@ -11,6 +12,9 @@ try:  # pragma: no cover - optional dependency
     from fpdf import FPDF
 except Exception:  # pragma: no cover
     FPDF = None  # type: ignore
+
+
+FONT_PATH = Path(__file__).resolve().parent.parent / "font/DejaVuSans.ttf"
 
 
 def extract_text_from_pdf(pdf_bytes: bytes) -> str:
@@ -38,7 +42,7 @@ def extract_text_from_pdf(pdf_bytes: bytes) -> str:
 
 def generate_notes_pdf(
     notes: List[Dict[str, Any]],
-    font_path: str = "./font/DejaVuSans.ttf",
+    font_path: str = str(FONT_PATH),
 ) -> bytes:
     """Return a PDF containing the provided notes."""
     if FPDF is None:  # pragma: no cover - dependency missing
@@ -82,7 +86,7 @@ def generate_notes_pdf(
 
 def generate_single_note_pdf(
     note: Dict[str, Any],
-    font_path: str = "./font/DejaVuSans.ttf",
+    font_path: str = str(FONT_PATH),
 ) -> bytes:
     """Return a PDF for a single note."""
     if FPDF is None:  # pragma: no cover - dependency missing
@@ -115,7 +119,7 @@ def generate_chat_pdf(messages: List[Dict[str, Any]]) -> bytes:
 
     def _build_pdf(msgs: List[Dict[str, Any]]) -> "FPDF":
         pdf = FPDF()
-        pdf.add_font("DejaVu", "", "./font/DejaVuSans.ttf", uni=True)
+        pdf.add_font("DejaVu", "", str(FONT_PATH), uni=True)
         pdf.add_page()
         pdf.set_font("DejaVu", size=12)
         for m in msgs:

--- a/tests/test_attendance_pdf_unicode.py
+++ b/tests/test_attendance_pdf_unicode.py
@@ -2,12 +2,13 @@ import zlib
 
 from fpdf import FPDF
 
+from src.pdf_handling import FONT_PATH
 from src.pdf_utils import clean_for_pdf
 
 
 def test_attendance_pdf_preserves_unicode_and_emoji():
     pdf = FPDF()
-    pdf.add_font("DejaVu", "", "font/DejaVuSans.ttf", uni=True)
+    pdf.add_font("DejaVu", "", str(FONT_PATH), uni=True)
     pdf.add_page()
     pdf.set_font("DejaVu", "", 12)
     txt = clean_for_pdf("Schüler 😊")

--- a/tests/test_results_pdf_unicode.py
+++ b/tests/test_results_pdf_unicode.py
@@ -2,12 +2,13 @@ import zlib
 
 from fpdf import FPDF
 
+from src.pdf_handling import FONT_PATH
 from src.pdf_utils import clean_for_pdf
 
 
 def test_pdf_cells_preserve_unicode():
     pdf = FPDF()
-    pdf.add_font("DejaVu", "", "font/DejaVuSans.ttf", uni=True)
+    pdf.add_font("DejaVu", "", str(FONT_PATH), uni=True)
     pdf.add_page()
     pdf.set_font("DejaVu", "", 12)
     # Text with umlauts and ß
@@ -29,7 +30,7 @@ def test_pdf_cells_preserve_unicode():
 
 def test_pdf_cells_preserve_emoji():
     pdf = FPDF()
-    pdf.add_font("DejaVu", "", "font/DejaVuSans.ttf", uni=True)
+    pdf.add_font("DejaVu", "", str(FONT_PATH), uni=True)
     pdf.add_page()
     pdf.set_font("DejaVu", "", 12)
     emoji_txt = clean_for_pdf("Emoji 😊")


### PR DESCRIPTION
## Summary
- centralize PDF font path in `pdf_handling` via `FONT_PATH`
- update unicode PDF tests to use shared `FONT_PATH`

## Testing
- `ruff check src/pdf_handling.py tests/test_attendance_pdf_unicode.py tests/test_results_pdf_unicode.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdcee890548321a380d3b50f2bcb00