### PR TITLE
Add SoftwareApplication schema to login page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#25317e" />
   <title>Falowen Login</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Falowen",
+    "applicationCategory": "EducationalApplication",
+    "operatingSystem": "Web",
+    "url": "https://www.falowen.app/",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Learn Language Education Academy",
+      "url": "https://www.learngermanghana.com/"
+    },
+    "sameAs": [
+      "https://www.learngermanghana.com/",
+      "https://www.falowen.app/",
+      "https://register.falowen.app/",
+      "https://www.instagram.com/lleaghana/",
+      "https://www.youtube.com/@LLEAGhana",
+      "https://www.tiktok.com/@lleaghana",
+      "https://www.linkedin.com/in/lleaghana/"
+    ]
+  }
+  </script>
   <!-- Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- embed JSON-LD SoftwareApplication schema for Falowen on login page

## Testing
- `python -m pytest`
- `ruff check .` *(fails: Found 130 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bef4932bb88321a402be4a2f73dade