### PR TITLE
Add warn and info toast helpers

### DIFF
--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -23,6 +23,28 @@ def toast_err(msg: str) -> None:
     st.toast(msg, icon="❌")
 
 
+def toast_warn(msg: str) -> None:
+    """Show a warning toast message.
+
+    Parameters
+    ----------
+    msg:
+        The message to display.
+    """
+    st.toast(msg, icon="⚠️")
+
+
+def toast_info(msg: str) -> None:
+    """Show an informational toast message.
+
+    Parameters
+    ----------
+    msg:
+        The message to display.
+    """
+    st.toast(msg, icon="ℹ️")
+
+
 def refresh_with_toast() -> None:
     """Increment ``__refresh`` and show a saved toast.
 

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -18,6 +18,20 @@ def test_toast_err(monkeypatch):
     mock_st.toast.assert_called_once_with("oops", icon="❌")
 
 
+def test_toast_warn(monkeypatch):
+    mock_st = types.SimpleNamespace(toast=MagicMock())
+    monkeypatch.setattr(toasts, "st", mock_st)
+    toasts.toast_warn("careful")
+    mock_st.toast.assert_called_once_with("careful", icon="⚠️")
+
+
+def test_toast_info(monkeypatch):
+    mock_st = types.SimpleNamespace(toast=MagicMock())
+    monkeypatch.setattr(toasts, "st", mock_st)
+    toasts.toast_info("note")
+    mock_st.toast.assert_called_once_with("note", icon="ℹ️")
+
+
 def test_refresh_with_toast(monkeypatch):
     mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
     monkeypatch.setattr(toasts, "st", mock_st)


### PR DESCRIPTION
## Summary
- add `toast_warn` and `toast_info` helpers with warning and info icons
- document new toast helpers alongside existing ones
- test toast helpers ensure correct icons are used

## Testing
- `python -m pytest tests/test_toasts.py`
- `ruff check src/utils/toasts.py tests/test_toasts.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0003ecfe48321ae99c4cb3d379a37