### PR TITLE
Add session cookie write to Google OAuth login

### DIFF
--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -483,6 +483,22 @@ def _handle_google_oauth(code: str, state: str) -> None:
                 "student_level": level,
             }
         )
+        cm = get_cookie_manager()
+        token = st.session_state.get("session_token")
+        if token:
+            cm.set(
+                COOKIE_NAME,
+                token,
+                expires=30,
+                key=COOKIE_NAME,
+                secure=True,
+                samesite="Lax",
+            )
+            try:
+                cm.save()
+            except Exception:
+                pass
+            st.session_state["logged_in"] = True
         if cookie_manager:
             set_student_code_cookie(
                 cookie_manager,


### PR DESCRIPTION
## Summary
- write session cookie after Google OAuth login, mirroring email/password login
- ensure `logged_in` flag persists after cookie is saved

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'extra_streamlit_components')*
- `ruff check` *(fails: Found 135 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68c48dcd37c483219cf460d929fa2cce