### PR TITLE
Add footer to Falowen login page

### DIFF
--- a/templates/falowen_login.html
+++ b/templates/falowen_login.html
@@ -69,6 +69,10 @@
     [data-animate]{opacity:0;transform:translateY(10px);animation:fadeUp .6s ease forwards}
     [data-animate="2"]{animation-delay:.05s}[data-animate="3"]{animation-delay:.1s}[data-animate="4"]{animation-delay:.15s}[data-animate="5"]{animation-delay:.2s}
     @keyframes fadeUp{to{opacity:1;transform:translateY(0)}}
+    .app-footer{margin-top:18px;padding:16px 14px;border-top:1px solid var(--border);color:var(--muted);font-size:.95rem}
+    .app-footer a{text-decoration:none;font-weight:700;color:inherit}
+    .app-footer .row{display:flex;flex-wrap:wrap;gap:14px}
+    @media (max-width:640px){.app-footer{padding:14px 10px}}
   </style>
 </head>
 <body>
@@ -136,5 +140,16 @@
       fetch("/auth/refresh", { credentials: "include" }).catch(console.error);
     });
   </script>
+  <footer class="app-footer">
+    <div class="row">
+      <a href="https://register.falowen.app/#terms-of-service" target="_blank">Terms of Service</a> |
+      <a href="https://register.falowen.app/#privacy-policy" target="_blank">Privacy Policy</a> |
+      <a href="https://script.google.com/macros/s/AKfycbwXrfiuKl65Va_B2Nr4dFnyLRW5z6wT5kAbCj6cNl1JxdOzWVKT_ZMwdh2pN_dbdFoy/exec" target="_blank">Request Account Deletion</a> |
+      <a href="https://blog.falowen.app" target="_blank">Blog</a> |
+      <a href="https://register.falowen.app/#about-us" target="_blank">About Us</a> |
+      <a href="https://register.falowen.app/#mission" target="_blank">Mission</a>
+    </div>
+    <div style="margin-top:6px;font-size:.9rem;">© 2024 Falowen</div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style login page footer to match app footer
- include links to terms, privacy, deletion request, blog, about, and mission

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0b2433370832186d65499a82c56a0