### PR TITLE
feat: allow custom toast messages

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -490,7 +490,7 @@ def render_results_and_resources_tab() -> None:
         if st.button("🔄 Refresh"):
             st.cache_data.clear()
             st.success("Cache cleared! Reloading…")
-            refresh_with_toast()
+            refresh_with_toast("Refreshed!")
 
     df_scores = fetch_scores(GOOGLE_SHEET_CSV)
     required_cols = {

--- a/src/sentence_builder.py
+++ b/src/sentence_builder.py
@@ -158,7 +158,7 @@ def render_sentence_builder(student_code: str, student_level_locked: str) -> Non
                     disabled=selected,
                 ):
                     st.session_state.sb_selected_idx.append(i)
-                    refresh_with_toast()
+                    refresh_with_toast("Word added!")
 
     chosen_tokens = [
         st.session_state.sb_shuffled[i] for i in st.session_state.sb_selected_idx
@@ -172,7 +172,7 @@ def render_sentence_builder(student_code: str, student_level_locked: str) -> Non
             st.session_state.sb_selected_idx = []
             st.session_state.sb_feedback = ""
             st.session_state.sb_correct = None
-            refresh_with_toast()
+            refresh_with_toast("Cleared!")
     with b:
         if st.button("✅ Check"):
             target_sentence = st.session_state.sb_current.get("target_de", "").strip()
@@ -196,7 +196,7 @@ def render_sentence_builder(student_code: str, student_level_locked: str) -> Non
                 correct=correct,
                 tip=st.session_state.sb_current.get("hint_en", ""),
             )
-            refresh_with_toast()
+            refresh_with_toast("Attempt recorded!")
     with c:
         next_disabled = st.session_state.sb_correct is None
         if st.button("➡️ Next", disabled=next_disabled):
@@ -205,7 +205,7 @@ def render_sentence_builder(student_code: str, student_level_locked: str) -> Non
                     f"Session complete! Score: {st.session_state.sb_score}/{st.session_state.sb_total}"
                 )
             new_sentence()
-            refresh_with_toast()
+            refresh_with_toast("Next sentence!")
 
     if st.session_state.sb_feedback:
         (st.success if st.session_state.sb_correct else st.info)(

--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -468,7 +468,7 @@ def _handle_google_oauth(code: str, state: str) -> None:
 
         qp_clear()
         st.success(f"Welcome, {student_row['Name']}!")
-        refresh_with_toast()
+        refresh_with_toast("Logged in!")
         st.session_state["need_rerun"] = True
 
     except Exception as e:  # pragma: no cover - network errors

--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -45,12 +45,17 @@ def toast_info(msg: str) -> None:
     st.toast(msg, icon="ℹ️")
 
 
-def refresh_with_toast() -> None:
+def refresh_with_toast(msg: str = "Saved!") -> None:
     """Increment ``__refresh`` and show a saved toast.
 
     This helper centralises the common pattern of bumping the
     ``__refresh`` counter in ``st.session_state`` to trigger a
     rerender and informing the user that their action was saved.
+
+    Parameters
+    ----------
+    msg:
+        The message to display in the success toast. Defaults to ``"Saved!"``.
     """
     st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
-    toast_ok("Saved!")
+    toast_ok(msg)

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -38,3 +38,11 @@ def test_refresh_with_toast(monkeypatch):
     toasts.refresh_with_toast()
     mock_st.toast.assert_called_once_with("Saved!", icon="✅")
     assert mock_st.session_state["__refresh"] == 1
+
+
+def test_refresh_with_toast_custom_msg(monkeypatch):
+    mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
+    monkeypatch.setattr(toasts, "st", mock_st)
+    toasts.refresh_with_toast("Updated!")
+    mock_st.toast.assert_called_once_with("Updated!", icon="✅")
+    assert mock_st.session_state["__refresh"] == 1


### PR DESCRIPTION
## Summary
- add optional message param to `refresh_with_toast`
- pass specific messages for login, assignment refresh and sentence builder interactions
- cover default and custom message in toast tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c000ee12c88321bc7d7c9e3e073786