### PR TITLE
Strip HTML tags in blog card bodies

### DIFF
--- a/src/blog_cards_widget.py
+++ b/src/blog_cards_widget.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 from typing import List, Dict
+from bs4 import BeautifulSoup
 import streamlit as st
 import streamlit.components.v1 as components
+
+
+def strip_html(s: str) -> str:
+    try:
+        return BeautifulSoup(s or "", "html.parser").get_text(" ", strip=True)
+    except Exception:
+        return s or ""
 
 
 def render_blog_cards(items: List[Dict[str, str]], height: int = 380) -> None:
@@ -19,7 +27,9 @@ def render_blog_cards(items: List[Dict[str, str]], height: int = 380) -> None:
     for it in items:
         title = esc(it.get("title", ""))
         href = esc(it.get("href", "#"))
-        body = esc(it.get("body", ""))
+        raw_body = it.get("body", "")
+        clean_body = strip_html(raw_body)
+        body = esc(clean_body[:220])
         img = it.get("image") or ""
         img_html = f'<img class="card-img" src="{esc(img)}" alt="">' if img else ""
         cards.append(f"""


### PR DESCRIPTION
## Summary
- sanitize blog card bodies by stripping HTML using BeautifulSoup
- limit blog card body text to 220 characters before escaping

## Testing
- `ruff check src/blog_cards_widget.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c469bdb6888321b68acee5938c106c