### PR TITLE
Remove obsolete class board button and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This value is required for secure cookie management. If it is omitted the app fa
 
 ## Usage
 
-- From the Dashboard, use **View class board** to jump to the class notes & Q&A section.
 
 ### Vocab Sheet Format
 

--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -518,7 +518,6 @@ def render_sidebar_published():
 - **Practice speaking:** **Tools → Sprechen** for instant pronunciation feedback.
 - **Build vocab:** **Vocab Trainer** for daily words & review cycles.
 - **Track progress:** **Dashboard** shows streaks, next lesson, and missed items.
-- **See class notes:** Dashboard → **View class board** for notes and Q&A.
             """
         )
 
@@ -1040,16 +1039,6 @@ render_announcements_once(announcements, tab == "Dashboard")
 # ===================== Dashboard =========================
 # =========================================================
 if tab == "Dashboard":
-    def _go_classboard() -> None:
-        st.session_state["nav_sel"] = "My Course"
-        st.session_state["main_tab_select"] = "My Course"
-        st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
-        st.session_state["cb_prev_subtab"] = "🧑‍🏫 Classroom"
-        st.session_state["classroom_page"] = "Class Notes & Q&A"
-        st.session_state["classroom_prev_page"] = "Class Notes & Q&A"
-        _qp_set(tab="My Course")
-        st.session_state["need_rerun"] = True
-
     def _go_attendance() -> None:
         st.session_state["nav_sel"] = "My Course"
         st.session_state["main_tab_select"] = "My Course"
@@ -1059,8 +1048,6 @@ if tab == "Dashboard":
         st.session_state["classroom_prev_page"] = "Attendance"
         _qp_set(tab="My Course")
         st.session_state["need_rerun"] = True
-
-    st.button("View class board", on_click=_go_classboard)
 
     # ---------- Helpers ----------
     def safe_get(row, key, default=""):


### PR DESCRIPTION
## Summary
- remove unused `View class board` navigation button and helper
- prune related sidebar bullet and README reference

## Testing
- `ruff check a1sprechen.py | head -n 20` *(fails: F401, etc.)*
- `ruff format --check a1sprechen.py` *(fails: would reformat)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1c37e66208321addb11116d244213