### PR TITLE
Use direct Streamlit rerun after logout

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -66,21 +66,15 @@ st.set_page_config(
 inject_global_styles()
 
 
-if st.session_state.get("_needs_rerun"):
-    st.info("Refreshed")
-    st.session_state.pop("_needs_rerun", None)
-    st.rerun()
-
-
 def _reopen_sidebar() -> None:
     """Force the sidebar open and rerun the app."""
     st.session_state["sidebar_state"] = "expanded"
-    st.session_state["_needs_rerun"] = True
+    st.rerun()
 
 
 def _collapse_sidebar() -> None:
     st.session_state["sidebar_state"] = "collapsed"
-    st.session_state["_needs_rerun"] = True
+    st.rerun()
 
 
 if st.session_state.get("sidebar_state") == "collapsed":
@@ -471,7 +465,7 @@ def render_sidebar_published():
         st.session_state["nav_sel"] = tab_name
         st.session_state["main_tab_select"] = tab_name
         _qp_set_safe(tab=tab_name)
-        st.session_state["_needs_rerun"] = True
+        st.rerun()
 
     def _go_post_qna():
         st.session_state["nav_sel"] = "My Course"
@@ -479,7 +473,7 @@ def render_sidebar_published():
         st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
         st.session_state["classroom_page"] = "Class Notes & Q&A"
         _qp_set_safe(tab="My Course")
-        st.session_state["_needs_rerun"] = True
+        st.rerun()
 
     st.sidebar.markdown("## Quick access")
     st.sidebar.button("🏠 Dashboard",                use_container_width=True, on_click=_go, args=("Dashboard",))
@@ -884,7 +878,7 @@ if tab == "Dashboard":
         st.session_state["classroom_page"] = "Class Notes & Q&A"
         st.session_state["classroom_prev_page"] = "Class Notes & Q&A"
         _qp_set(tab="My Course")
-        st.session_state["_needs_rerun"] = True
+        st.rerun()
 
     def _go_attendance() -> None:
         st.session_state["nav_sel"] = "My Course"
@@ -894,7 +888,7 @@ if tab == "Dashboard":
         st.session_state["classroom_page"] = "Attendance"
         st.session_state["classroom_prev_page"] = "Attendance"
         _qp_set(tab="My Course")
-        st.session_state["_needs_rerun"] = True
+        st.rerun()
 
     st.button("View class board", on_click=_go_classboard)
 

--- a/src/logout.py
+++ b/src/logout.py
@@ -52,5 +52,5 @@ def do_logout(
     for k in list(st_module.session_state.keys()):
         if k.startswith("__google_btn_rendered::"):
             st_module.session_state.pop(k, None)
-    st_module.session_state["_needs_rerun"] = True
     st_module.success("You’ve been logged out.")
+    st_module.rerun()

--- a/tests/test_logout_clears_ann_flag.py
+++ b/tests/test_logout_clears_ann_flag.py
@@ -12,3 +12,4 @@ def test_ann_flag_reset_after_logout():
     )
     do_logout({}, st_module=mock_st, destroy_token=MagicMock(), clear_session_fn=MagicMock(), logger=types.SimpleNamespace(exception=MagicMock()))
     assert "_ann_hash" not in mock_st.session_state
+    mock_st.rerun.assert_called_once()

--- a/tests/test_logout_rerenders_google_button.py
+++ b/tests/test_logout_rerenders_google_button.py
@@ -61,9 +61,11 @@ def test_logout_rerenders_components():
     ui_widgets.render_google_signin_once("https://auth.example")
     mock_components.html.assert_called_once()
 
+    mock_st.rerun.assert_called_once()
+
 
 def test_logout_saves_cookie_changes():
-    mock_st = types.SimpleNamespace(session_state={}, success=MagicMock())
+    mock_st = types.SimpleNamespace(session_state={}, success=MagicMock(), rerun=MagicMock())
     cookie_manager = types.SimpleNamespace(save=MagicMock())
     clear_session = MagicMock()
     do_logout(
@@ -75,3 +77,4 @@ def test_logout_saves_cookie_changes():
     )
     clear_session.assert_called_once_with(cookie_manager)
     cookie_manager.save.assert_called_once()
+    mock_st.rerun.assert_called_once()


### PR DESCRIPTION
## Summary
- Replace `_needs_rerun` flag with a direct `st.rerun()` in the logout utility
- Remove rerun flag logic and use `st.rerun()` across navigation helpers
- Update logout tests to expect immediate reruns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd3e362748321bf5a2190a93c6a7b