### PR TITLE
Handle unknown vocab levels

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5668,13 +5668,21 @@ if tab == "Vocab Trainer":
 
         # Build data from selected levels
         available_levels = sorted(VOCAB_LISTS.keys())
+        has_unknown = False
+        if "nan" in available_levels:
+            available_levels = [lvl for lvl in available_levels if lvl != "nan"]
+            available_levels.append("Unknown level")
+            has_unknown = True
+        if has_unknown:
+            st.info("Words without a level are listed under 'Unknown level'.")
         default_levels = [student_level_locked] if student_level_locked in available_levels else []
-        levels = st.multiselect(
+        levels_display = st.multiselect(
             "Select level(s)",
             available_levels,
             default=default_levels,
             key="dict_levels",
         )
+        levels = ["nan" if lvl == "Unknown level" else lvl for lvl in levels_display]
         df_dict = build_dict_df(levels)
         for c in ["Level","German","English","Pronunciation"]:
             if c not in df_dict.columns: df_dict[c] = ""

--- a/src/services/vocab.py
+++ b/src/services/vocab.py
@@ -33,6 +33,9 @@ def load_vocab_lists() -> Tuple[Dict[str, list], Dict[Tuple[str, str], Dict[str,
         st.warning("Missing 'Level' column in your vocab sheet. Defaulting to 'A1'.")
         df["Level"] = "A1"
 
+    # Remove rows with missing Level or German before converting to strings.
+    df = df.dropna(subset=["Level", "German"])
+
     df["Level"] = df["Level"].astype(str).str.strip()
     df["German"] = df["German"].astype(str).str.strip()
     df["English"] = df["English"].astype(str).str.strip()
@@ -40,7 +43,6 @@ def load_vocab_lists() -> Tuple[Dict[str, list], Dict[Tuple[str, str], Dict[str,
     if not has_pron:
         df["Pronunciation"] = ""
     df["Pronunciation"] = df["Pronunciation"].astype(str).str.strip()
-    df = df.dropna(subset=["Level", "German"])
 
     def pick(*names):
         for n in names:


### PR DESCRIPTION
## Summary
- Drop rows with missing Level or German before string conversion to avoid 'nan' level entries
- Present 'Unknown level' for vocab items without a level and alert users to this mapping

## Testing
- `pytest -q`
- `ruff check .` *(fails: F401 unused import and additional lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf69380e1c8321bbaac8efb03b77dd