### PR TITLE
Use cached cookie manager for login UI

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -68,7 +68,6 @@ _DEFAULT_COOKIE_KW = {
     "httponly": True,
     "secure": True,
     "samesite": "Lax",
-    "path": "/",
     "domain": ".falowen.app",  # make sure you always serve from https://www.falowen.app
 }
 
@@ -103,7 +102,6 @@ def _cm_set(cm: MutableMapping[str, Any] | Any, key: str, value: Any, **kwargs: 
             except Exception:
                 # Final fallback: set value only
                 setter(key, value)
-        _cm_save(cm)
         return
 
     # Mapping fallback (tests)
@@ -131,7 +129,6 @@ def clear_session(cm: MutableMapping[str, Any] | Any) -> None:
         if callable(deleter):
             deleter("student_code")
             deleter("session_token")
-            _cm_save(cm)
             return
     except Exception:
         pass
@@ -149,7 +146,6 @@ def clear_session(cm: MutableMapping[str, Any] | Any) -> None:
             del cm["session_token"]  # type: ignore[index]
         except Exception:
             pass
-    _cm_save(cm)
 
 # --------------------------------------------------------------------
 # Session token registry (in-memory)

--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -14,7 +14,7 @@ import html  # noqa: F401
 
 import bcrypt
 import streamlit as st
-from extra_streamlit_components import CookieManager
+from src.config import get_cookie_manager
 
 from falowen.email_utils import send_reset_email, build_gas_reset_link
 from falowen.sessions import create_session_token, destroy_session_token
@@ -33,10 +33,6 @@ from src.utils.toasts import refresh_with_toast, toast_ok, toast_err
 
 # Session cookie helpers
 COOKIE_NAME = "falowen_session"
-
-
-def get_cookie_manager() -> CookieManager:
-    return CookieManager()
 
 
 def read_session_cookie_into_state() -> None:


### PR DESCRIPTION
## Summary
- use `src.config.get_cookie_manager` in the login UI instead of creating a new CookieManager
- require explicit cookie saves by removing automatic `save()` calls and default path option

## Testing
- `timeout 15 streamlit run /tmp/check_cookie.py --server.headless true --global.developmentMode false`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c499fcbd0483219e46f9151e8aaa30