### PR TITLE
Add SoftwareApplication schema and quick-access social links

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -49,35 +49,14 @@ register_health_route(app)
 
 ICON_PATH = Path(__file__).parent / "static/icons/falowen-512.png"
 
-# Ensure the sidebar starts visible on first load and remember user's choice
-if "sidebar_state" not in st.session_state:
-    st.session_state["sidebar_state"] = "expanded"
-_sb_state = st.session_state["sidebar_state"]
-
 st.set_page_config(
     page_title="Falowen – Your German Conversation Partner",
     page_icon=str(ICON_PATH),  # now uses official Falowen icon
     layout="wide",
-    initial_sidebar_state=_sb_state,
 )
 
 # Load global CSS classes and variables
 inject_global_styles()
-
-
-def _reopen_sidebar() -> None:
-    """Force the sidebar open and rerun the app."""
-    st.session_state["sidebar_state"] = "expanded"
-    st.session_state["need_rerun"] = True
-
-
-def _collapse_sidebar() -> None:
-    st.session_state["sidebar_state"] = "collapsed"
-    st.session_state["need_rerun"] = True
-
-
-if st.session_state.get("sidebar_state") == "collapsed":
-    st.button("☰ Menu", key="_sb_restore", on_click=_reopen_sidebar)
 
 
 # Ensure the latest lesson schedule is loaded
@@ -486,6 +465,17 @@ def render_sidebar_published():
     st.sidebar.button("❓ Class Notes & Q&A",         use_container_width=True, on_click=_go_post_qna)
     st.sidebar.divider()
 
+    st.sidebar.markdown("## Our Socials")
+    st.sidebar.markdown(
+        """
+- 📸 [Instagram](https://www.instagram.com/lleaghana/)
+- ▶️ [YouTube](https://www.youtube.com/@LLEAGhana)
+- 🎵 [TikTok](https://www.tiktok.com/@lleaghana)
+- 💼 [LinkedIn](https://www.linkedin.com/in/lleaghana/)
+        """
+    )
+    st.sidebar.divider()
+
     st.sidebar.markdown("## How-to & tips")
     with st.sidebar.expander("📚 Quick guide", expanded=False):
         st.markdown(
@@ -539,8 +529,6 @@ def render_sidebar_published():
 - ✉️ [About Us](https://register.falowen.app/#about-us)
         """
     )
-
-    st.sidebar.button("Hide menu", on_click=_collapse_sidebar)
 
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#25317e" />
   <title>Falowen Login</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Falowen",
+    "applicationCategory": "EducationalApplication",
+    "operatingSystem": "Web",
+    "url": "https://www.falowen.app/",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Learn Language Education Academy",
+      "url": "https://www.learngermanghana.com/"
+    },
+    "sameAs": [
+      "https://www.learngermanghana.com/",
+      "https://www.falowen.app/",
+      "https://register.falowen.app/",
+      "https://www.instagram.com/lleaghana/",
+      "https://www.youtube.com/@LLEAGhana",
+      "https://www.tiktok.com/@lleaghana",
+      "https://www.linkedin.com/in/lleaghana/"
+    ]
+  }
+  </script>
   <!-- Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -253,6 +277,19 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
 
     .legal { margin-top: 12px; color: var(--muted); font-size: .85rem; line-height: 1.5; }
 
+    .quick-access {
+      margin-top: 24px;
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .quick-access a {
+      color: var(--primary);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
     /* Animations */
     [data-animate] { opacity: 0; transform: translateY(10px); animation: fadeUp .6s ease forwards; }
     [data-animate="2"] { animation-delay: .05s; }
@@ -369,6 +406,15 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
         <p class="legal">By continuing, you agree to our <a href="#" style="color:var(--accent); text-decoration:none; font-weight:600">Terms</a> and <a href="#" style="color:var(--accent); text-decoration:none; font-weight:600">Privacy Policy</a>.</p>
       </aside>
     </div>
+    <nav class="quick-access" aria-label="Quick access">
+      <a href="https://www.learngermanghana.com/" target="_blank" rel="noopener noreferrer">LLEA</a>
+      <a href="https://www.falowen.app/" target="_blank" rel="noopener noreferrer">Falowen</a>
+      <a href="https://register.falowen.app/" target="_blank" rel="noopener noreferrer">Register</a>
+      <a href="https://www.instagram.com/lleaghana/" target="_blank" rel="noopener noreferrer">Instagram</a>
+      <a href="https://www.youtube.com/@LLEAGhana" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a href="https://www.tiktok.com/@lleaghana" target="_blank" rel="noopener noreferrer">TikTok</a>
+      <a href="https://www.linkedin.com/in/lleaghana/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+    </nav>
   </main>
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
 


### PR DESCRIPTION
## Summary
- embed JSON-LD SoftwareApplication schema for Falowen on login page
- add quick-access navigation with links to Falowen sites and social profiles
- add "Our Socials" section in dashboard sidebar and remove hide menu toggle

## Testing
- `python -m pytest`
- `ruff check .` *(fails: Found 130 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bef4932bb88321a402be4a2f73dade