### PR TITLE
Add optional pronunciation support to vocabulary and dictionary

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5362,18 +5362,21 @@ def build_dict_df(levels):
                 sentence_map.setdefault((lvl, t), sentence)
 
     # Build initial rows from the vocab lists
-    for lvl in levels:
-        for de, en in VOCAB_LISTS.get(lvl, []):
-            sent = sentence_map.get((lvl, de), "")
-            rows.append(
-                {
-                    "Level": lvl,
-                    "German": de,
-                    "English": en,
-                    "Pronunciation": "",
-                    "Sentence": sent,
-                }
-            )
+        for lvl in levels:
+            for entry in VOCAB_LISTS.get(lvl, []):
+                de = entry[0]
+                en = entry[1]
+                pron = entry[2] if len(entry) > 2 else ""
+                sent = sentence_map.get((lvl, de), "")
+                rows.append(
+                    {
+                        "Level": lvl,
+                        "German": de,
+                        "English": en,
+                        "Pronunciation": pron,
+                        "Sentence": sent,
+                    }
+                )
 
     df = (
         pd.DataFrame(rows)
@@ -5562,7 +5565,9 @@ if tab == "Vocab Trainer":
                 render_message(who, msg)
 
         if isinstance(tot, int) and idx < tot:
-            word, answer = st.session_state.vt_list[idx]
+            current = st.session_state.vt_list[idx]
+            word = current[0]
+            answer = current[1]
 
             # ---- AUDIO (download-only: prefer sheet link; fallback to gTTS bytes) ----
             audio_url = get_audio_url(level, word)
@@ -5605,7 +5610,7 @@ if tab == "Vocab Trainer":
 
         if isinstance(tot, int) and idx >= tot:
             score = st.session_state.vt_score
-            words = [w for w, _ in (st.session_state.vt_list or [])]
+            words = [item[0] for item in (st.session_state.vt_list or [])]
             st.markdown(f"### 🏁 Done! You scored {score}/{tot}.")
             if not st.session_state.get("vt_saved", False):
                 if not st.session_state.get("vt_session_id"):
@@ -5724,6 +5729,9 @@ if tab == "Vocab Trainer":
 
             st.markdown(f"### {de}")
             if en: st.markdown(f"**Meaning:** {en}")
+            pron = str(top_row.get("Pronunciation", "") or "").strip()
+            if pron:
+                st.markdown(f"**Pronunciation:** {pron}")
 
             # Show first example sentence containing the word
             example_sentence = ""

--- a/src/services/vocab.py
+++ b/src/services/vocab.py
@@ -36,6 +36,10 @@ def load_vocab_lists() -> Tuple[Dict[str, list], Dict[Tuple[str, str], Dict[str,
     df["Level"] = df["Level"].astype(str).str.strip()
     df["German"] = df["German"].astype(str).str.strip()
     df["English"] = df["English"].astype(str).str.strip()
+    has_pron = "Pronunciation" in df.columns
+    if not has_pron:
+        df["Pronunciation"] = ""
+    df["Pronunciation"] = df["Pronunciation"].astype(str).str.strip()
     df = df.dropna(subset=["Level", "German"])
 
     def pick(*names):
@@ -47,7 +51,15 @@ def load_vocab_lists() -> Tuple[Dict[str, list], Dict[Tuple[str, str], Dict[str,
     normal_col = pick("Audio (normal)", "Audio normal", "Audio_Normal", "Audio")
     slow_col = pick("Audio (slow)", "Audio slow", "Audio_Slow")
 
-    vocab_lists = {lvl: list(zip(grp["German"], grp["English"])) for lvl, grp in df.groupby("Level")}
+    if has_pron:
+        vocab_lists = {
+            lvl: list(zip(grp["German"], grp["English"], grp["Pronunciation"]))
+            for lvl, grp in df.groupby("Level")
+        }
+    else:
+        vocab_lists = {
+            lvl: list(zip(grp["German"], grp["English"])) for lvl, grp in df.groupby("Level")
+        }
     audio_urls: Dict[Tuple[str, str], Dict[str, str]] = {}
     for _, r in df.iterrows():
         key = (r["Level"], r["German"])


### PR DESCRIPTION
## Summary
- load optional pronunciation column from Google Sheet into `VOCAB_LISTS`
- show word pronunciation in dictionary details when provided
- handle pronunciation-aware tuples in vocab practice

## Testing
- `ruff check a1sprechen.py src/services/vocab.py` *(fails: Undefined name `_dict_tts_bytes_de`, plus additional existing lint errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf66a7dadc832196b0d8a9febc2869