### PR TITLE
Ensure normalized lesson titles appear in dictionary views

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2282,7 +2282,8 @@ if tab == "My Course":
                         st.markdown('<em>Further notice:</em> 📘 contains notes; 📒 is your workbook assignment.', unsafe_allow_html=True)
                     if part.get('workbook_link'):
                         st.markdown(f"- [📒 Workbook (Assignment)]({part['workbook_link']})")
-                        with st.expander("📖 Dictionary"):
+                        title = _schedule.full_lesson_title(day_info)
+                        with st.expander(f"📖 Dictionary – {title}"):
                             render_vocab_lookup(f"{key}-{idx_part}")
                         render_assignment_reminder()
                     extras = part.get('extra_resources')
@@ -2312,7 +2313,8 @@ if tab == "My Course":
                     showed = True
                 if info.get("workbook_link"):
                     st.markdown(f"- [📒 Workbook (Assignment)]({info['workbook_link']})")
-                    with st.expander("📖 Dictionary"):
+                    title = _schedule.full_lesson_title(info)
+                    with st.expander(f"📖 Dictionary – {title}"):
                         render_vocab_lookup(f"fallback-{info.get('day', '')}")
                     render_assignment_reminder()
                     showed = True

--- a/src/schedule.py
+++ b/src/schedule.py
@@ -22,6 +22,19 @@ def _strip_topic_chapter(schedule: list[dict]) -> list[dict]:
             item["topic"] = re.sub(pattern, "", topic).strip()
     return schedule
 
+
+def full_lesson_title(lesson: dict) -> str:
+    """Return the full lesson title for display.
+
+    The format is ``"Day X: Topic (Chapter Y)"`` so callers can present a
+    concise, duplication-free summary in the UI.
+    """
+
+    return (
+        f"Day {lesson.get('day', '?')}: {lesson.get('topic', '')} "
+        f"(Chapter {lesson.get('chapter', '')})"
+    )
+
 def get_a1_schedule():
     schedule = [
         # DAY 0

--- a/tests/test_schedule_module.py
+++ b/tests/test_schedule_module.py
@@ -5,6 +5,7 @@ from src.schedule import (
     get_a2_schedule,
     get_b1_schedule,
     get_b2_schedule,
+    full_lesson_title,
 )
 
 
@@ -37,3 +38,12 @@ def test_get_b2_schedule_has_day0():
     schedule = get_b2_schedule()
     assert schedule[0]["day"] == 0
     assert schedule[0]["topic"] == "Tutorial – Course Overview"
+
+
+def test_day15_title_normalized():
+    schedules = load_level_schedules()
+    day15 = next(d for d in schedules["A2"] if d["day"] == 15)
+    assert (
+        full_lesson_title(day15)
+        == "Day 15: Mein Lieblingssport (Chapter 6.15)"
+    )


### PR DESCRIPTION
## Summary
- Provide helper `full_lesson_title` to generate complete lesson titles without chapter duplication
- Display the full lesson title in dictionary sections tied to assignments
- Test Day 15 schedule entry to guarantee normalized title “Day 15: Mein Lieblingssport (Chapter 6.15)”

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c528dc17848321b02ae75e36b040f0