### PR TITLE
Use Google Sheets for blog feed and tweak announcements UI

### DIFF
--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -160,7 +160,7 @@ def render_announcements(announcements: list) -> None:
       .ann-dot[aria-current="true"]{background:var(--brand);opacity:1;transform:scale(1.22);box-shadow:0 0 0 4px var(--ring)}
     </style>
     <div class="page-wrap">
-      <div class="ann-title">📣 New Updates</div>
+      <div class="ann-title">📣 Blog Updates.</div>
       <div class="ann-shell" id="ann_shell" aria-live="polite">
         <div id="ann_card">
           <div class="ann-heading"><span class="ann-chip" id="ann_tag" style="display:none;"></span><span id="ann_title"></span></div>
@@ -182,9 +182,9 @@ def render_announcements(announcements: list) -> None:
       function render(idx){
         const c = data[idx] || {};
         titleEl.textContent = c.title || '';
-        bodyEl.textContent  = c.body  || '';
+        if (c.body){ bodyEl.textContent = c.body; bodyEl.style.display=''; } else { bodyEl.textContent=''; bodyEl.style.display='none'; }
         if (c.tag){ tagEl.textContent = c.tag; tagEl.style.display=''; } else { tagEl.style.display='none'; }
-        if (c.href){ const link = document.createElement('a'); link.href = c.href; link.target = '_blank'; link.rel='noopener'; link.textContent='Open';
+        if (c.href){ const link = document.createElement('a'); link.href = c.href; link.target = '_blank'; link.rel='noopener'; link.textContent='Read more.';
           actionEl.textContent=''; actionEl.appendChild(link); actionEl.style.display=''; } else { actionEl.textContent=''; actionEl.style.display='none'; }
         setActiveDot(idx);
       }
@@ -208,7 +208,11 @@ def render_announcements(announcements: list) -> None:
         )
     except TypeError:
         for a in announcements:
-            st.markdown(f"**{a.get('title','')}** — {a.get('body','')}")
+            text = f"**{a.get('title','')}**"
+            if a.get('body'):
+                text += f" — {a.get('body','')}"
+            st.markdown(text)
+    st.markdown("Visit [blog.falowen.app](https://blog.falowen.app) for more.")
 
 
 def render_announcements_once(data: list, dashboard_active: bool) -> None:

--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -6,10 +6,7 @@ from src.blog_feed import fetch_blog_feed
 
 
 def test_fetch_blog_feed_parses_items(monkeypatch):
-    sample = (
-        "<?xml version='1.0'?><rss><channel><item><title>Test</title>"
-        "<link>http://example.com</link><description>Hello</description></item></channel></rss>"
-    )
+    sample = "Topic,Link,Body\nTest,http://example.com,Hello\n" "Another,http://ex.com,"
 
     def fake_get(url, timeout=10):
         return types.SimpleNamespace(content=sample.encode(), raise_for_status=lambda: None)
@@ -17,7 +14,7 @@ def test_fetch_blog_feed_parses_items(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
     fetch_blog_feed.clear()
     items = fetch_blog_feed(limit=1)
-    assert items == [{"title": "Test", "body": "Hello", "href": "http://example.com"}]
+    assert items == [{"title": "Test", "href": "http://example.com", "body": "Hello"}]
 
 
 def test_fetch_blog_feed_handles_error(monkeypatch):

--- a/tests/test_ui_widgets_announcements.py
+++ b/tests/test_ui_widgets_announcements.py
@@ -5,7 +5,6 @@ import hashlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import pytest
 from streamlit.testing.v1 import AppTest
 
 # Allow importing from src
@@ -44,7 +43,7 @@ def test_render_announcements_fallback_without_banner(monkeypatch):
     monkeypatch.setattr(ui_widgets, "components", SimpleNamespace(html=failing_html))
     monkeypatch.setattr(ui_widgets.st, "markdown", fake_markdown)
     ui_widgets.render_announcements([{"title": "t", "body": "b"}])
-    assert outputs == ["**t** — b"]
+    assert outputs == ["**t** — b", "Visit [blog.falowen.app](https://blog.falowen.app) for more."]
     assert all(BANNER not in o for o in outputs)
 
 


### PR DESCRIPTION
## Summary
- Switch blog feed to pull CSV from Google Sheets and map Topic/Link columns
- Refresh announcement widget: “📣 Blog Updates.” heading, hide missing body, “Read more.” links, and site note
- Update tests for new CSV feed and UI note

## Testing
- `ruff check src/blog_feed.py src/ui_widgets.py tests/test_blog_feed.py tests/test_ui_widgets_announcements.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a28180d88321b6eb980fc7d35a1c