### PR TITLE
Skip empty blog feed rows

### DIFF
--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -42,6 +42,8 @@ def fetch_blog_feed(limit: int = 5) -> List[Dict[str, str]]:
             break
         title = (row.get("Topic") or "").strip()
         href = (row.get("Link") or "").strip()
+        if not title or not href:
+            continue
         body = (row.get("Body") or row.get("Description") or "").strip()
         item: Dict[str, str] = {"title": title, "href": href}
         if body:

--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -19,6 +19,20 @@ def test_fetch_blog_feed_maps_topic_and_link(monkeypatch):
     assert "body" not in items[0]
 
 
+def test_fetch_blog_feed_skips_empty_rows(monkeypatch):
+    csv_data = "Topic,Link\nValid,http://example.com\n,\nAnother,http://example.org\n"
+
+    def fake_get(url, timeout=10):
+        return types.SimpleNamespace(content=csv_data.encode("utf-8"), raise_for_status=lambda: None)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    fetch_blog_feed.clear()
+    items = fetch_blog_feed(limit=5)
+    assert len(items) == 2
+    assert items[0]["title"] == "Valid"
+    assert items[1]["title"] == "Another"
+
+
 def test_fetch_blog_feed_handles_error(monkeypatch):
     def boom(*a, **k):
         raise RuntimeError("nope")


### PR DESCRIPTION
## Summary
- ignore blog feed entries missing a title or link
- test that empty CSV rows are skipped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1bf3255c88321b97b490cbb956530