### PR TITLE
feat: add refresh helper for save actions

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -108,7 +108,7 @@ from src.contracts import (
 )
 from src.services.contracts import contract_active
 from src.utils.currency import format_cedis
-from src.utils.toasts import toast_ok
+from src.utils.toasts import toast_ok, refresh_with_toast
 from src.firestore_utils import (
     _draft_doc_ref,
     load_chat_draft_from_db,
@@ -1353,7 +1353,7 @@ if tab == "Dashboard":
                 )
                 if st.button("Got it — hide this notice for today", key=f"btn_contract_alert_{_student_code}"):
                     st.session_state[_alert_key] = True
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
 
     # ---------- Class schedules ----------
     with st.expander("🗓️ Class Schedule & Upcoming Sessions", expanded=False):
@@ -1715,18 +1715,18 @@ if tab == "My Course":
     if st.session_state.get("__go_classroom"):
         st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
         del st.session_state["__go_classroom"]
-        st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+        refresh_with_toast()
 
     if st.session_state.get("__go_notes"):
         st.session_state["coursebook_subtab"] = "📒 Learning Notes"
         del st.session_state["__go_notes"]
-        st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+        refresh_with_toast()
 
     # Backward-compat: older code may still set this
     if st.session_state.get("switch_to_notes"):
         st.session_state["coursebook_subtab"] = "📒 Learning Notes"
         del st.session_state["switch_to_notes"]
-        st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+        refresh_with_toast()
 
     # First run default
     if "coursebook_subtab" not in st.session_state:
@@ -2499,7 +2499,7 @@ if tab == "My Course":
                             if has_existing_submission(student_level, code, lesson_key):
                                 st.session_state[locked_key] = True
                                 st.warning("You have already submitted this assignment. It is locked.")
-                                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                refresh_with_toast()
                             else:
                                 st.info("Found an old lock without a submission — recovering and submitting now…")
 
@@ -2595,7 +2595,7 @@ if tab == "My Course":
                                 )
 
                             # Rerun so hydration path immediately shows locked view
-                            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                            refresh_with_toast()
                         else:
                             # 4) Failure: remove the lock doc so student can retry cleanly
                             try:
@@ -3658,7 +3658,7 @@ if tab == "My Course":
                     )
                     st.session_state["__clear_q_form"] = True
                     st.success("Post published!")
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
 
 
             colsa, colsb, colsc = st.columns([2, 1, 1])
@@ -3668,7 +3668,7 @@ if tab == "My Course":
                 show_latest = st.toggle("Newest first", value=True, key="q_show_latest")
             with colsc:
                 if st.button("↻ Refresh", key="qna_refresh"):
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
 
             try:
                 try:
@@ -3735,7 +3735,7 @@ if tab == "My Course":
                 st.session_state[saved_flag_key] = False
                 st.session_state[saved_at_key] = None
                 st.success("Comment sent!")
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
 
             if not questions:
                 st.info("No posts yet.")
@@ -3787,12 +3787,12 @@ if tab == "My Course":
                                     f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC"
                                 )
                                 st.success("Post deleted.")
-                                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                refresh_with_toast()
                         with qc3:
                             pin_label = "📌 Unpin" if q.get("pinned") else "📌 Pin"
                             if st.button(pin_label, key=f"q_pin_btn_{q_id}"):
                                 board_base.document(q_id).update({"pinned": not q.get("pinned", False)})
-                                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                refresh_with_toast()
 
                         if st.session_state.get(f"q_editing_{q_id}", False):
                             with st.form(f"q_edit_form_{q_id}"):
@@ -3830,10 +3830,10 @@ if tab == "My Course":
                                     )
                                     st.session_state[f"q_editing_{q_id}"] = False
                                     st.success("Post updated.")
-                                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                    refresh_with_toast()
                             if cancel_edit:
                                 st.session_state[f"q_editing_{q_id}"] = False
-                                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                refresh_with_toast()
 
                     c_ref = board_base.document(q_id).collection("comments")
                     try:
@@ -3870,7 +3870,7 @@ if tab == "My Course":
                                             f"*When:* {_dt.now(_timezone.utc).strftime('%Y-%m-%d %H:%M')} UTC"
                                         )
                                         st.success("Comment deleted.")
-                                        st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                        refresh_with_toast()
 
                                 if st.session_state.get(f"c_editing_{q_id}_{cid}", False):
                                     with st.form(f"c_edit_form_{q_id}_{cid}"):
