### PR TITLE
Avoid saved toast on login

### DIFF
--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -240,7 +240,7 @@ def render_login_form(login_id: str, login_pass: str) -> bool:
     )
 
     st.success(f"Welcome, {student_row['Name']}!")
-    refresh_with_toast()
+    st.toast(f"Welcome, {student_row['Name']}!", icon="✅")
     return True
 
 


### PR DESCRIPTION
## Summary
- Remove saved toast refresh in login form and show a simple welcome toast instead

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfead1296c832192492330a4095507