### PR TITLE
Add toast_once helper to suppress duplicate toasts

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -82,7 +82,7 @@ from src.contracts import (
 )
 from src.services.contracts import contract_active
 from src.utils.currency import format_cedis
-from src.utils.toasts import toast_ok, refresh_with_toast
+from src.utils.toasts import toast_ok, refresh_with_toast, toast_once
 from src.firestore_utils import (
     _draft_doc_ref,
     load_chat_draft_from_db,
@@ -6071,7 +6071,7 @@ if tab == "Schreiben Trainer":
 
         if st.button("\U0001f4be Save Draft", key=f"save_draft_btn_{student_code}"):
             save_now(draft_key, student_code)
-            toast_ok("Draft saved!")
+            toast_once("Draft saved!", "✅")
         st.caption("Auto-saves every few seconds or click 'Save Draft' to save now.")
 
         def clear_feedback_and_start_new():
@@ -6609,7 +6609,7 @@ if tab == "Schreiben Trainer":
 
             if st.button("\U0001f4be Save Draft", key=f"save_prompt_draft_btn_{student_code}"):
                 save_now(draft_key, student_code)
-                toast_ok("Draft saved!")
+                toast_once("Draft saved!", "✅")
             st.caption("Auto-saves every few seconds or click 'Save Draft' to save now.")
 
             saved_at = st.session_state.get(f"{draft_key}_saved_at")
@@ -6735,7 +6735,7 @@ if tab == "Schreiben Trainer":
             if col_save.button("\U0001f4be Save Draft", key=ns("save_letter_draft_btn")):
                 st.session_state[letter_draft_key] = letter_draft
                 save_now(letter_draft_key, student_code)
-                toast_ok("Draft saved!")
+                toast_once("Draft saved!", "✅")
 
             if send:
                 user_input = st.session_state[draft_key].strip()

--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -1,6 +1,34 @@
 import streamlit as st
 
 
+_RECENT_TOASTS_KEY = "__recent_toasts__"
+
+
+def _already_toasted(msg: str) -> bool:
+    shown: set[str] = st.session_state.setdefault(_RECENT_TOASTS_KEY, set())
+    if msg in shown:
+        return True
+    shown.add(msg)
+    return False
+
+
+def toast_once(msg: str, icon: str) -> None:
+    """Show a toast message only once per session.
+
+    The function keeps track of messages shown in ``st.session_state`` and
+    suppresses duplicates.
+
+    Parameters
+    ----------
+    msg:
+        The message to display.
+    icon:
+        The icon to display with the toast.
+    """
+    if not _already_toasted(msg):
+        st.toast(msg, icon=icon)
+
+
 def toast_ok(msg: str) -> None:
     """Show a success toast message.
 

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -46,3 +46,15 @@ def test_refresh_with_toast_custom_msg(monkeypatch):
     toasts.refresh_with_toast("Updated!")
     mock_st.toast.assert_called_once_with("Updated!", icon="✅")
     assert mock_st.session_state["__refresh"] == 1
+
+
+def test_toast_once_suppresses_duplicates(monkeypatch):
+    mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
+    monkeypatch.setattr(toasts, "st", mock_st)
+
+    toasts.toast_once("hi", "✅")
+    toasts.toast_once("hi", "✅")
+    toasts.toast_once("bye", "✅")
+
+    assert mock_st.toast.call_count == 2
+    assert mock_st.session_state["__recent_toasts__"] == {"hi", "bye"}


### PR DESCRIPTION
## Summary
- avoid duplicate toast messages by tracking shown messages in session state
- add `toast_once` helper for single-use toasts
- use `toast_once` for draft save notifications in `a1sprechen.py`
- test new behaviour with unit tests

## Testing
- `pytest tests/test_toasts.py`
- `ruff check src/utils/toasts.py tests/test_toasts.py`


------
https://chatgpt.com/codex/tasks/task_e_68c003671db48321a45a363e9d27aac1