### PR TITLE
Truncate announcement body text and add consistent action link

### DIFF
--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -185,10 +185,15 @@ def render_announcements(announcements: list) -> None:
       function render(idx){
         const c = data[idx] || {};
         titleEl.textContent = c.title || '';
-        if (c.body){ const tmp=document.createElement('div'); tmp.innerHTML=c.body; bodyEl.textContent=tmp.textContent||''; bodyEl.style.display=''; } else { bodyEl.textContent=''; bodyEl.style.display='none'; }
+        if (c.body){
+          const tmp=document.createElement('div'); tmp.innerHTML=c.body;
+          let text=(tmp.textContent||'').trim();
+          if (text.length>120){ text=text.slice(0,120).trimEnd()+'…'; }
+          bodyEl.textContent=text; bodyEl.style.display='';
+        } else { bodyEl.textContent=''; bodyEl.style.display='none'; }
         if (c.tag){ tagEl.textContent = c.tag; tagEl.style.display=''; } else { tagEl.style.display='none'; }
-        if (c.href){ const link = document.createElement('a'); link.href = c.href; link.target = '_blank'; link.rel='noopener'; link.textContent='Read more.';
-          actionEl.textContent=''; actionEl.appendChild(link); actionEl.style.display=''; } else { actionEl.textContent=''; actionEl.style.display='none'; }
+        const link = document.createElement('a'); link.target = '_blank'; link.rel='noopener'; link.textContent='Read more'; link.href = c.href || '#';
+        actionEl.textContent=''; actionEl.appendChild(link); actionEl.style.display = c.href ? '' : 'none';
         setActiveDot(idx);
       }
       function restartTimer(){

--- a/tests/test_ui_widgets_announcements.py
+++ b/tests/test_ui_widgets_announcements.py
@@ -32,7 +32,7 @@ def test_render_announcements_without_banner(monkeypatch):
     assert "Falowen: Your German Conversation Partner for Everyday Learning" in captured["html"]
     assert "t" in captured["html"]
     assert "b" in captured["html"]
-    assert "Read more." in captured["html"]
+    assert "Read more" in captured["html"]
     assert "setInterval" in captured["html"]
     assert BANNER not in captured["html"]
 


### PR DESCRIPTION
## Summary
- Trim and truncate announcement body text to 120 characters with ellipsis
- Ensure announcement action always renders a "Read more" link
- Update announcement tests for new link label

## Testing
- `pytest`
- `ruff check src/ui_widgets.py tests/test_ui_widgets_announcements.py`


------
https://chatgpt.com/codex/tasks/task_e_68c443669d78832197db1ecd77cf320e