### PR TITLE
test: ensure fetch_blog_feed strips leading CSS from descriptions

### DIFF
--- a/tests/test_login_page_blog_announcements.py
+++ b/tests/test_login_page_blog_announcements.py
@@ -70,7 +70,7 @@ def test_announcements_body_sanitized(monkeypatch):
       <item>
         <title>T</title>
         <link>http://example.com</link>
-        <description>Hello <b>World</b><style>p{color:red}</style></description>
+        <description>p{color:red} body{margin:0}<p>Hello <b>World</b></p></description>
       </item>
     </channel></rss>
     """
@@ -87,4 +87,5 @@ def test_announcements_body_sanitized(monkeypatch):
     render_mock.assert_called_once()
     body = render_mock.call_args[0][0][0].get("body")
     assert body == "Hello World"
-    assert "style" not in body
+    assert "p{color:red}" not in body
+    assert "body{margin:0}" not in body


### PR DESCRIPTION
## Summary
- add login page announcement test to verify raw leading CSS is removed

## Testing
- `pytest tests/test_login_page_blog_announcements.py::test_announcements_body_sanitized -q`
- `pytest tests/test_blog_feed.py::test_fetch_blog_feed_strips_html -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44036621c832180b799406971a797