### PR TITLE
Clarify blog announcement banner heading

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -772,7 +772,7 @@ inject_notice_css()
 # Sidebar (no logout; logout lives in the header)
 render_sidebar_published()
 
-# New posts (render once)
+# Falowen blog updates (render once)
 new_posts = fetch_blog_feed()
 
 st.markdown("---")

--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -158,9 +158,11 @@ def render_announcements(announcements: list) -> None:
       .ann-dots{display:flex;gap:12px;justify-content:center;margin-top:12px}
       .ann-dot{width:11px;height:11px;border-radius:999px;background:#9ca3af;opacity:.9;transform:scale(.95);border:none;cursor:pointer;touch-action:manipulation;}
       .ann-dot[aria-current="true"]{background:var(--brand);opacity:1;transform:scale(1.22);box-shadow:0 0 0 4px var(--ring)}
+      .ann-tagline{margin:0 0 10px 0;color:var(--muted);font-size:.9rem}
     </style>
     <div class="page-wrap">
-      <div class="ann-title">📣 New posts.</div>
+      <div class="ann-title">📣 Falowen blog updates</div>
+      <p class="ann-tagline">Falowen: Your German Conversation Partner for Everyday Learning</p>
       <div class="ann-shell" id="ann_shell" aria-live="polite">
         <div id="ann_card">
           <div class="ann-heading"><span class="ann-chip" id="ann_tag" style="display:none;"></span><span id="ann_title"></span></div>

--- a/tests/test_ui_widgets_announcements.py
+++ b/tests/test_ui_widgets_announcements.py
@@ -27,7 +27,8 @@ def test_render_announcements_without_banner(monkeypatch):
         {"title": "t", "body": "b", "href": "https://xmpl"},
         {"title": "t2"},
     ])
-    assert "📣 New posts." in captured["html"]
+    assert "📣 Falowen blog updates" in captured["html"]
+    assert "Falowen: Your German Conversation Partner for Everyday Learning" in captured["html"]
     assert "t" in captured["html"]
     assert "b" in captured["html"]
     assert "Read more." in captured["html"]


### PR DESCRIPTION
## Summary
- Clarify announcements banner with "📣 Falowen blog updates" and a Falowen tagline
- Update announcements tests for new heading and tagline
- Align main app comment with updated banner wording

## Testing
- `pytest -q`
- `ruff check src/ui_widgets.py tests/test_ui_widgets_announcements.py`
- `ruff check a1sprechen.py | tail -n 20` *(fails: Found 107 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c438e7d930832189390abef7f70e0f