### PR TITLE
Remove Mission link from login footer

### DIFF
--- a/templates/falowen_login.html
+++ b/templates/falowen_login.html
@@ -146,8 +146,7 @@
       <a href="https://register.falowen.app/#privacy-policy" target="_blank">Privacy Policy</a> |
       <a href="https://script.google.com/macros/s/AKfycbwXrfiuKl65Va_B2Nr4dFnyLRW5z6wT5kAbCj6cNl1JxdOzWVKT_ZMwdh2pN_dbdFoy/exec" target="_blank">Request Account Deletion</a> |
       <a href="https://blog.falowen.app" target="_blank">Blog</a> |
-      <a href="https://register.falowen.app/#about-us" target="_blank">About Us</a> |
-      <a href="https://register.falowen.app/#mission" target="_blank">Mission</a>
+      <a href="https://register.falowen.app/#about-us" target="_blank">About Us</a>
     </div>
     <div style="margin-top:6px;font-size:.9rem;">© 2024 Falowen</div>
   </footer>


### PR DESCRIPTION
## Summary
- remove unused Mission link from the Falowen login footer
- keep Terms, Privacy Policy, Request Account Deletion, Blog, and About Us links intact

## Testing
- `ruff check .` *(fails: Found 130 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0b7dcadc08321b7455f55cd56f868