### PR TITLE
Allow rerun after successful login

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -603,7 +603,8 @@ if not st.session_state.get("logged_in", False):
 # Gate
 if not st.session_state.get("logged_in", False):
     login_page()
-    st.stop()
+    if not st.session_state.get("logged_in", False):
+        st.stop()
 
 # ==================== LOGGED IN ====================
 # Show header immediately after login on every page


### PR DESCRIPTION
## Summary
- Run `login_page` and only halt execution if the user remains unauthenticated
- Permit successful logins to reach existing rerun logic for immediate refresh

## Testing
- `pytest -q`
- `ruff check a1sprechen.py` *(fails: E402 Module level import not at top of file, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe98c45788321a27d0bf307e38329