### PR TITLE
Normalize blog feed CSV headers

### DIFF
--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -36,15 +36,18 @@ def fetch_blog_feed(limit: int = 5) -> List[Dict[str, str]]:
     except Exception:
         return []
 
+    # Normalize headers to be case-insensitive and whitespace tolerant
+    reader.fieldnames = [fn.strip().lower() for fn in reader.fieldnames or []]
+
     items: List[Dict[str, str]] = []
     for row in reader:
         if len(items) >= min(limit, 5):
             break
-        title = (row.get("Topic") or "").strip()
-        href = (row.get("Link") or "").strip()
+        title = (row.get("topic") or "").strip()
+        href = (row.get("link") or "").strip()
         if not title or not href:
             continue
-        body = (row.get("Body") or row.get("Description") or "").strip()
+        body = (row.get("body") or row.get("description") or "").strip()
         item: Dict[str, str] = {"title": title, "href": href}
         if body:
             item["body"] = body

--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -19,6 +19,20 @@ def test_fetch_blog_feed_maps_topic_and_link(monkeypatch):
     assert "body" not in items[0]
 
 
+def test_fetch_blog_feed_handles_lowercase_headers(monkeypatch):
+    csv_data = "topic,link,body\nTest,http://example.com,Desc\n"
+
+    def fake_get(url, timeout=10):
+        return types.SimpleNamespace(content=csv_data.encode("utf-8"), raise_for_status=lambda: None)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    fetch_blog_feed.clear()
+    items = fetch_blog_feed(limit=1)
+    assert items[0]["title"] == "Test"
+    assert items[0]["href"] == "http://example.com"
+    assert items[0]["body"] == "Desc"
+
+
 def test_fetch_blog_feed_skips_empty_rows(monkeypatch):
     csv_data = "Topic,Link\nValid,http://example.com\n,\nAnother,http://example.org\n"
 


### PR DESCRIPTION
## Summary
- Normalize CSV reader headers and parse fields case-insensitively in blog feed
- Add regression test for lowercase blog feed headers

## Testing
- `ruff check src/blog_feed.py tests/test_blog_feed.py`
- `pytest tests/test_blog_feed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1bffbf47083219c490d4daa285185