### PR TITLE
Add German writing rules links

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6462,6 +6462,10 @@ if tab == "Schreiben Trainer":
         daily_so_far = get_schreiben_usage(student_code)
         st.markdown(f"**Daily usage:** {daily_so_far} / {SCHREIBEN_DAILY_LIMIT}")
 
+        st.markdown(
+            "**[German Writing Rules](https://drive.google.com/file/d/1o7_ez3WSNgpgxU_nEtp6EO1PXDyi3K3b/view?usp=sharing)**",
+        )
+
         try:
             _ = _wkey
         except NameError:
@@ -6840,6 +6844,9 @@ if tab == "Schreiben Trainer":
             save_now(ns("chat_draft"), student_code)
             st.session_state.pop(ns("reset_coach"))
 
+        st.markdown(
+            "**[German Writing Rules](https://drive.google.com/file/d/1o7_ez3WSNgpgxU_nEtp6EO1PXDyi3K3b/view?usp=sharing)**",
+        )
 
         LETTER_COACH_PROMPTS = {
             "A1": (


### PR DESCRIPTION
## Summary
- Display German writing rules link in the 'Mark My Letter' tab
- Surface the same writing rules link in the 'Ideas Generator (Letter Coach)' tab

## Testing
- `ruff check a1sprechen.py` *(fails: Multiple statements on one line, other style issues)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c15fe3191c8321b57e399beff6ad02