### PR TITLE
Improve profile editing UI

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -3494,13 +3494,10 @@ if tab == "My Course":
                 st.session_state.setdefault(edit_key, False)
 
                 editing = st.session_state.get(edit_key, False)
-                disabled = not bool(student_code) or not editing
-                st.text_area(
-                    "About me",
-                    key=about_key,
-                    height=180,
-                    disabled=disabled,
-                )
+                if editing:
+                    st.text_area("About me", key=about_key, height=300)
+                else:
+                    st.markdown(st.session_state[about_key])
 
                 if not editing:
                     if st.button("Edit", disabled=not bool(student_code), key=_ukey("edit_profile")):


### PR DESCRIPTION
## Summary
- Replace read-only profile text area with markdown display when not editing
- Provide larger 300px text area while editing profile

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c011407ce483219dfdd7a11fe8c24c