### PR TITLE
Use blog card widget on login page

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -41,6 +41,7 @@ from auth import auth_bp
 from src.routes.health import register_health_route
 from src.group_schedules import load_group_schedules
 from src.blog_feed import fetch_blog_feed
+from src.blog_cards_widget import render_blog_cards
 import src.schedule as _schedule
 load_level_schedules = _schedule.load_level_schedules
 refresh_level_schedules = getattr(_schedule, "refresh_level_schedules", lambda: None)
@@ -185,7 +186,6 @@ from src.youtube import (
 from src.ui_widgets import (
     render_google_brand_button_once,
     render_announcements_once,
-    render_announcements,
 )
 from src.logout import do_logout
 from src.pdf_handling import (
@@ -331,9 +331,11 @@ def login_page():
         """, unsafe_allow_html=True)
 
     # Blog posts / announcements
-    blog_posts = fetch_blog_feed()
+    blog_posts = [p for p in fetch_blog_feed() if p.get("image")]
     if blog_posts:
-        render_announcements(blog_posts)
+        st.markdown("---")
+        with st.container():
+            render_blog_cards(blog_posts)
 
     # Footer links
     st.markdown("""

--- a/tests/test_blog_feed.py
+++ b/tests/test_blog_feed.py
@@ -1,7 +1,7 @@
 import types
 import requests
 
-from src.blog_feed import fetch_blog_feed
+from src.blog_feed import fetch_blog_feed, _get
 
 
 def test_fetch_blog_feed_maps_title_and_url(monkeypatch):
@@ -14,11 +14,11 @@ def test_fetch_blog_feed_maps_title_and_url(monkeypatch):
     </channel></rss>
     """
 
-    def fake_get(url, timeout=10):
+    def fake_get(url, timeout=10, headers=None):
         return types.SimpleNamespace(text=xml_data, raise_for_status=lambda: None)
 
     monkeypatch.setattr(requests, "get", fake_get)
-    fetch_blog_feed.clear()
+    fetch_blog_feed.clear(); _get.clear()
     items = fetch_blog_feed(limit=1)
     assert items[0]["title"] == "Test"
     assert items[0]["href"] == "http://example.com"
@@ -36,11 +36,11 @@ def test_fetch_blog_feed_parses_description(monkeypatch):
     </channel></rss>
     """
 
-    def fake_get(url, timeout=10):
+    def fake_get(url, timeout=10, headers=None):
         return types.SimpleNamespace(text=xml_data, raise_for_status=lambda: None)
 
     monkeypatch.setattr(requests, "get", fake_get)
-    fetch_blog_feed.clear()
+    fetch_blog_feed.clear(); _get.clear()
     items = fetch_blog_feed(limit=1)
     assert items[0]["title"] == "Test"
     assert items[0]["href"] == "http://example.com"
@@ -57,11 +57,11 @@ def test_fetch_blog_feed_skips_items_missing_fields(monkeypatch):
     </channel></rss>
     """
 
-    def fake_get(url, timeout=10):
+    def fake_get(url, timeout=10, headers=None):
         return types.SimpleNamespace(text=xml_data, raise_for_status=lambda: None)
 
     monkeypatch.setattr(requests, "get", fake_get)
-    fetch_blog_feed.clear()
+    fetch_blog_feed.clear(); _get.clear()
     items = fetch_blog_feed()
     assert len(items) == 2
     assert items[0]["title"] == "Valid"
@@ -74,11 +74,11 @@ def test_fetch_blog_feed_no_limit(monkeypatch):
     )
     xml_data = f"<rss><channel>{xml_items}</channel></rss>"
 
-    def fake_get(url, timeout=10):
+    def fake_get(url, timeout=10, headers=None):
         return types.SimpleNamespace(text=xml_data, raise_for_status=lambda: None)
 
     monkeypatch.setattr(requests, "get", fake_get)
-    fetch_blog_feed.clear()
+    fetch_blog_feed.clear(); _get.clear()
     items = fetch_blog_feed()
     assert len(items) == 7
 
@@ -88,7 +88,7 @@ def test_fetch_blog_feed_handles_error(monkeypatch):
         raise RuntimeError("nope")
 
     monkeypatch.setattr(requests, "get", boom)
-    fetch_blog_feed.clear()
+    fetch_blog_feed.clear(); _get.clear()
     assert fetch_blog_feed() == []
 
 
@@ -103,11 +103,11 @@ def test_fetch_blog_feed_strips_html(monkeypatch):
     </channel></rss>
     """
 
-    def fake_get(url, timeout=10):
+    def fake_get(url, timeout=10, headers=None):
         return types.SimpleNamespace(text=xml_data, raise_for_status=lambda: None)
 
     monkeypatch.setattr(requests, "get", fake_get)
-    fetch_blog_feed.clear()
+    fetch_blog_feed.clear(); _get.clear()
     items = fetch_blog_feed(limit=1)
     assert items[0]["body"] == "Hello World !"
     assert "p{color:red}" not in items[0]["body"]


### PR DESCRIPTION
## Summary
- Replace login page announcement list with blog card grid and filter posts for images
- Add blog card widget import and layout styling for consistent spacing
- Update blog feed tests and login page tests to use `render_blog_cards`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c454a823e88321b10d45b011aafac1