### PR TITLE
Update blog feed endpoint

### DIFF
--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -20,7 +20,7 @@ def fetch_blog_feed(limit: int = 5) -> List[Dict[str, str]]:
         A list of dictionaries each containing ``title``, ``body`` and ``href``.
         Returns an empty list on any error.
     """
-    feed_url = "https://blog.falowen.app/feed.xml"
+    feed_url = "https://blog.falowen.app/feed/"
     try:
         resp = requests.get(feed_url, timeout=10)
         resp.raise_for_status()


### PR DESCRIPTION
## Summary
- point blog feed fetcher to new https://blog.falowen.app/feed/ endpoint

## Testing
- `python -m pytest tests/test_blog_feed.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0b29e7fec8321af266b631a5d1e87