### PR TITLE
Add SoftwareApplication schema and quick-access social links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#25317e" />
   <title>Falowen Login</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Falowen",
+    "applicationCategory": "EducationalApplication",
+    "operatingSystem": "Web",
+    "url": "https://www.falowen.app/",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Learn Language Education Academy",
+      "url": "https://www.learngermanghana.com/"
+    },
+    "sameAs": [
+      "https://www.learngermanghana.com/",
+      "https://www.falowen.app/",
+      "https://register.falowen.app/",
+      "https://www.instagram.com/lleaghana/",
+      "https://www.youtube.com/@LLEAGhana",
+      "https://www.tiktok.com/@lleaghana",
+      "https://www.linkedin.com/in/lleaghana/"
+    ]
+  }
+  </script>
   <!-- Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -253,6 +277,19 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
 
     .legal { margin-top: 12px; color: var(--muted); font-size: .85rem; line-height: 1.5; }
 
+    .quick-access {
+      margin-top: 24px;
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .quick-access a {
+      color: var(--primary);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
     /* Animations */
     [data-animate] { opacity: 0; transform: translateY(10px); animation: fadeUp .6s ease forwards; }
     [data-animate="2"] { animation-delay: .05s; }
@@ -369,6 +406,15 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
         <p class="legal">By continuing, you agree to our <a href="#" style="color:var(--accent); text-decoration:none; font-weight:600">Terms</a> and <a href="#" style="color:var(--accent); text-decoration:none; font-weight:600">Privacy Policy</a>.</p>
       </aside>
     </div>
+    <nav class="quick-access" aria-label="Quick access">
+      <a href="https://www.learngermanghana.com/" target="_blank" rel="noopener noreferrer">LLEA</a>
+      <a href="https://www.falowen.app/" target="_blank" rel="noopener noreferrer">Falowen</a>
+      <a href="https://register.falowen.app/" target="_blank" rel="noopener noreferrer">Register</a>
+      <a href="https://www.instagram.com/lleaghana/" target="_blank" rel="noopener noreferrer">Instagram</a>
+      <a href="https://www.youtube.com/@LLEAGhana" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a href="https://www.tiktok.com/@lleaghana" target="_blank" rel="noopener noreferrer">TikTok</a>
+      <a href="https://www.linkedin.com/in/lleaghana/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+    </nav>
   </main>
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
 


### PR DESCRIPTION
## Summary
- embed JSON-LD SoftwareApplication schema for Falowen on login page
- add quick-access navigation with links to Falowen sites and social profiles

## Testing
- `python -m pytest`
- `ruff check .` *(fails: Found 130 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bef4932bb88321a402be4a2f73dade