### PR TITLE
Add announcement autoplay timer with reset on navigation

### DIFF
--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -178,6 +178,7 @@ def render_announcements(announcements: list) -> None:
       const actionEl= document.getElementById('ann_action');
       const dotsWrap= document.getElementById('ann_dots');
       let i = 0;
+      let timer;
       function setActiveDot(idx){ [...dotsWrap.children].forEach((d,j)=> d.setAttribute('aria-current', j===idx ? 'true':'false')); }
       function render(idx){
         const c = data[idx] || {};
@@ -188,16 +189,22 @@ def render_announcements(announcements: list) -> None:
           actionEl.textContent=''; actionEl.appendChild(link); actionEl.style.display=''; } else { actionEl.textContent=''; actionEl.style.display='none'; }
         setActiveDot(idx);
       }
+      function restartTimer(){
+        if (data.length <= 1) return;
+        clearInterval(timer);
+        timer = setInterval(()=>{ i = (i + 1) % data.length; render(i); }, 5000);
+      }
       function bindQuick(el, handler){
-        el.addEventListener('click', handler);
-        el.addEventListener('pointerdown', (e)=>{ if(e.pointerType!=='mouse'){ e.preventDefault(); handler(); }});
+        el.addEventListener('click', ()=>{ handler(); restartTimer(); });
+        el.addEventListener('pointerdown', (e)=>{ if(e.pointerType!=='mouse'){ e.preventDefault(); handler(); restartTimer(); }});
       }
 
       data.forEach((_, idx)=>{ const b=document.createElement('button'); b.className='ann-dot'; b.type='button'; b.setAttribute('role','tab');
         b.setAttribute('aria-label','Slide '+(idx+1)); b.setAttribute('tabindex','0'); bindQuick(b, ()=>{ i=idx; render(i); });
-        b.addEventListener('keydown', (e)=>{ if(e.key==='Enter'||e.key===' '||e.key==='Spacebar'){ e.preventDefault(); i=idx; render(i); }});
+        b.addEventListener('keydown', (e)=>{ if(e.key==='Enter'||e.key===' '||e.key==='Spacebar'){ e.preventDefault(); i=idx; render(i); restartTimer(); }});
         dotsWrap.appendChild(b); });
       render(i);
+      if (data.length > 1) { timer = setInterval(()=>{ i = (i + 1) % data.length; render(i); }, 5000); }
     </script>
     """
     try:

--- a/tests/test_ui_widgets_announcements.py
+++ b/tests/test_ui_widgets_announcements.py
@@ -23,11 +23,15 @@ def test_render_announcements_without_banner(monkeypatch):
         captured["html"] = html
 
     monkeypatch.setattr(ui_widgets, "components", SimpleNamespace(html=fake_html))
-    ui_widgets.render_announcements([{"title": "t", "body": "b", "href": "https://xmpl"}])
+    ui_widgets.render_announcements([
+        {"title": "t", "body": "b", "href": "https://xmpl"},
+        {"title": "t2"},
+    ])
     assert "📣 Blog Updates." in captured["html"]
     assert "t" in captured["html"]
     assert "b" in captured["html"]
     assert "Read more." in captured["html"]
+    assert "setInterval" in captured["html"]
     assert BANNER not in captured["html"]
 
 


### PR DESCRIPTION
## Summary
- Autoplay announcements with a 5s timer
- Restart timer when navigating manually and skip timer for single-item feeds
- Test announcements render includes timer logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1e52103d883219ad807c01b8280de