### PR TITLE
chore: preload Google fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,8 @@
   <!-- Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"></noscript>
   <style>
     
 /* --- Accessibility & states --- */

--- a/templates/falowen_login.html
+++ b/templates/falowen_login.html
@@ -7,7 +7,8 @@
   <title>Falowen</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"></noscript>
   <style>
     :root {
       --bg:#0b1220; --bg2:#0e172a; --card:rgba(255,255,255,0.08); --card-opaque:#ffffff;


### PR DESCRIPTION
## Summary
- preload Inter font with async loading to reduce render blocking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1bfcf415c8321b0c026a8cc4bc21d