### PR TITLE
Handle login session cookies when rendering login form

### DIFF
--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -237,6 +237,22 @@ def render_login_form(login_id: str, login_pass: str) -> bool:
             "student_level": level,
         }
     )
+    cm = get_cookie_manager()
+    token = st.session_state.get("session_token")
+    if token:
+        cm.set(
+            COOKIE_NAME,
+            token,
+            expires=30,
+            key=COOKIE_NAME,
+            secure=True,
+            samesite="Lax",
+        )
+        try:
+            cm.save()
+        except Exception:
+            pass
+        st.session_state["logged_in"] = True
     if cookie_manager:
         set_student_code_cookie(
             cookie_manager,


### PR DESCRIPTION
## Summary
- Store session token in cookie after login by invoking new cookie manager helper
- Persist login state when session token cookie saved

## Testing
- `ruff check src/ui/auth.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'extra_streamlit_components')*

------
https://chatgpt.com/codex/tasks/task_e_68c48cc271e08321802dc1d95981a0ce