### PR TITLE
Wrap vocab lookup in expander and add dictionary heading

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2030,7 +2030,8 @@ if tab == "My Course":
                         st.markdown('<em>Further notice:</em> 📘 contains notes; 📒 is your workbook assignment.', unsafe_allow_html=True)
                     if part.get('workbook_link'):
                         st.markdown(f"- [📒 Workbook (Assignment)]({part['workbook_link']})")
-                        render_vocab_lookup(f"{key}-{idx_part}")
+                        with st.expander("📖 Dictionary"):
+                            render_vocab_lookup(f"{key}-{idx_part}")
                         render_assignment_reminder()
                     extras = part.get('extra_resources')
                     if extras:
@@ -2058,8 +2059,9 @@ if tab == "My Course":
                     st.markdown(f"- [📘 Grammar Book (Notes)]({info['grammarbook_link']})")
                     showed = True
                 if info.get("workbook_link"):
-                    st.markdown(f"- [📒 Workbook (Assignment)]({info['workbook_link']})")              
-                    render_vocab_lookup(f"fallback-{info.get('day', '')}")
+                    st.markdown(f"- [📒 Workbook (Assignment)]({info['workbook_link']})")
+                    with st.expander("📖 Dictionary"):
+                        render_vocab_lookup(f"fallback-{info.get('day', '')}")
                     render_assignment_reminder()
                     showed = True
                 for ex in _as_list(info.get("extra_resources")):

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -77,15 +77,22 @@ def render_vocab_lookup(key: str) -> None:
         Unique key so Streamlit state doesn't clash across lessons.
     """
 
+    st.markdown("#### 📖 Mini Dictionary")
+    st.caption("Search words from this assignment")
+
+    translate_caption = (
+        'Need to translate a longer phrase? Try '
+        '<a href="https://www.deepl.com/translator" target="_blank">DeepL</a> '
+        'or <a href="https://translate.google.com" target="_blank">Google Translate</a>.'
+    )
+
     df = _load_vocab_sheet()
     if df is None:
         st.info("Vocabulary lookup currently unavailable.")
-    st.caption(
-        'Need to translate a longer phrase? Try '
-        '<a href="https://www.deepl.com/translator" target="_blank">DeepL</a> '
-        'or <a href="https://translate.google.com" target="_blank">Google Translate</a>.',
-        unsafe_allow_html=True,
-    )
+        st.caption(translate_caption, unsafe_allow_html=True)
+        return
+
+    st.caption(translate_caption, unsafe_allow_html=True)
 
     query = st.text_input("🔎 Search vocabulary", key=f"vocab-{key}")
     if not query:


### PR DESCRIPTION
## Summary
- Wrap vocab lookup widget in a 📖 Dictionary expander on assignment pages
- Add "📖 Mini Dictionary" heading with caption and keep translator links

## Testing
- `pytest tests/test_vocab_sheet_timeout.py tests/test_vocab_default_level.py -q`
- `python - <<'PY'
import pandas as pd
from types import SimpleNamespace
import src.ui_components as ui
calls=[]

def markdown(msg, **kwargs):
    calls.append(('markdown', msg))

def caption(msg, **kwargs):
    calls.append(('caption', msg))

def info(msg, **kwargs):
    calls.append(('info', msg))

def text_input(label, key):
    calls.append(('text_input', label, key))
    return 'Hallo'

def write(msg, **kwargs):
    calls.append(('write', msg))

def audio(url):
    calls.append(('audio', url))

ui.st = SimpleNamespace(markdown=markdown, caption=caption, info=info, text_input=text_input, write=write, audio=audio)
ui._load_vocab_sheet = lambda: pd.DataFrame({'German':['Hallo','Tschüss'], 'English':['Hello','Bye']})
ui.render_vocab_lookup('test')
print('calls:', calls)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bf650f314c8321bee86f2684ec9a25