### PR TITLE
Add save confirmation toast in send flow

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6615,6 +6615,7 @@ if tab == "Schreiben Trainer":
             if send:
                 user_input = st.session_state[draft_key].strip()
                 save_now(draft_key, student_code)
+                toast_ok("Saved!")
 
             else:
                 user_input = ""


### PR DESCRIPTION
## Summary
- Show a success toast after sending saves a letter draft

## Testing
- `ruff check a1sprechen.py` *(fails: 108 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdcfb1d8f8832192233543bdde92a4