### PR TITLE
Simplify login blog announcements layout

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -334,19 +334,17 @@ def login_page():
     blog_posts = fetch_blog_feed()[:3]
     if blog_posts:
         st.markdown("---")
-        col_left, col_mid, col_right = st.columns([1, 2, 1])
-        with col_mid:
-            st.markdown(
-                '<h2 style="text-align:center;">Falowen Blog</h2>',
-                unsafe_allow_html=True,
-            )
-            render_blog_cards(blog_posts)
-            st.markdown(
-                '<div style="text-align:center;margin-top:8px;">'
-                '<a href="https://blog.falowen.app/" target="_blank" rel="noopener">Read more</a>'
-                '</div>',
-                unsafe_allow_html=True,
-            )
+        st.markdown(
+            '<h2 style="text-align:center;">Falowen Blog</h2>',
+            unsafe_allow_html=True,
+        )
+        render_blog_cards(blog_posts, height=380)
+        st.markdown(
+            '<div style="text-align:center;margin-top:8px;">'
+            '<a href="https://blog.falowen.app/" target="_blank" rel="noopener">Read more</a>'
+            '</div>',
+            unsafe_allow_html=True,
+        )
 
     # Footer links
     st.markdown("""


### PR DESCRIPTION
## Summary
- Remove column wrapper from blog announcements section
- Render blog cards with fixed height and direct "Read more" link

## Testing
- `pytest tests/test_login_page_blog_announcements.py`


------
https://chatgpt.com/codex/tasks/task_e_68c45e58fa1c83218a70a60121a3723f