### PR TITLE
Add blog and about/mission links to footer

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -889,6 +889,9 @@ FOOTER_LINKS = {
     "Privacy Policy": "https://register.falowen.app/#privacy-policy",
     "Request Account Deletion": "https://script.google.com/macros/s/AKfycbwXrfiuKl65Va_B2Nr4dFnyLRW5z6wT5kAbCj6cNl1JxdOzWVKT_ZMwdh2pN_dbdFoy/exec",
     "Contact": "https://register.falowen.app/#contact",
+    "Blog": "https://blog.falowen.app",
+    "About Us": "https://register.falowen.app/#about-us",
+    "Mission": "https://register.falowen.app/#mission",
 }
 
 def render_app_footer(links: dict):


### PR DESCRIPTION
## Summary
- Extend `FOOTER_LINKS` with Blog, About Us, and Mission URLs
- Footer rendering continues to iterate over links in insertion order

## Testing
- `ruff check a1sprechen.py` *(fails: Found 107 errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b39aa04c8321b0abd506b9fb7875