### PR TITLE
Handle missing title tag in blog feed

### DIFF
--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -98,7 +98,8 @@ def fetch_blog_feed(limit: Optional[int] = None) -> List[Dict[str, str]]:
             break
 
         # Title
-        title = (row.find_text("title") or "").strip()
+        title_tag = row.find("title")
+        title = title_tag.get_text(strip=True) if title_tag else ""
 
         # Link (RSS <link> text, Atom <link href="..."> or <link rel="alternate" ...>)
         href = ""


### PR DESCRIPTION
## Summary
- Safely extract blog post titles by checking for a title element before reading its text.

## Testing
- `pytest tests/test_blog_feed.py` *(fails: tests/test_blog_feed.py::test_fetch_blog_feed_maps_title_and_url, tests/test_blog_feed.py::test_fetch_blog_feed_parses_description, tests/test_blog_feed.py::test_fetch_blog_feed_skips_items_missing_fields, tests/test_blog_feed.py::test_fetch_blog_feed_no_limit, tests/test_blog_feed.py::test_fetch_blog_feed_strips_html)*

------
https://chatgpt.com/codex/tasks/task_e_68c4530ae17c8321a0ae830b1ec90e49