### PR TITLE
Include links in announcement fallback

### DIFF
--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -222,8 +222,10 @@ def render_announcements(announcements: list) -> None:
         )
     except TypeError:
         for a in announcements:
-            text = f"**{a.get('title','')}**"
-            if a.get('body'):
+            href = a.get("href")
+            title = a.get("title", "")
+            text = f"[**{title}**]({href})" if href else f"**{title}**"
+            if a.get("body"):
                 text += f" — {a.get('body','')}"
             st.markdown(text)
     st.markdown("Visit [blog.falowen.app](https://blog.falowen.app) for more.")

--- a/tests/test_ui_widgets_announcements.py
+++ b/tests/test_ui_widgets_announcements.py
@@ -50,8 +50,13 @@ def test_render_announcements_fallback_without_banner(monkeypatch):
 
     monkeypatch.setattr(ui_widgets, "components", SimpleNamespace(html=failing_html))
     monkeypatch.setattr(ui_widgets.st, "markdown", fake_markdown)
-    ui_widgets.render_announcements([{"title": "t", "body": "b"}])
-    assert outputs == ["**t** — b", "Visit [blog.falowen.app](https://blog.falowen.app) for more."]
+    ui_widgets.render_announcements(
+        [{"title": "t", "body": "b", "href": "https://xmpl"}]
+    )
+    assert outputs == [
+        "[**t**](https://xmpl) — b",
+        "Visit [blog.falowen.app](https://blog.falowen.app) for more.",
+    ]
     assert all(BANNER not in o for o in outputs)
 
 


### PR DESCRIPTION
## Summary
- include announcement URLs when fallback rendering markdown announcements
- test fallback announcements render title hyperlinks

## Testing
- `pytest tests/test_ui_widgets_announcements.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4a75dc85c8321a15fa0e3838afe21