### PR TITLE
Pull blog announcements from feed

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -40,6 +40,7 @@ from flask import Flask
 from auth import auth_bp
 from src.routes.health import register_health_route
 from src.group_schedules import load_group_schedules
+from src.blog_feed import fetch_blog_feed
 import src.schedule as _schedule
 load_level_schedules = _schedule.load_level_schedules
 refresh_level_schedules = getattr(_schedule, "refresh_level_schedules", lambda: None)
@@ -758,13 +759,14 @@ inject_notice_css()
 render_sidebar_published()
 
 # Announcements (render once)
-announcements = [
+_fallback_announcements = [
     {"title": "Quick Access Menu", "body": "Use the left sidebar for quick access to lessons, tools, and resources.", "tag": "New"},
     {"title": "Download Receipts & Results", "body": "Grab your receipt, results, and enrollment letter under **My Results & Resources**.", "tag": "New"},
     {"title": "Account Deletion Requests", "body": "You can now request account deletion from your account settings.", "tag": "Info"},
     {"title": "Refresh Session Fix", "body": "Frequent refresh session prompts have been resolved for smoother navigation.", "tag": "Update"},
     {"title": "Attendance Now Being Marked", "body": "Find attendance under My Course ➜ Classroom/Attendance. Telegram notifications are available.", "tag": "New"},
 ]
+announcements = fetch_blog_feed() or _fallback_announcements
 
 st.markdown("---")
 st.markdown("**You’re logged in.** Continue to your lessons and tools from the navigation.")

--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -1,0 +1,75 @@
+import xml.etree.ElementTree as ET
+from typing import List, Dict
+
+import requests
+import streamlit as st
+
+
+@st.cache_data(ttl=3600)
+def fetch_blog_feed(limit: int = 5) -> List[Dict[str, str]]:
+    """Fetch and parse the Falowen blog feed.
+
+    Parameters
+    ----------
+    limit: int
+        Maximum number of recent items to return.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        A list of dictionaries each containing ``title``, ``body`` and ``href``.
+        Returns an empty list on any error.
+    """
+    feed_url = "https://blog.falowen.app/feed.xml"
+    try:
+        resp = requests.get(feed_url, timeout=10)
+        resp.raise_for_status()
+    except Exception:
+        return []
+
+    try:
+        root = ET.fromstring(resp.content)
+    except ET.ParseError:
+        return []
+
+    items: List[Dict[str, str]] = []
+    ns = {
+        "atom": "http://www.w3.org/2005/Atom",
+        "content": "http://purl.org/rss/1.0/modules/content/",
+    }
+
+    if root.tag.endswith("feed"):
+        entries = root.findall("atom:entry", ns)
+        for entry in entries[:limit]:
+            title_el = entry.find("atom:title", ns)
+            content_el = entry.find("atom:content", ns) or entry.find("atom:summary", ns)
+            link_el = entry.find("atom:link", ns)
+            items.append(
+                {
+                    "title": title_el.text if title_el is not None else "",
+                    "body": content_el.text if content_el is not None else "",
+                    "href": link_el.get("href") if link_el is not None else None,
+                }
+            )
+    else:
+        channel = root.find("channel")
+        if channel is None:
+            return []
+        for entry in channel.findall("item")[:limit]:
+            title_el = entry.find("title")
+            link_el = entry.find("link")
+            desc_el = entry.find("description")
+            content_el = entry.find("content:encoded", ns)
+            body = ""
+            if content_el is not None and content_el.text:
+                body = content_el.text
+            elif desc_el is not None and desc_el.text:
+                body = desc_el.text
+            items.append(
+                {
+                    "title": title_el.text if title_el is not None else "",
+                    "body": body,
+                    "href": link_el.text if link_el is not None else None,
+                }
+            )
+    return items

--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -1,0 +1,29 @@
+import types
+
+import requests
+
+from src.blog_feed import fetch_blog_feed
+
+
+def test_fetch_blog_feed_parses_items(monkeypatch):
+    sample = (
+        "<?xml version='1.0'?><rss><channel><item><title>Test</title>"
+        "<link>http://example.com</link><description>Hello</description></item></channel></rss>"
+    )
+
+    def fake_get(url, timeout=10):
+        return types.SimpleNamespace(content=sample.encode(), raise_for_status=lambda: None)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    fetch_blog_feed.clear()
+    items = fetch_blog_feed(limit=1)
+    assert items == [{"title": "Test", "body": "Hello", "href": "http://example.com"}]
+
+
+def test_fetch_blog_feed_handles_error(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(requests, "get", boom)
+    fetch_blog_feed.clear()
+    assert fetch_blog_feed() == []


### PR DESCRIPTION
## Summary
- add `fetch_blog_feed` with cached RSS parsing
- load announcements from Falowen blog feed with static fallback
- cover feed parsing and error handling in new tests

## Testing
- `python -m ruff check .` *(fails: multiple existing lint errors)*
- `python -m ruff check src/blog_feed.py tests/test_blog_feed.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ad65fe048321909f963bde511c2b