### PR TITLE
Remove Resources option from results tab

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -519,7 +519,7 @@ def render_results_and_resources_tab() -> None:
         df_display = df_lvl.copy()
         total = completed = 0
         avg_score = best_score = 0.0
-        sections = ["Downloads", "Resources"]
+        sections = ["Downloads"]
     else:
         df_user = df_user.copy()
         df_user["level"] = df_user["level"].astype(str).str.upper().str.strip()
@@ -549,7 +549,6 @@ def render_results_and_resources_tab() -> None:
             "Badges",
             "Missed & Next",
             "Downloads",
-            "Resources",
         ]
 
     if ("rr_page" not in st.session_state) or (
@@ -987,9 +986,6 @@ def render_results_and_resources_tab() -> None:
                 else:
                     st.info("No attendance data available.")
 
-
-    elif rr_page == "Resources":
-        st.subheader("Useful Resources")
 
 
 __all__ = [

--- a/tests/test_results_downloads_only.py
+++ b/tests/test_results_downloads_only.py
@@ -56,4 +56,4 @@ def test_downloads_option_rendered_when_no_scores(monkeypatch):
 
     assignment_ui.render_results_and_resources_tab()
 
-    assert calls[0] == ["Downloads", "Resources"]
+    assert calls[0] == ["Downloads"]


### PR DESCRIPTION
## Summary
- drop "Resources" option from results tab
- adjust tests to expect only downloads when no scores

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3fa7174d0832181d8f63e2c119ff2