### PR TITLE
Link course chapters to class discussions

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2106,11 +2106,27 @@ if tab == "My Course":
         st.markdown(f"### {highlight_terms(title_txt, search_terms)} (Chapter {info['chapter']})", unsafe_allow_html=True)
         if info.get("grammar_topic"):
             st.markdown(f"**🔤 Grammar Focus:** {highlight_terms(info['grammar_topic'], search_terms)}", unsafe_allow_html=True)
+        def _go_class_thread(chapter: str) -> None:
+            st.session_state["nav_sel"] = "My Course"
+            st.session_state["main_tab_select"] = "My Course"
+            st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
+            st.session_state["classroom_page"] = "Class Notes & Q&A"
+            st.session_state["q_search"] = str(chapter)
+            try:
+                st.query_params["tab"] = "My Course"
+            except Exception:
+                pass
+            st.session_state["need_rerun"] = True
         if info.get("goal") or info.get("instruction"):
             st.info(
                 f"🎯 **Goal:** {info.get('goal','')}\n\n"
                 f"📝 **Instruction:** {info.get('instruction','')}"
             )
+            b1, b2 = st.columns(2)
+            with b1:
+                st.button("💬 Class Board", key=f"go_board_{info['chapter']}", on_click=_go_class_thread, args=(info["chapter"],), use_container_width=True)
+            with b2:
+                st.button("❓ Class Notes & Q&A", key=f"go_qna_{info['chapter']}", on_click=_go_class_thread, args=(info["chapter"],), use_container_width=True)
 
         st.divider()
 

--- a/tests/test_coursebook_discussion_links.py
+++ b/tests/test_coursebook_discussion_links.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+def test_coursebook_discussion_links_present():
+    src = Path('a1sprechen.py').read_text(encoding='utf-8')
+    assert 'Class Board' in src
+    assert 'Class Notes & Q&A' in src
+    assert "go_board_{info['chapter']}" in src
+    assert "go_qna_{info['chapter']}" in src


### PR DESCRIPTION
## Summary
- Add classroom navigation callback and buttons on each course chapter to open Class Board and Class Notes & Q&A, pre-filtered by chapter
- Cover new discussion links with unit test

## Testing
- `pytest tests/test_coursebook_discussion_links.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c51fd0ea048321af086b03c56254f8