### PR TITLE
Summarize student responses after six chat turns

### DIFF
--- a/tests/test_turn_count.py
+++ b/tests/test_turn_count.py
@@ -8,44 +8,51 @@ def _load_increment_fn():
     mod = ast.parse(src)
     wanted = []
     for node in mod.body:
-        if isinstance(node, ast.Assign):
-            for tgt in node.targets:
-                if isinstance(tgt, ast.Name) and tgt.id == 'FINAL_FEEDBACK_MESSAGE':
-                    wanted.append(node)
         if isinstance(node, ast.FunctionDef) and node.name == 'increment_turn_count_and_maybe_close':
             wanted.append(node)
     module_ast = ast.Module(body=wanted, type_ignores=[])
     code = compile(module_ast, 'a1sprechen.py', 'exec')
     st = SimpleNamespace(session_state={})
-    glb = {'st': st}
+
+    def dummy_summary(msgs):
+        dummy_summary.called_with = msgs
+        return 'SUMMARY'
+
+    glb = {'st': st, 'generate_summary': dummy_summary}
     exec(code, glb)
-    return glb['increment_turn_count_and_maybe_close'], glb['FINAL_FEEDBACK_MESSAGE'], st
+    return glb['increment_turn_count_and_maybe_close'], dummy_summary, st
 
 
 def test_increment_and_finalize_after_six():
-    inc, final_msg, st = _load_increment_fn()
+    inc, dummy, st = _load_increment_fn()
     ss = st.session_state
     ss['falowen_turn_count'] = 5
-    ss['falowen_messages'] = []
+    ss['falowen_messages'] = [
+        {'role': 'user', 'content': 'Hallo'},
+        {'role': 'assistant', 'content': 'Hi'},
+        {'role': 'user', 'content': 'Tschüss'},
+    ]
     ended = inc(False)
     assert ended is True
     assert ss['falowen_turn_count'] == 6
-    assert ss['falowen_messages'][-1]['content'] == final_msg
+    assert ss['falowen_messages'][-1]['content'] == 'SUMMARY'
+    assert dummy.called_with == ['Hallo', 'Tschüss']
 
 
 def test_increment_when_below_limit():
-    inc, final_msg, st = _load_increment_fn()
+    inc, dummy, st = _load_increment_fn()
     ss = st.session_state
     ss['falowen_turn_count'] = 2
-    ss['falowen_messages'] = []
+    ss['falowen_messages'] = [{'role': 'user', 'content': 'Hallo'}]
     ended = inc(False)
     assert ended is False
     assert ss['falowen_turn_count'] == 3
-    assert ss['falowen_messages'] == []
+    assert ss['falowen_messages'] == [{'role': 'user', 'content': 'Hallo'}]
+    assert not hasattr(dummy, 'called_with')
 
 
 def test_no_increment_in_exam_mode():
-    inc, final_msg, st = _load_increment_fn()
+    inc, dummy, st = _load_increment_fn()
     ss = st.session_state
     ss['falowen_turn_count'] = 4
     ss['falowen_messages'] = []
@@ -53,3 +60,4 @@ def test_no_increment_in_exam_mode():
     assert ended is False
     assert ss['falowen_turn_count'] == 4
     assert ss['falowen_messages'] == []
+    assert not hasattr(dummy, 'called_with')


### PR DESCRIPTION
## Summary
- add `generate_summary` helper that calls OpenAI to condense user messages into a ~60-word presentation
- update turn handling to gather user messages and append the generated summary when the sixth response is reached
- adjust tests to expect summary behavior instead of a fixed final message

## Testing
- `ruff check a1sprechen.py tests/test_turn_count.py` *(fails: many existing style errors)*
- `pytest tests/test_turn_count.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2dff66f5883218d62244d1ecb35f2