### PR TITLE
Display chapter in coursebook lesson titles

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2086,7 +2086,7 @@ if tab == "My Course":
             idx = st.selectbox(
                 "Lesson selection",
                 list(range(len(schedule))),
-                format_func=lambda i: f"Day {schedule[i]['day']} - {schedule[i]['topic']}",
+                format_func=lambda i: f"Day {schedule[i]['day']} - {schedule[i]['topic']} {schedule[i]['chapter']}".strip(),
                 label_visibility="collapsed",
             )
 
@@ -2102,8 +2102,11 @@ if tab == "My Course":
 
         # ---- Lesson info ----
         info = schedule[idx]
-        title_txt = f"Day {info['day']}: {info['topic']}"
-        st.markdown(f"### {highlight_terms(title_txt, search_terms)} (Chapter {info['chapter']})", unsafe_allow_html=True)
+        title_txt = f"Day {info['day']}: {info['topic']} {info['chapter']}".strip()
+        st.markdown(
+            f"### {highlight_terms(title_txt, search_terms)}",
+            unsafe_allow_html=True,
+        )
         if info.get("grammar_topic"):
             st.markdown(f"**🔤 Grammar Focus:** {highlight_terms(info['grammar_topic'], search_terms)}", unsafe_allow_html=True)
         def _go_class_thread(chapter: str) -> None:

--- a/tests/test_schedule_module.py
+++ b/tests/test_schedule_module.py
@@ -47,3 +47,10 @@ def test_day15_title_normalized():
         full_lesson_title(day15)
         == "Day 15: Mein Lieblingssport (Chapter 6.15)"
     )
+
+
+def test_day6_coursebook_entry():
+    schedule = get_a1_schedule()
+    day6 = next(d for d in schedule if d["day"] == 6)
+    label = f"Day {day6['day']} - {day6['topic']} {day6['chapter']}".strip()
+    assert label == "Day 6 - Schreiben & Sprechen 2.3"


### PR DESCRIPTION
## Summary
- Show chapter number alongside topic in coursebook lesson dropdown and heading to avoid duplicated text
- Add unit test ensuring Day 6 lesson is labelled "Day 6 - Schreiben & Sprechen 2.3"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5337bb274832189d834b5a37cfecb