### PR TITLE
Add blog and account deletion links to footers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -489,6 +489,8 @@ button[disabled] { opacity: .6; cursor: not-allowed; }
     <div class="row">
       <a href="#tutors">👩‍🏫 Tutors</a> |
       <a href="#classes">🗓️ Upcoming Classes</a> |
+      <a href="#blog">📖 Blog</a> |
+      <a href="#delete-account">🗑️ Request Account Deletion</a> |
       <a href="#privacy">🔒 Privacy</a> |
       <a href="#terms">📜 Terms</a> |
       <a href="#contact">✉️ Contact</a>

--- a/templates/falowen_login.html
+++ b/templates/falowen_login.html
@@ -152,6 +152,8 @@
     <div class="row">
       <a href="#tutors">👩‍🏫 Tutors</a> |
       <a href="#classes">🗓️ Upcoming Classes</a> |
+      <a href="#blog">📖 Blog</a> |
+      <a href="#delete-account">🗑️ Request Account Deletion</a> |
       <a href="#privacy">🔒 Privacy</a> |
       <a href="#terms">📜 Terms</a> |
       <a href="#contact">✉️ Contact</a>


### PR DESCRIPTION
## Summary
- include Blog and Request Account Deletion links in public landing page footer
- mirror seven-link footer in login template for consistency

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1781ffb8c8321845c4a74a00a52e7