### PR TITLE
Handle missing title tags in blog feed

### DIFF
--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -41,7 +41,8 @@ def fetch_blog_feed(limit: Optional[int] = None) -> List[Dict[str, str]]:
             break
 
         # Title
-        title = (row.find_text("title") or "").strip()
+        title_tag = row.find("title")
+        title = title_tag.get_text(strip=True) if title_tag else ""
 
         # Link (Atom often uses <link rel="alternate" href="..."/>)
         href = ""


### PR DESCRIPTION
## Summary
- Safely parse blog feed titles by checking for missing title tags

## Testing
- `pytest tests/test_blog_feed.py tests/test_login_page_blog_announcements.py`


------
https://chatgpt.com/codex/tasks/task_e_68c44f6ba60c8321899102cd7088d76e