### PR TITLE
Reuse existing chat drafts via Firestore current_conv

### DIFF
--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -169,11 +169,14 @@ def save_chat_draft_to_db(code: str, conv_key: str, text: str) -> None:
     if db is None:
         return
     ref = db.collection("falowen_chats").document(code)
+    mode_level_teil = conv_key.rsplit("_", 1)[0]
     try:
+        updates = {"current_conv": {mode_level_teil: conv_key}}
         if text:
-            ref.set({"drafts": {conv_key: text}}, merge=True)
+            updates["drafts"] = {conv_key: text}
         else:
-            ref.set({"drafts": {conv_key: firestore.DELETE_FIELD}}, merge=True)
+            updates["drafts"] = {conv_key: firestore.DELETE_FIELD}
+        ref.set(updates, merge=True)
     except Exception as exc:  # pragma: no cover - runtime depends on Firestore
         logging.warning("Failed to save chat draft for %s/%s: %s", code, conv_key, exc)
         return


### PR DESCRIPTION
## Summary
- Reuse saved conversation drafts by looking up the current `mode_level_teil` in Firestore before generating a new conversation key
- Track the active conversation in `save_chat_draft_to_db` via a new `current_conv` field
- Load stored draft text on every run to keep the text area populated
- Test coverage for saving chat drafts updates `current_conv`

## Testing
- `ruff check a1sprechen.py src/firestore_utils.py tests/test_firestore_utils.py tests/test_firestore_utils_failures.py` *(fails: existing style errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be139b59448321890432688903be83