### PR TITLE
Update blog feed and announcements tests

### DIFF
--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -5,16 +5,18 @@ import requests
 from src.blog_feed import fetch_blog_feed
 
 
-def test_fetch_blog_feed_parses_items(monkeypatch):
-    sample = "Topic,Link,Body\nTest,http://example.com,Hello\n" "Another,http://ex.com,"
+def test_fetch_blog_feed_maps_topic_and_link(monkeypatch):
+    csv_data = "Topic,Link\nTest,http://example.com\n"
 
     def fake_get(url, timeout=10):
-        return types.SimpleNamespace(content=sample.encode(), raise_for_status=lambda: None)
+        return types.SimpleNamespace(content=csv_data.encode("utf-8"), raise_for_status=lambda: None)
 
     monkeypatch.setattr(requests, "get", fake_get)
     fetch_blog_feed.clear()
     items = fetch_blog_feed(limit=1)
-    assert items == [{"title": "Test", "href": "http://example.com", "body": "Hello"}]
+    assert items[0]["title"] == "Test"
+    assert items[0]["href"] == "http://example.com"
+    assert "body" not in items[0]
 
 
 def test_fetch_blog_feed_handles_error(monkeypatch):

--- a/tests/test_ui_widgets_announcements.py
+++ b/tests/test_ui_widgets_announcements.py
@@ -23,9 +23,11 @@ def test_render_announcements_without_banner(monkeypatch):
         captured["html"] = html
 
     monkeypatch.setattr(ui_widgets, "components", SimpleNamespace(html=fake_html))
-    ui_widgets.render_announcements([{"title": "t", "body": "b"}])
+    ui_widgets.render_announcements([{"title": "t", "body": "b", "href": "https://xmpl"}])
+    assert "📣 Blog Updates." in captured["html"]
     assert "t" in captured["html"]
     assert "b" in captured["html"]
+    assert "Read more." in captured["html"]
     assert BANNER not in captured["html"]
 
 
@@ -65,6 +67,23 @@ def test_render_announcements_empty(monkeypatch):
     assert info_msgs == ["📣 No new updates to show."]
     assert "html" not in called
     assert all(BANNER not in m for m in info_msgs)
+
+
+def test_render_announcements_footer_has_blog_link(monkeypatch):
+    import importlib
+    importlib.reload(ui_widgets)
+    footers = []
+
+    def fake_html(*_, **__):
+        return None
+
+    def fake_markdown(msg, *_, **__):
+        footers.append(msg)
+
+    monkeypatch.setattr(ui_widgets, "components", SimpleNamespace(html=fake_html))
+    monkeypatch.setattr(ui_widgets.st, "markdown", fake_markdown)
+    ui_widgets.render_announcements([{"title": "t"}])
+    assert footers == ["Visit [blog.falowen.app](https://blog.falowen.app) for more."]
 
 def test_render_announcements_once_skips_when_hash_matches(monkeypatch):
     render_mock = MagicMock()


### PR DESCRIPTION
## Summary
- mock CSV in blog feed test to verify Topic and Link mapping
- adjust announcement widget tests for new heading, empty state message, and "Read more" link
- add regression test to ensure footer links to blog.falowen.app

## Testing
- `pytest tests/test_blog_feed.py tests/test_ui_widgets_announcements.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1a47c9d5c83219dff1e5489ea7b27