@@ -3895,10 +3895,10 @@ if tab == "My Course":
                                         )
                                         st.session_state[f"c_editing_{q_id}_{cid}"] = False
                                         st.success("Comment updated.")
-                                        st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                        refresh_with_toast()
                                     if ccancel:
                                         st.session_state[f"c_editing_{q_id}_{cid}"] = False
-                                        st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                        refresh_with_toast()
 
                     draft_key = f"classroom_comment_draft_{q_id}"
                     last_val_key, last_ts_key, saved_flag_key, saved_at_key = _draft_state_keys(draft_key)
@@ -4096,7 +4096,7 @@ if tab == "My Course":
                         del st.session_state[k]
 
                 st.session_state["switch_to_library"] = True
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
 
         elif notes_subtab == "📚 My Notes Library":
             st.markdown("#### 📚 All My Notes")
@@ -4246,27 +4246,27 @@ if tab == "My Course":
                             st.session_state["edit_note_text"] = note["text"]
                             st.session_state["edit_note_tag"] = note.get("tag", "")
                             st.session_state["switch_to_edit_note"] = True
-                            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                            refresh_with_toast()
                     with cols[1]:
                         if st.button("🗑️ Delete", key=f"del_{i}"):
                             notes.remove(note)
                             st.session_state[key_notes] = notes
                             save_notes_to_db(student_code, notes)
                             st.success("Note deleted.")
-                            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                            refresh_with_toast()
                     with cols[2]:
                         if note.get("pinned"):
                             if st.button("📌 Unpin", key=f"unpin_{i}"):
                                 note["pinned"] = False
                                 st.session_state[key_notes] = notes
                                 save_notes_to_db(student_code, notes)
-                                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                refresh_with_toast()
                         else:
                             if st.button("📍 Pin", key=f"pin_{i}"):
                                 note["pinned"] = True
                                 st.session_state[key_notes] = notes
                                 save_notes_to_db(student_code, notes)
-                                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                                refresh_with_toast()
                     with cols[3]:
                         st.caption("")
 
@@ -4328,7 +4328,7 @@ def back_step():
             st.session_state.pop(extra, None)
     st.session_state["_falowen_loaded"] = False
     st.session_state["falowen_stage"] = 1
-    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+    refresh_with_toast()
 
 # --- CONFIG (same doc, no duplicate db init) ---
 exam_sheet_id = "1zaAT5NjRGKiITV7EpuSHvYMBHHENMs9Piw3pNcyQtho"
@@ -4796,7 +4796,7 @@ if tab == "Exams Mode & Custom Chat":
                     st.session_state["falowen_teil"] = None
                     st.session_state["falowen_messages"] = []
                     st.session_state["custom_topic_intro_done"] = False
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
 
 
 
@@ -4810,7 +4810,7 @@ if tab == "Exams Mode & Custom Chat":
                 st.session_state["falowen_stage"] = 1
                 st.session_state["falowen_messages"] = []
                 st.session_state["_falowen_loaded"] = False
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
         with col2:
             if st.button("Next ➡️", key="falowen_next_level"):
                 if st.session_state.get("falowen_level"):
@@ -4818,7 +4818,7 @@ if tab == "Exams Mode & Custom Chat":
                     st.session_state["falowen_teil"] = None
                     st.session_state["falowen_messages"] = []
                     st.session_state["custom_topic_intro_done"] = False
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
         st.stop()
 
     # ——— Step 3: Exam Part or Lesen/Hören links ———
@@ -4881,7 +4881,7 @@ if tab == "Exams Mode & Custom Chat":
             if st.button("⬅️ Back", key="lesen_hoeren_back"):
                 st.session_state["falowen_stage"] = 2
                 st.session_state["falowen_messages"] = []
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
 
         else:
             # Topic picker (your format: "Topic/Prompt" + "Keyword/Subtopic")
@@ -4935,7 +4935,7 @@ if tab == "Exams Mode & Custom Chat":
                 if st.button("⬅️ Back", key="falowen_back_part"):
                     st.session_state["falowen_stage"]    = 2
                     st.session_state["falowen_messages"] = []
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
             with col_start:
                 if st.button("Start Practice", key="falowen_start_practice"):
                     st.session_state["falowen_teil"]            = teil
@@ -4944,7 +4944,7 @@ if tab == "Exams Mode & Custom Chat":
                     st.session_state["custom_topic_intro_done"] = False
                     student_code = st.session_state.get("student_code")
                     save_exam_progress(student_code, [{"level": level, "teil": teil, "topic": topic}])
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
 
 
     # ——— Step 4: Chat (Exam or Custom) ———
