### PR TITLE
Show blog announcements on login page

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -185,6 +185,7 @@ from src.youtube import (
 from src.ui_widgets import (
     render_google_brand_button_once,
     render_announcements_once,
+    render_announcements,
 )
 from src.logout import do_logout
 from src.pdf_handling import (
@@ -327,6 +328,11 @@ def login_page():
         <h3 style="margin:0 0 4px 0;">3️⃣ Get results</h3>
         <p style="margin:0;">You’ll get an <b>email when marked</b>. Check <b>Results & Resources</b> for feedback.</p>
         """, unsafe_allow_html=True)
+
+    # Blog posts / announcements
+    blog_posts = fetch_blog_feed()
+    if blog_posts:
+        render_announcements(blog_posts)
 
     # Footer links
     st.markdown("""

--- a/tests/test_login_page_blog_announcements.py
+++ b/tests/test_login_page_blog_announcements.py
@@ -1,0 +1,68 @@
+import ast
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+class DummyCtx:
+    def __enter__(self):
+        return None
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def load_login_page():
+    src = Path('a1sprechen.py').read_text()
+    module = ast.parse(src, filename='a1sprechen.py')
+    login_node = next(
+        node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == 'login_page'
+    )
+    code = compile(ast.Module(body=[login_node], type_ignores=[]), filename='login_page', mode='exec')
+    ns = {}
+    exec(code, ns)
+    return ns['login_page'], ns
+
+
+def make_streamlit_stub():
+    st = types.SimpleNamespace(session_state={}, markdown=MagicMock(), info=MagicMock())
+    def tabs(labels):
+        return (DummyCtx(), DummyCtx())
+    st.tabs = tabs
+    def columns(n):
+        return [DummyCtx() for _ in range(n)]
+    st.columns = columns
+    return st
+
+
+def run_login_page():
+    login_page, ns = load_login_page()
+    st = make_streamlit_stub()
+    ns.update({
+        'st': st,
+        'render_google_oauth': MagicMock(return_value='auth'),
+        'render_falowen_login': MagicMock(),
+        'render_returning_login_area': MagicMock(return_value=False),
+        'render_signup_request_banner': MagicMock(),
+        'render_signup_form': MagicMock(),
+        'render_google_brand_button_once': MagicMock(),
+    })
+    fetch_mock = MagicMock(return_value=[{'title': 't'}])
+    render_mock = MagicMock()
+    ns['fetch_blog_feed'] = fetch_mock
+    ns['render_announcements'] = render_mock
+    login_page.__globals__.update(ns)
+    return login_page, fetch_mock, render_mock
+
+
+def test_announcements_render_for_logged_out_and_after_signup():
+    login_page, fetch_mock, render_mock = run_login_page()
+    login_page()
+    fetch_mock.assert_called_once()
+    render_mock.assert_called_once_with([{'title': 't'}])
+
+    fetch_mock.reset_mock()
+    render_mock.reset_mock()
+    login_page()
+    fetch_mock.assert_called_once()
+    render_mock.assert_called_once_with([{'title': 't'}])


### PR DESCRIPTION
## Summary
- Fetch latest blog posts on the login page and show them beneath the step images
- Import announcement renderer and blog feed utility
- Add regression test ensuring announcements render for repeated visits

## Testing
- `pytest tests/test_login_page_blog_announcements.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c431a9dc008321a237b1f5c729397b