### PR TITLE
Update footer privacy and terms links

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -341,9 +341,9 @@ def login_page():
       &nbsp;|&nbsp;
       <a href="https://www.learngermanghana.com/upcoming-classes" target="_blank" rel="noopener">🗓️ Upcoming Classes</a>
       &nbsp;|&nbsp;
-      <a href="https://www.learngermanghana.com/privacy-policy"   target="_blank" rel="noopener">🔒 Privacy</a>
+      <a href="https://register.falowen.app/#privacy-policy"      target="_blank" rel="noopener">🔒 Privacy</a>
       &nbsp;|&nbsp;
-      <a href="https://www.learngermanghana.com/terms-of-service" target="_blank" rel="noopener">📜 Terms</a>
+      <a href="https://register.falowen.app/#terms-of-service"    target="_blank" rel="noopener">📜 Terms</a>
       &nbsp;|&nbsp;
       <a href="https://www.learngermanghana.com/contact-us"       target="_blank" rel="noopener">✉️ Contact</a>
       &nbsp;|&nbsp;
@@ -893,8 +893,8 @@ def _dict_tts_bytes_de(text: str) -> Optional[bytes]:
 FOOTER_LINKS = {
     "👩‍🏫 Tutors": "https://www.learngermanghana.com/tutors",
     "🗓️ Upcoming Classes": "https://www.learngermanghana.com/upcoming-classes",
-    "🔒 Privacy": "https://www.learngermanghana.com/privacy-policy",
-    "📜 Terms": "https://www.learngermanghana.com/terms-of-service",
+    "🔒 Privacy": "https://register.falowen.app/#privacy-policy",
+    "📜 Terms": "https://register.falowen.app/#terms-of-service",
     "✉️ Contact": "https://www.learngermanghana.com/contact-us",
     "📝 Register": "https://register.falowen.app",
     "ℹ️ About Us": "https://register.falowen.app/#about-us",


### PR DESCRIPTION
## Summary
- switch privacy and terms links to `register.falowen.app` references in the footer HTML
- update `FOOTER_LINKS` dictionary to use `register.falowen.app` privacy and terms URLs

## Testing
- `ruff check a1sprechen.py` *(fails: E402 Module level import not at top of file, F401 unused import, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c437d8c36483218011d5fa2613adfd