### PR TITLE
Persist cookie deletions on logout

### DIFF
--- a/src/logout.py
+++ b/src/logout.py
@@ -30,6 +30,10 @@ def do_logout(
             except Exception:
                 logger.exception("Token revoke failed on logout")
         clear_session_fn(cookie_manager)
+        try:
+            cookie_manager.save()
+        except Exception:
+            logger.exception("Cookie save failed")
     except Exception:
         logger.exception("Cookie/session clear failed")
     st_module.session_state.update(

--- a/tests/test_logout_rerenders_google_button.py
+++ b/tests/test_logout_rerenders_google_button.py
@@ -60,3 +60,18 @@ def test_logout_rerenders_components():
     mock_components.html.reset_mock()
     ui_widgets.render_google_signin_once("https://auth.example")
     mock_components.html.assert_called_once()
+
+
+def test_logout_saves_cookie_changes():
+    mock_st = types.SimpleNamespace(session_state={}, success=MagicMock())
+    cookie_manager = types.SimpleNamespace(save=MagicMock())
+    clear_session = MagicMock()
+    do_logout(
+        cookie_manager,
+        st_module=mock_st,
+        destroy_token=MagicMock(),
+        clear_session_fn=clear_session,
+        logger=types.SimpleNamespace(exception=MagicMock()),
+    )
+    clear_session.assert_called_once_with(cookie_manager)
+    cookie_manager.save.assert_called_once()


### PR DESCRIPTION
## Summary
- Ensure logout persists cookie deletions by saving the cookie manager with error handling.
- Verify logout saves cookie changes via a new test using a mock cookie manager.

## Testing
- `ruff check src/logout.py tests/test_logout_rerenders_google_button.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd27257a88321b062563ca4b04dee