### PR TITLE
Display chapter in coursebook lesson titles

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -45,6 +45,7 @@ from src.blog_cards_widget import render_blog_cards
 import src.schedule as _schedule
 load_level_schedules = _schedule.load_level_schedules
 refresh_level_schedules = getattr(_schedule, "refresh_level_schedules", lambda: None)
+format_topic_with_chapter = _schedule.format_topic_with_chapter
 
 app = Flask(__name__)
 app.register_blueprint(auth_bp)
@@ -2086,7 +2087,10 @@ if tab == "My Course":
             idx = st.selectbox(
                 "Lesson selection",
                 list(range(len(schedule))),
-                format_func=lambda i: f"Day {schedule[i]['day']} - {schedule[i]['topic']}",
+                format_func=lambda i: (
+                    f"Day {schedule[i]['day']} - "
+                    f"{format_topic_with_chapter(schedule[i]['topic'], schedule[i]['chapter'])}"
+                ),
                 label_visibility="collapsed",
             )
 
@@ -2102,8 +2106,14 @@ if tab == "My Course":
 
         # ---- Lesson info ----
         info = schedule[idx]
-        title_txt = f"Day {info['day']}: {info['topic']}"
-        st.markdown(f"### {highlight_terms(title_txt, search_terms)} (Chapter {info['chapter']})", unsafe_allow_html=True)
+        title_txt = (
+            f"Day {info['day']}: "
+            f"{format_topic_with_chapter(info['topic'], info['chapter'])}"
+        )
+        st.markdown(
+            f"### {highlight_terms(title_txt, search_terms)}",
+            unsafe_allow_html=True,
+        )
         if info.get("grammar_topic"):
             st.markdown(f"**🔤 Grammar Focus:** {highlight_terms(info['grammar_topic'], search_terms)}", unsafe_allow_html=True)
         def _go_class_thread(chapter: str) -> None:

--- a/src/schedule.py
+++ b/src/schedule.py
@@ -35,6 +35,35 @@ def full_lesson_title(lesson: dict) -> str:
         f"(Chapter {lesson.get('chapter', '')})"
     )
 
+
+def format_topic_with_chapter(topic: str, chapter: str) -> str:
+    """Return topic with chapter numbers appended if needed.
+
+    Underscores in ``chapter`` are converted to a human readable list (e.g.
+    ``"12.1_12.2"`` becomes ``"12.1 and 12.2"``).  If the resulting chapter
+    string already appears in ``topic``, the topic is returned unchanged to
+    avoid duplication.
+    """
+
+    topic = topic.strip() if isinstance(topic, str) else ""
+    chapter = chapter.strip() if isinstance(chapter, str) else ""
+    if not chapter:
+        return topic
+
+    parts = [p.strip() for p in chapter.split("_") if p.strip()]
+    if not parts:
+        return topic
+    if len(parts) == 1:
+        chapter_text = parts[0]
+    elif len(parts) == 2:
+        chapter_text = " and ".join(parts)
+    else:
+        chapter_text = ", ".join(parts[:-1]) + f" and {parts[-1]}"
+
+    if chapter_text in topic:
+        return topic
+    return f"{topic} {chapter_text}".strip()
+
 def get_a1_schedule():
     schedule = [
         # DAY 0

--- a/tests/test_schedule_module.py
+++ b/tests/test_schedule_module.py
@@ -6,6 +6,7 @@ from src.schedule import (
     get_b1_schedule,
     get_b2_schedule,
     full_lesson_title,
+    format_topic_with_chapter,
 )
 
 
@@ -47,3 +48,23 @@ def test_day15_title_normalized():
         full_lesson_title(day15)
         == "Day 15: Mein Lieblingssport (Chapter 6.15)"
     )
+
+
+def test_day6_coursebook_entry():
+    schedule = get_a1_schedule()
+    day6 = next(d for d in schedule if d["day"] == 6)
+    label = (
+        f"Day {day6['day']} - "
+        f"{format_topic_with_chapter(day6['topic'], day6['chapter'])}"
+    )
+    assert label == "Day 6 - Schreiben & Sprechen 2.3"
+
+
+def test_day18_coursebook_entry_without_duplication():
+    schedule = get_a1_schedule()
+    day18 = next(d for d in schedule if d["day"] == 18)
+    label = (
+        f"Day {day18['day']} - "
+        f"{format_topic_with_chapter(day18['topic'], day18['chapter'])}"
+    )
+    assert label == "Day 18 - Lesen & Hören 12.1 and 12.2"


### PR DESCRIPTION
## Summary
- Provide helper to append chapter numbers to lesson topics, converting underscore ranges to "and" and skipping duplicates
- Use helper when labeling lessons so multi-chapter topics like Day 18 avoid repeated chapter strings
- Extend tests to verify topics with underscores display as "12.1 and 12.2" without duplication

## Testing
- `pytest -q`
- `ruff check src/schedule.py tests/test_schedule_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5337bb274832189d834b5a37cfecb