### PR TITLE
Capture cookie manager before logout

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -407,12 +407,13 @@ def render_logged_in_topbar():
                 unsafe_allow_html=True
             )
         with c2:
+            cm = st.session_state["cookie_manager"]
             st.button(
                 "Log out",
                 key="logout_global",
                 type="primary",
                 use_container_width=True,
-                on_click=lambda: do_logout(st.session_state["cookie_manager"]),
+                on_click=lambda cm=cm: do_logout(cm),
             )
 
     level_key = (level or "").strip().upper()


### PR DESCRIPTION
## Summary
- Store session cookie manager before rendering logout button
- Pass stored cookie manager into `do_logout` callback to avoid stale reference

## Testing
- `ruff check a1sprechen.py` (fails: many existing style errors)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd52383188321b59f58460cb46779