### PR TITLE
Add profile editing toggle and deletion

### DIFF
--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -225,6 +225,20 @@ def save_student_profile(code: str, about: str) -> None:
         logging.warning("Failed to save student profile for %s: %s", code, exc)
 
 
+def delete_student_profile(code: str) -> None:
+    """Remove the ``about`` field for ``code``'s profile."""
+
+    if db is None:
+        return
+    if not code:
+        return
+    ref = db.collection("students").document(code)
+    try:
+        ref.set({"about": firestore.DELETE_FIELD}, merge=True)
+    except Exception as exc:  # pragma: no cover - runtime depends on Firestore
+        logging.warning("Failed to delete student profile for %s: %s", code, exc)
+
+
 def load_student_profile(code: str) -> str:
     """Return the stored 'about' text for ``code``."""
 


### PR DESCRIPTION
## Summary
- Allow profile "About me" section to be read-only by default with an Edit mode including Save, Cancel, and Delete options
- Add helper to remove a student's profile text from Firestore

## Testing
- `python -m ruff check a1sprechen.py src/firestore_utils.py` *(fails: E402 module level import not at top of file, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c00b613c788321b983003cc671da59