### PR TITLE
Handle IndexError during notes PDF generation

### DIFF
--- a/src/pdf_handling.py
+++ b/src/pdf_handling.py
@@ -54,36 +54,53 @@ def generate_notes_pdf(
             self.cell(0, 12, "My Learning Notes", align="C", ln=1)
             self.ln(5)
 
-    pdf = PDF()
-    pdf.add_font("DejaVu", "", font_path, uni=True)
-    pdf.add_page()
-    pdf.set_auto_page_break(auto=True, margin=15)
-    pdf.set_font("DejaVu", "", 13)
-    pdf.cell(0, 10, "Table of Contents", ln=1)
-    pdf.set_font("DejaVu", "", 11)
-    for idx, note in enumerate(notes):
-        toc_line = f"{idx+1}. {note.get('title','')} - {note.get('created', note.get('updated',''))}"
-        pdf.cell(0, 8, clean_for_pdf(toc_line), ln=1)
-    pdf.ln(5)
-    for n in notes:
+    def _build_pdf(ns: List[Dict[str, Any]]) -> "FPDF":
+        pdf = PDF()
+        pdf.add_font("DejaVu", "", font_path, uni=True)
+        pdf.add_page()
+        pdf.set_auto_page_break(auto=True, margin=15)
         pdf.set_font("DejaVu", "", 13)
-        pdf.cell(0, 10, clean_for_pdf(f"Title: {n.get('title','')}"), ln=1)
+        pdf.cell(0, 10, "Table of Contents", ln=1)
         pdf.set_font("DejaVu", "", 11)
-        if n.get("tag"):
-            pdf.cell(0, 8, clean_for_pdf(f"Tag: {n['tag']}"), ln=1)
-        if n.get("lesson"):
-            pdf.cell(0, 8, clean_for_pdf(f"Lesson: {n['lesson']}"), ln=1)
-        pdf.set_font("DejaVu", "", 12)
-        for line in n.get("text", "").split("\n"):
-            pdf.multi_cell(0, 7, clean_for_pdf(line))
-        pdf.ln(1)
-        pdf.set_font("DejaVu", "", 11)
-        pdf.cell(0, 8, clean_for_pdf(f"Date: {n.get('updated', n.get('created',''))}"), ln=1)
+        for idx, note in enumerate(ns):
+            toc_line = f"{idx+1}. {note.get('title','')} - {note.get('created', note.get('updated',''))}"
+            pdf.cell(0, 8, clean_for_pdf(toc_line), ln=1)
         pdf.ln(5)
-        pdf.set_font("DejaVu", "", 10)
-        pdf.cell(0, 4, "-" * 55, ln=1)
-        pdf.ln(8)
-    return pdf.output(dest="S").encode("latin1", "replace")
+        for n in ns:
+            pdf.set_font("DejaVu", "", 13)
+            pdf.cell(0, 10, clean_for_pdf(f"Title: {n.get('title','')}"), ln=1)
+            pdf.set_font("DejaVu", "", 11)
+            if n.get("tag"):
+                pdf.cell(0, 8, clean_for_pdf(f"Tag: {n['tag']}"), ln=1)
+            if n.get("lesson"):
+                pdf.cell(0, 8, clean_for_pdf(f"Lesson: {n['lesson']}"), ln=1)
+            pdf.set_font("DejaVu", "", 12)
+            for line in n.get("text", "").split("\n"):
+                pdf.multi_cell(0, 7, clean_for_pdf(line))
+            pdf.ln(1)
+            pdf.set_font("DejaVu", "", 11)
+            pdf.cell(0, 8, clean_for_pdf(f"Date: {n.get('updated', n.get('created',''))}"), ln=1)
+            pdf.ln(5)
+            pdf.set_font("DejaVu", "", 10)
+            pdf.cell(0, 4, "-" * 55, ln=1)
+            pdf.ln(8)
+        return pdf
+
+    pdf = _build_pdf(notes)
+    try:
+        return pdf.output(dest="S").encode("latin1", "replace")
+    except IndexError:
+        cleaned: List[Dict[str, Any]] = []
+        for note in notes:
+            new_note: Dict[str, Any] = {}
+            for k, v in note.items():
+                if isinstance(v, str):
+                    v = v.encode("utf-8", "ignore").decode("utf-8")
+                    v = v.encode("latin1", "ignore").decode("latin1")
+                new_note[k] = v
+            cleaned.append(new_note)
+        pdf = _build_pdf(cleaned)
+        return pdf.output(dest="S").encode("latin1", "replace")
 
 
 def generate_single_note_pdf(

--- a/tests/test_notes_pdf_emoji.py
+++ b/tests/test_notes_pdf_emoji.py
@@ -6,9 +6,6 @@ from src.pdf_handling import FPDF, generate_notes_pdf
 @pytest.mark.skipif(FPDF is None, reason="fpdf not installed")
 def test_generate_notes_pdf_handles_emoji():
     note = {"title": "Emoji 😊", "tag": "tag😊", "text": "Body with emoji 😊"}
-    try:
-        pdf_bytes = generate_notes_pdf([note])
-    except Exception:
-        pytest.skip("emoji not supported by current font")
+    pdf_bytes = generate_notes_pdf([note])
     assert isinstance(pdf_bytes, bytes)
     assert len(pdf_bytes) > 0


### PR DESCRIPTION
## Summary
- rebuild notes PDF generation inside helper
- re-encode note fields and retry when FPDF raises IndexError
- add regression test covering emoji characters

## Testing
- `pytest tests/test_notes_pdf_emoji.py -q`
- `pytest tests/test_chat_pdf_unicode.py -q`
- `pytest tests/test_attendance_pdf_unicode.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2eedca8bc8321ba6962763a00babf