### PR TITLE
refactor: remove blog announcement fallback

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -768,14 +768,7 @@ inject_notice_css()
 render_sidebar_published()
 
 # Announcements (render once)
-_fallback_announcements = [
-    {"title": "Quick Access Menu", "body": "Use the left sidebar for quick access to lessons, tools, and resources.", "tag": "New"},
-    {"title": "Download Receipts & Results", "body": "Grab your receipt, results, and enrollment letter under **My Results & Resources**.", "tag": "New"},
-    {"title": "Account Deletion Requests", "body": "You can now request account deletion from your account settings.", "tag": "Info"},
-    {"title": "Refresh Session Fix", "body": "Frequent refresh session prompts have been resolved for smoother navigation.", "tag": "Update"},
-    {"title": "Attendance Now Being Marked", "body": "Find attendance under My Course ➜ Classroom/Attendance. Telegram notifications are available.", "tag": "New"},
-]
-announcements = fetch_blog_feed() or _fallback_announcements
+announcements = fetch_blog_feed()
 
 st.markdown("---")
 st.markdown("**You’re logged in.** Continue to your lessons and tools from the navigation.")


### PR DESCRIPTION
## Summary
- remove hardcoded announcement fallback and rely solely on blog feed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a7c78c64832182299cd4e7a958d9