@@ -5195,7 +5195,7 @@ if tab == "Exams Mode & Custom Chat":
                         st.session_state.pop(k, None)
                     st.session_state["falowen_stage"] = 1
                     st.success("All chat history deleted.")
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
         with col2:
             if st.button("⬅️ Back", key=_wkey("btn_back_stage4")):
                 save_now(draft_key, student_code)
@@ -5243,7 +5243,7 @@ if tab == "Exams Mode & Custom Chat":
                 _entered = _norm_code(_entered)
                 if _entered:
                     st.session_state["student_code"] = _entered
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
             st.stop()
 
         try:
@@ -5286,7 +5286,7 @@ if tab == "Exams Mode & Custom Chat":
 
         if st.button("⬅️ Back to Start"):
             st.session_state["falowen_stage"] = 1
-            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+            refresh_with_toast()
 
 # =========================================
 # End
@@ -5420,7 +5420,7 @@ if tab == "Vocab Trainer":
         if st.button("🔁 Start New Practice", key="vt_reset"):
             for k in defaults:
                 st.session_state[k] = defaults[k]
-            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+            refresh_with_toast()
 
         if st.session_state.vt_total is None:
             with st.form("vt_setup"):
@@ -5453,7 +5453,7 @@ if tab == "Vocab Trainer":
                 ]
                 st.session_state.vt_saved = False
                 st.session_state.vt_session_id = str(uuid4())
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
         else:
             st.markdown("### Daily Practice Setup")
             st.info(
@@ -5461,7 +5461,7 @@ if tab == "Vocab Trainer":
             )
             if st.button("Change goal", key="vt_change_goal"):
                 st.session_state.vt_total = None
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
 
         tot = st.session_state.vt_total
         idx = st.session_state.vt_index
@@ -5521,7 +5521,7 @@ if tab == "Vocab Trainer":
                     fb = f"❌ Nope. '{word}' = '{answer}'"
                 st.session_state.vt_history.append(("assistant", fb))
                 st.session_state.vt_index += 1
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
 
         if isinstance(tot, int) and idx >= tot:
             score = st.session_state.vt_score
@@ -5541,11 +5541,11 @@ if tab == "Vocab Trainer":
                         session_id=st.session_state.vt_session_id
                     )
                 st.session_state.vt_saved = True
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
             if st.button("Practice Again", key="vt_again"):
                 for k in defaults:
                     st.session_state[k] = defaults[k]
-                st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                refresh_with_toast()
 
     # ===========================
     # SUBTAB: Dictionary  (download-only audio)
@@ -5659,7 +5659,7 @@ if tab == "Vocab Trainer":
                 with bcols[i]:
                     if st.button(s, key=f"sugg_{i}"):
                         st.session_state["dict_q"] = s
-                        st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                        refresh_with_toast()
 
         with st.expander(f"Browse all words at level {student_level_locked}", expanded=False):
             df_show = df_view[["German","English"]].copy()

--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -22,6 +22,7 @@ from .pdf_utils import make_qr_code, clean_for_pdf
 from .data_loading import load_student_data
 from .attendance_utils import load_attendance_records
 from .utils.currency import format_cedis
+from src.utils.toasts import refresh_with_toast
 
 # URLs for letterhead and watermark images are configurable via environment
 # variables so deployments can easily swap in different assets without touching
@@ -489,7 +490,7 @@ def render_results_and_resources_tab() -> None:
         if st.button("🔄 Refresh"):
             st.cache_data.clear()
             st.success("Cache cleared! Reloading…")
-            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+            refresh_with_toast()
 
     df_scores = fetch_scores(GOOGLE_SHEET_CSV)
     required_cols = {

--- a/src/sentence_builder.py
+++ b/src/sentence_builder.py
@@ -12,6 +12,7 @@ import streamlit as st
 
 from src.config import SB_SESSION_TARGET
 from src.sentence_bank import SENTENCE_BANK
+from src.utils.toasts import refresh_with_toast
 
 
 def _normalize_join(tokens: Iterable[str]) -> str:
@@ -157,7 +158,7 @@ def render_sentence_builder(student_code: str, student_level_locked: str) -> Non
                     disabled=selected,
                 ):
                     st.session_state.sb_selected_idx.append(i)
