### PR TITLE
Fix TypeError in exam reminder info message

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1530,9 +1530,13 @@ if tab == "Dashboard":
         if exam_info:
             if days_to_exam is not None and days_to_exam > 0:
                 st.info(
-                    f"Your {level} exam is in {days_to_exam} days ({exam_date:%d %b %Y}).  \n",
-                    f"{fee_text}  \n",
-                    "[Register online here](https://www.goethe.de/ins/gh/en/spr/prf.html)"
+                    "\n".join(
+                        [
+                            f"Your {level} exam is in {days_to_exam} days ({exam_date:%d %b %Y}).",
+                            fee_text,
+                            "[Register online here](https://www.goethe.de/ins/gh/en/spr/prf.html)",
+                        ]
+                    )
                 )
             elif days_to_exam == 0:
                 st.success("🚀 Exam is today! Good luck!")


### PR DESCRIPTION
## Summary
- ensure exam reminder's `st.info` uses a single string via newline join

## Testing
- `ruff check a1sprechen.py` *(fails: numerous pre-existing lint errors)*
- `pytest`
- `streamlit run a1sprechen.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_68bf6ea6578c8321a29fa60f672d3813