### PR TITLE
Increase font size in content textarea

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -3613,6 +3613,8 @@ if tab == "My Course":
                     background-color: #f1f5f9;
                     color: #0f172a;
                     font-family: 'Chalkboard', 'Chalkduster', 'Comic Sans MS', cursive;
+                    font-size: 1.1rem;
+                    line-height: 1.4;
                 }
                 </style>
                 """,


### PR DESCRIPTION
## Summary
- enlarge font and line-height for `Your content` textarea styling

## Testing
- `ruff check .` *(fails: unrecognized subcommand '.'? Wait we corrected; but final run shows no output but we cat log which shows many errors.* We'll mention accordingly: `ruff check .` (fails: many lint errors).
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0135ae8c8321bef0b54af006d9ce