### PR TITLE
Show info when dictionary lookup has no matches

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5662,6 +5662,8 @@ if tab == "Vocab Trainer":
             else:
                 vocab_all = df_view["German"].astype(str).unique().tolist()
                 suggestions = difflib.get_close_matches(q, vocab_all, n=5, cutoff=0.72)
+                if not suggestions:
+                    st.info("No matches found.")
                 # Still show a card for the query itself
                 dummy = {"Level": student_level_locked, "German": q, "English": "", "Pronunciation": "", "g_norm": qn, "e_norm": ""}
                 df_view = pd.concat([df_view, pd.DataFrame([dummy])], ignore_index=True)


### PR DESCRIPTION
## Summary
- Inform users when dictionary search returns no results by displaying an info message

## Testing
- `ruff check a1sprechen.py` *(fails: 108 errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf6382dde8832180156cd3019b3bca