### PR TITLE
Render newlines in notes

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4378,7 +4378,7 @@ if tab == "My Course":
                     if note.get("tag"):
                         st.caption(f"🏷️ Tag: {note['tag']}")
                     st.markdown(
-                        f"<div style='margin-top:-5px; margin-bottom:6px; font-size:1.08rem; line-height:1.7;'>{note['text']}</div>",
+                        f"<div style='margin-top:-5px; margin-bottom:6px; font-size:1.08rem; line-height:1.7;'>{note['text'].replace('\n', '<br>')}</div>",
                         unsafe_allow_html=True)
                     st.caption(f"🕒 {note.get('updated',note.get('created',''))}")
 


### PR DESCRIPTION
## Summary
- Render note text with `<br>` tags so numbered lines display on separate lines

## Testing
- `ruff check a1sprechen.py` *(fails: 107 errors, including E402, F401)*
- `pytest`
- `python - <<'PY'
text='1. First\n2. Second'
print(text.replace('\\n','<br>'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c01c53862c8321b89e3194ea4ac603