### PR TITLE
Add session renewal helper and tests

### DIFF
--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -38,7 +38,49 @@ GOOGLE_CLIENT_SECRET = st.secrets.get("GOOGLE_CLIENT_SECRET", "GOCSPX-K7F-d8oy4_
 REDIRECT_URI = st.secrets.get("GOOGLE_REDIRECT_URI", "https://www.falowen.app/")
 
 
+def renew_session_if_needed() -> None:
+    """Refresh session cookie and mapping if a token is present."""
+    token = st.session_state.get("session_token")
+    if not token:
+        return
+
+    try:
+        from falowen.sessions import (
+            refresh_or_rotate_session_token,
+            validate_session_token,
+        )
+
+        data = validate_session_token(token) or {}
+        if not data:
+            return
+
+        new_token = refresh_or_rotate_session_token(token)
+    except Exception:
+        logging.exception("Session renewal failed")
+        return
+
+    if new_token and new_token != token:
+        st.session_state["session_token"] = new_token
+        token = new_token
+
+    student_code = st.session_state.get("student_code") or data.get("student_code", "")
+    persist_session_client(token, student_code)
+
+    cm = st.session_state.get("cookie_manager")
+    if cm:
+        set_session_token_cookie(
+            cm, token, expires=datetime.now(UTC) + timedelta(days=30)
+        )
+        try:
+            cm.save()
+        except Exception:
+            logging.exception("Cookie save failed")
+
+
 def render_signup_form() -> None:
+    _renew = globals().get("renew_session_if_needed")
+    if _renew:
+        _renew()
     with st.form("signup_form", clear_on_submit=False):
         new_name = st.text_input("Full Name", key="ca_name")
         new_email = st.text_input(
@@ -88,6 +130,9 @@ def render_signup_form() -> None:
 
 
 def render_login_form(login_id: str, login_pass: str) -> bool:
+    _renew = globals().get("renew_session_if_needed")
+    if _renew:
+        _renew()
     login_id = (login_id or "").strip().lower()
     login_pass = login_pass or ""
     if not (login_id and login_pass):
@@ -193,6 +238,9 @@ def render_login_form(login_id: str, login_pass: str) -> bool:
 
 
 def render_forgot_password_panel() -> None:
+    _renew = globals().get("renew_session_if_needed")
+    if _renew:
+        _renew()
     st.markdown("##### Forgot password")
     email_for_reset = st.text_input("Registered email", key="reset_email")
     c3, c4 = st.columns([0.55, 0.45])
@@ -246,6 +294,9 @@ def render_forgot_password_panel() -> None:
 
 def render_returning_login_area() -> bool:
     """Email/Password login + optional forgot-password panel. No Google button here."""
+    _renew = globals().get("renew_session_if_needed")
+    if _renew:
+        _renew()
     with st.form("returning_login_form", clear_on_submit=False):
         st.markdown("#### Returning user login")
         login_id = st.text_input("Email or Student Code")
@@ -441,6 +492,9 @@ def render_google_oauth(return_url: bool = True) -> Optional[str]:
 
 def render_returning_login_form() -> bool:
     """Simplified returning-user login form used in tests."""
+    _renew = globals().get("renew_session_if_needed")
+    if _renew:
+        _renew()
     with st.form("returning_login_form", clear_on_submit=False):
         login_id = st.text_input("Email or Student Code")
         login_pass = st.text_input("Password", type="password")

--- a/tests/test_session_renew_helper.py
+++ b/tests/test_session_renew_helper.py
@@ -1,0 +1,63 @@
+import sys
+import types
+from datetime import datetime, timedelta, UTC
+
+import streamlit as st
+
+# Stub falowen.sessions before importing module under test
+stub_sessions = types.SimpleNamespace(
+    create_session_token=lambda *a, **k: "tok",
+    destroy_session_token=lambda *a, **k: None,
+    refresh_or_rotate_session_token=lambda tok: tok,
+    validate_session_token=lambda tok, ua_hash="": {"student_code": "abc"},
+)
+sys.modules["falowen.sessions"] = stub_sessions
+
+from src.auth import (
+    SimpleCookieManager,
+    set_session_token_cookie,
+    clear_session_clients,
+    get_session_client,
+)
+from src.ui.auth import renew_session_if_needed
+
+
+def setup_function(function):
+    st.session_state.clear()
+    clear_session_clients()
+
+
+def test_cookie_expiry_refreshed_and_mapping_persisted():
+    cm = SimpleCookieManager()
+    st.session_state.update(
+        {"session_token": "tok123", "student_code": "abc", "cookie_manager": cm}
+    )
+    set_session_token_cookie(
+        cm, "tok123", expires=datetime.now(UTC) + timedelta(days=1)
+    )
+    old_expiry = cm.store["session_token"]["kwargs"]["expires"]
+
+    renew_session_if_needed()
+
+    new_expiry = cm.store["session_token"]["kwargs"]["expires"]
+    assert new_expiry > old_expiry
+    assert get_session_client("tok123") == "abc"
+
+
+def test_token_rotation_updates_state_cookie_and_mapping(monkeypatch):
+    cm = SimpleCookieManager()
+    st.session_state.update(
+        {"session_token": "old", "student_code": "abc", "cookie_manager": cm}
+    )
+    set_session_token_cookie(cm, "old", expires=datetime.now(UTC) + timedelta(days=1))
+
+    monkeypatch.setattr(
+        stub_sessions, "refresh_or_rotate_session_token", lambda tok: "new"
+    )
+
+    renew_session_if_needed()
+
+    assert st.session_state["session_token"] == "new"
+    assert cm["session_token"] == "new"
+    assert get_session_client("new") == "abc"
+    assert get_session_client("old") is None


### PR DESCRIPTION
## Summary
- add `renew_session_if_needed` to refresh session tokens, persist mappings, and renew cookies
- call session renewal across auth UI entry points
- test that session renewal updates cookie expiry and token mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec6bd65188321b32948b7bc454989