### PR TITLE
Update German writing rules link placement

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6440,6 +6440,9 @@ if tab == "Schreiben Trainer":
                 options,
                 key=f"practice_prompt_{student_code}",
             )
+            st.markdown(
+                "**[German Writing Rules](https://drive.google.com/file/d/1o7_ez3WSNgpgxU_nEtp6EO1PXDyi3K3b/view?usp=sharing)**",
+            )
             prompt = next((p for p in prompts if p["Thema"] == selected_theme), None)
             if prompt:
                 st.markdown(f"### ✉️ {prompt['Thema']}")

--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -990,12 +990,6 @@ def render_results_and_resources_tab() -> None:
 
     elif rr_page == "Resources":
         st.subheader("Useful Resources")
-        st.markdown(
-            """
-**[German Writing Rules](https://drive.google.com/file/d/1o7_ez3WSNgpgxU_nEtp6EO1PXDyi3K3b/view?usp=sharing)**
-Tips and grammar rules for better writing.
-            """
-        )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Remove obsolete German Writing Rules link from results resources tab
- Add German Writing Rules link in Practice Letters section before instructional info

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c151ea8b2c8321ac223f0e2d97fecf