### PR TITLE
Streamline coursebook discussion navigation

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2120,13 +2120,16 @@ if tab == "My Course":
         if info.get("goal") or info.get("instruction"):
             st.info(
                 f"🎯 **Goal:** {info.get('goal','')}\n\n"
-                f"📝 **Instruction:** {info.get('instruction','')}"
+                f"📝 **Instruction:** {info.get('instruction','')}\n\n"
+                "Check the group discussion for this chapter and class notes."
             )
-            b1, b2 = st.columns(2)
-            with b1:
-                st.button("💬 Class Board", key=f"go_board_{info['chapter']}", on_click=_go_class_thread, args=(info["chapter"],), use_container_width=True)
-            with b2:
-                st.button("❓ Class Notes & Q&A", key=f"go_qna_{info['chapter']}", on_click=_go_class_thread, args=(info["chapter"],), use_container_width=True)
+            st.button(
+                "💬 Class Discussion & Notes",
+                key=f"go_discussion_{info['chapter']}",
+                on_click=_go_class_thread,
+                args=(info["chapter"],),
+                use_container_width=True,
+            )
 
         st.divider()
 

--- a/tests/test_coursebook_discussion_links.py
+++ b/tests/test_coursebook_discussion_links.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-def test_coursebook_discussion_links_present():
-    src = Path('a1sprechen.py').read_text(encoding='utf-8')
-    assert 'Class Board' in src
-    assert 'Class Notes & Q&A' in src
-    assert "go_board_{info['chapter']}" in src
-    assert "go_qna_{info['chapter']}" in src
+
+def test_coursebook_discussion_link_present():
+    src = Path("a1sprechen.py").read_text(encoding="utf-8")
+    assert "Class Discussion & Notes" in src
+    assert "go_discussion_{info['chapter']}" in src
+    assert "Check the group discussion for this chapter and class notes." in src


### PR DESCRIPTION
## Summary
- Replace two-class-discussion buttons with single "Class Discussion & Notes" button
- Include call-to-action in lesson info encouraging users to check group discussion and class notes
- Update coursebook discussion links test to expect new button and call-to-action

## Testing
- `ruff check a1sprechen.py` *(fails: 111 errors)*
- `ruff check tests/test_coursebook_discussion_links.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c523f3ef9c8321b1a2c9e7eb44e34d