### PR TITLE
Add divider between hero and returning-user login sections

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -253,6 +253,7 @@ def login_page():
 
     # 2) Branded hero (Google button suppressed inside the template)
     render_falowen_login(auth_url, show_google_in_hero=False)
+    st.divider()
 
     # 3) Returning user section (Google CTA below the form)
     login_success = render_returning_login_area()

--- a/tests/test_login_page_blog_announcements.py
+++ b/tests/test_login_page_blog_announcements.py
@@ -33,6 +33,7 @@ def make_streamlit_stub():
     def columns(n):
         return [DummyCtx() for _ in range(n)]
     st.columns = columns
+    st.divider = MagicMock()
     return st
 
 


### PR DESCRIPTION
## Summary
- add `st.divider()` after falowen login hero to separate sections visually
- update tests with stubbed `st.divider`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c442970700832195318e10117482ed