### PR TITLE
Improve profile AI correction error handling

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -594,8 +594,9 @@ def apply_profile_ai_correction(about_key: str) -> None:
         ai_text = (resp.choices[0].message.content or "").strip()
         if ai_text:
             st.session_state[about_key] = ai_text
-    except Exception:
-        st.error("AI correction failed.")
+    except Exception as e:
+        logging.exception("Profile AI correction error")
+        st.error(f"AI correction failed: {e}")
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- capture and display OpenAI errors in `apply_profile_ai_correction`
- log stack trace for easier debugging

## Testing
- `ruff check a1sprechen.py tests/test_profile_ai_correction.py` *(fails: E402 etc.)*
- `pytest tests/test_profile_ai_correction.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0114d1d088321b879e088e86588c8