### PR TITLE
Add blog feed tests and render-announcements coverage

### DIFF
--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import requests
+from xml.etree import ElementTree as ET
+
+# RSS feed URL is configurable for testing.
+BLOG_FEED_URL = "https://www.falowen.app/rss"
+
+# Fallback announcements if the feed cannot be loaded.
+FALLBACK = [
+    {
+        "title": "Quick Access Menu",
+        "body": "Use the left sidebar for quick access to lessons, tools, and resources.",
+        "href": "",
+    },
+    {
+        "title": "Download Receipts & Results",
+        "body": "Grab your receipt, results, and enrollment letter under **My Results & Resources**.",
+        "href": "",
+    },
+    {
+        "title": "Account Deletion Requests",
+        "body": "You can now request account deletion from your account settings.",
+        "href": "",
+    },
+    {
+        "title": "Refresh Session Fix",
+        "body": "Frequent refresh session prompts have been resolved for smoother navigation.",
+        "href": "",
+    },
+    {
+        "title": "Attendance Now Being Marked",
+        "body": "Find attendance under My Course ➜ Classroom/Attendance. Telegram notifications are available.",
+        "href": "",
+    },
+]
+
+
+def _parse_rss(xml: str) -> list[dict]:
+    """Parse a minimal RSS feed into announcement dictionaries."""
+    root = ET.fromstring(xml)
+    items: list[dict] = []
+    for item in root.findall(".//item"):
+        title = item.findtext("title", default="")
+        body = item.findtext("description", default="")
+        href = item.findtext("link", default="")
+        items.append({"title": title, "body": body, "href": href})
+    return items
+
+
+def fetch_blog_feed(url: str = BLOG_FEED_URL) -> list[dict]:
+    """Fetch and parse the blog RSS feed.
+
+    Returns a list of dictionaries with ``title``, ``body`` and ``href`` keys.
+    If the network request fails or the feed cannot be parsed, a static
+    fallback list is returned instead.
+    """
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+    except requests.RequestException:
+        return FALLBACK.copy()
+    try:
+        parsed = _parse_rss(resp.text)
+    except Exception:
+        return FALLBACK.copy()
+    return parsed or FALLBACK.copy()

--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+# Allow importing from src
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src import blog_feed
+
+
+RSS_SNIPPET = """<?xml version='1.0' encoding='UTF-8'?>
+<rss version='2.0'>
+  <channel>
+    <item>
+      <title>First Post</title>
+      <description>Hello World</description>
+      <link>https://example.com/1</link>
+    </item>
+    <item>
+      <title>Second Post</title>
+      <description>Another</description>
+      <link>https://example.com/2</link>
+    </item>
+  </channel>
+</rss>"""
+
+
+def test_fetch_blog_feed_parses_rss(monkeypatch):
+    resp = SimpleNamespace(text=RSS_SNIPPET, raise_for_status=lambda: None)
+    monkeypatch.setattr(blog_feed.requests, "get", lambda *_, **__: resp)
+    data = blog_feed.fetch_blog_feed("http://test")
+    assert data == [
+        {
+            "title": "First Post",
+            "body": "Hello World",
+            "href": "https://example.com/1",
+        },
+        {
+            "title": "Second Post",
+            "body": "Another",
+            "href": "https://example.com/2",
+        },
+    ]
+
+
+def test_fetch_blog_feed_network_error(monkeypatch):
+    def boom(*_, **__):
+        raise blog_feed.requests.RequestException("fail")
+
+    monkeypatch.setattr(blog_feed.requests, "get", boom)
+    data = blog_feed.fetch_blog_feed("http://test")
+    assert data == blog_feed.FALLBACK
+
+
+def test_fetch_blog_feed_malformed_feed(monkeypatch):
+    resp = SimpleNamespace(text="not xml", raise_for_status=lambda: None)
+    monkeypatch.setattr(blog_feed.requests, "get", lambda *_, **__: resp)
+    data = blog_feed.fetch_blog_feed("http://test")
+    assert data == blog_feed.FALLBACK

--- a/tests/test_ui_widgets_announcements.py
+++ b/tests/test_ui_widgets_announcements.py
@@ -82,3 +82,34 @@ def test_render_announcements_once_skips_when_hash_matches(monkeypatch):
     at = AppTest.from_function(app)
     at.run()
     render_mock.assert_not_called()
+
+
+def test_render_announcements_once_renders_feed_data(monkeypatch):
+    import importlib
+
+    importlib.reload(ui_widgets)
+    captured = {}
+
+    def fake_html(html, *_, **__):
+        captured["html"] = html
+
+    monkeypatch.setattr(ui_widgets, "components", SimpleNamespace(html=fake_html))
+
+    def app():
+        import streamlit as st
+        from src import ui_widgets as uw
+
+        data = [
+            {
+                "title": "Blog Post",
+                "body": "Summary",
+                "href": "https://example.com/post",
+            }
+        ]
+        uw.render_announcements_once(data, dashboard_active=True)
+
+    at = AppTest.from_function(app)
+    at.run()
+    assert "Blog Post" in captured["html"]
+    assert "Summary" in captured["html"]
+    assert "https://example.com/post" in captured["html"]


### PR DESCRIPTION
## Summary
- Add `blog_feed` module with RSS parsing and static fallback
- Test conversion of RSS to announcement dictionaries and fallback on errors
- Verify `render_announcements_once` handles feed-derived items without errors

## Testing
- `pytest tests/test_blog_feed.py tests/test_ui_widgets_announcements.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ad8d6c608321bcd1a5ff2ec42cda