### PR TITLE
Strip CSS snippets from blog feed bodies

### DIFF
--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString
 import streamlit as st
 
 
@@ -57,7 +57,15 @@ def fetch_blog_feed(limit: int | None = None) -> List[Dict[str, str]]:
         body_html = body_tag.decode_contents() if body_tag and body_tag.text else ""
         body = ""
         if body_html:
-            body = BeautifulSoup(body_html, "html.parser").get_text(" ", strip=True)
+            soup_body = BeautifulSoup(body_html, "html.parser")
+            for t in soup_body(["style", "script"]):
+                t.decompose()
+            for element in list(soup_body.contents):
+                if isinstance(element, NavigableString) and "{" in element and "}" in element:
+                    element.extract()
+                else:
+                    break
+            body = soup_body.get_text(" ", strip=True)
 
         item: Dict[str, str] = {"title": title, "href": href}
         if body:

--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -98,7 +98,7 @@ def test_fetch_blog_feed_strips_html(monkeypatch):
       <item>
         <title>T</title>
         <link>http://example.com</link>
-        <description><p>Hello <b>World</b><style>p{color:red}</style>!</p></description>
+        <description>p{color:red} body{margin:0}<p>Hello <b>World</b><style>p{color:red}</style><script>alert(1)</script>!</p></description>
       </item>
     </channel></rss>
     """
@@ -110,4 +110,5 @@ def test_fetch_blog_feed_strips_html(monkeypatch):
     fetch_blog_feed.clear()
     items = fetch_blog_feed(limit=1)
     assert items[0]["body"] == "Hello World !"
-    assert "style" not in items[0]["body"]
+    assert "p{color:red}" not in items[0]["body"]
+    assert "alert" not in items[0]["body"]


### PR DESCRIPTION
## Summary
- Clean blog feed bodies by removing style/script tags and leading CSS-like text before extracting plain text
- Extend blog feed tests to cover CSS and script removal

## Testing
- `pytest tests/test_blog_feed.py -q`
- `ruff check src/blog_feed.py tests/test_blog_feed.py`


------
https://chatgpt.com/codex/tasks/task_e_68c43a5750e083219117292c0134b862