-                    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+                    refresh_with_toast()
 
     chosen_tokens = [
         st.session_state.sb_shuffled[i] for i in st.session_state.sb_selected_idx
@@ -171,7 +172,7 @@ def render_sentence_builder(student_code: str, student_level_locked: str) -> Non
             st.session_state.sb_selected_idx = []
             st.session_state.sb_feedback = ""
             st.session_state.sb_correct = None
-            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+            refresh_with_toast()
     with b:
         if st.button("✅ Check"):
             target_sentence = st.session_state.sb_current.get("target_de", "").strip()
@@ -195,7 +196,7 @@ def render_sentence_builder(student_code: str, student_level_locked: str) -> Non
                 correct=correct,
                 tip=st.session_state.sb_current.get("hint_en", ""),
             )
-            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+            refresh_with_toast()
     with c:
         next_disabled = st.session_state.sb_correct is None
         if st.button("➡️ Next", disabled=next_disabled):
@@ -204,7 +205,7 @@ def render_sentence_builder(student_code: str, student_level_locked: str) -> Non
                     f"Session complete! Score: {st.session_state.sb_score}/{st.session_state.sb_total}"
                 )
             new_sentence()
-            st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+            refresh_with_toast()
 
     if st.session_state.sb_feedback:
         (st.success if st.session_state.sb_correct else st.info)(

--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -27,6 +27,7 @@ from src.data_loading import load_student_data
 from src.session_management import determine_level
 from src.ui_helpers import qp_get, qp_clear
 from src.services.contracts import contract_active
+from src.utils.toasts import refresh_with_toast
 
 # Google OAuth configuration
 GOOGLE_CLIENT_ID = st.secrets.get(
@@ -187,7 +188,7 @@ def render_login_form(login_id: str, login_pass: str) -> bool:
             logging.exception("Cookie save failed")
 
     st.success(f"Welcome, {student_row['Name']}!")
-    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+    refresh_with_toast()
     return True
 
 
@@ -403,7 +404,7 @@ def _handle_google_oauth(code: str, state: str) -> None:
 
         qp_clear()
         st.success(f"Welcome, {student_row['Name']}!")
-        st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+        refresh_with_toast()
         st.rerun()
 
     except Exception as e:  # pragma: no cover - network errors

--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -21,3 +21,14 @@ def toast_err(msg: str) -> None:
         The message to display.
     """
     st.toast(msg, icon="❌")
+
+
+def refresh_with_toast() -> None:
+    """Increment ``__refresh`` and show a saved toast.
+
+    This helper centralises the common pattern of bumping the
+    ``__refresh`` counter in ``st.session_state`` to trigger a
+    rerender and informing the user that their action was saved.
+    """
+    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+    toast_ok("Saved!")

--- a/tests/test_back_step.py
+++ b/tests/test_back_step.py
@@ -2,6 +2,7 @@ import ast
 from types import SimpleNamespace
 
 from src.draft_management import _draft_state_keys
+from src.utils import toasts
 
 
 def _load_back_step():
@@ -13,8 +14,13 @@ def _load_back_step():
     ]
     module_ast = ast.Module(body=funcs, type_ignores=[])
     code = compile(module_ast, "a1sprechen.py", "exec")
-    st = SimpleNamespace(session_state={})
-    glb = {"st": st, "_draft_state_keys": _draft_state_keys}
+    st = SimpleNamespace(session_state={}, toast=lambda *a, **k: None)
+    toasts.st = st
+    glb = {
+        "st": st,
+        "_draft_state_keys": _draft_state_keys,
+        "refresh_with_toast": toasts.refresh_with_toast,
+    }
     exec(code, glb)
     return glb["back_step"], st
 

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -16,3 +16,11 @@ def test_toast_err(monkeypatch):
     monkeypatch.setattr(toasts, "st", mock_st)
     toasts.toast_err("oops")
     mock_st.toast.assert_called_once_with("oops", icon="❌")
+
+
+def test_refresh_with_toast(monkeypatch):
+    mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
+    monkeypatch.setattr(toasts, "st", mock_st)
+    toasts.refresh_with_toast()
+    mock_st.toast.assert_called_once_with("Saved!", icon="✅")
+    assert mock_st.session_state["__refresh"] == 1


### PR DESCRIPTION
## Summary
- add `refresh_with_toast` utility to bump `__refresh` and show "Saved!" toast
- replace direct `__refresh` increments with helper across app
- cover helper with unit test and adjust back-step test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd0cc2d74832195e5cd9dc04c1fa8