### PR TITLE
Link assignments to reference URLs

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -582,10 +582,20 @@ def render_results_and_resources_tab() -> None:
         latest = df_display.head(5)
         for _, row in latest.iterrows():
             perf = score_label_fmt(row["score"])
+            ref_link = _clean_link(row.get("link"))
+            if _is_http_url(ref_link):
+                title_html = (
+                    f'<a href="{ref_link}" target="_blank" rel="noopener" '
+                    f'style="font-size:1.05em;font-weight:600;">{row["assignment"]}</a>'
+                )
+            else:
+                title_html = (
+                    f'<span style="font-size:1.05em;font-weight:600;">{row["assignment"]}</span>'
+                )
             st.markdown(
                 f"""
                 <div style="margin-bottom: 12px;">
-                    <span style="font-size:1.05em;font-weight:600;">{row['assignment']}</span><br>
+                    {title_html}<br>
                     Score: <b>{row['score']}</b> <span style='margin-left:12px;'>{perf}</span>
                     | Date: {row['date']}
                 </div>
@@ -602,14 +612,24 @@ def render_results_and_resources_tab() -> None:
             perf = score_label_fmt(row["score"])
             comment_html = linkify_html(row["comments"])
             ref_link = _clean_link(row.get("link"))
-            show_ref = bool(ref_link) and _is_http_url(ref_link) and pd.notna(
+            link_valid = _is_http_url(ref_link)
+            show_ref = link_valid and pd.notna(
                 pd.to_numeric(row["score"], errors="coerce")
             )
+            if link_valid:
+                title_html = (
+                    f'<a href="{ref_link}" target="_blank" rel="noopener" '
+                    f'style="font-size:1.05em;font-weight:600;">{row["assignment"]}</a>'
+                )
+            else:
+                title_html = (
+                    f'<span style="font-size:1.05em;font-weight:600;">{row["assignment"]}</span>'
+                )
 
             st.markdown(
                 f"""
                 <div style="margin-bottom: 18px;">
-                    <span style="font-size:1.05em;font-weight:600;">{row['assignment']}</span><br>
+                    {title_html}<br>
                     Score: <b>{row['score']}</b> <span style='margin-left:12px;'>{perf}</span>
                     | Date: {row['date']}<br>
                     <div style='margin:8px 0; padding:10px 14px; background:#f2f8fa; border-left:5px solid #007bff; border-radius:7px; color:#333; font-size:1em;'>

--- a/tests/test_assignment_link_display.py
+++ b/tests/test_assignment_link_display.py
@@ -1,0 +1,66 @@
+import types
+import pandas as pd
+import streamlit as st
+
+from src import assignment_ui
+
+
+class DummyCol:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def metric(self, *args, **kwargs):
+        pass
+
+
+def setup_streamlit(monkeypatch, rr_page, outputs, df):
+    st.session_state.clear()
+    st.session_state.update(
+        {
+            "student_code": "abc",
+            "student_name": "Alice",
+            "student_row": {"StudentCode": "abc", "Name": "Alice", "Level": "A1"},
+        }
+    )
+
+    monkeypatch.setattr(assignment_ui, "fetch_scores", lambda url: df)
+    monkeypatch.setattr(st, "markdown", lambda text, *a, **k: outputs.append(text))
+    monkeypatch.setattr(st, "divider", lambda *a, **k: None)
+    monkeypatch.setattr(st, "columns", lambda spec: [DummyCol() for _ in range(len(spec) if hasattr(spec, '__len__') else spec)])
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
+    monkeypatch.setattr(st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(st, "metric", lambda *a, **k: None)
+    monkeypatch.setattr(st, "radio", lambda *a, **k: rr_page)
+    monkeypatch.setattr(st, "selectbox", lambda *a, **k: "A1")
+    monkeypatch.setattr(st, "stop", lambda *a, **k: (_ for _ in ()).throw(AssertionError("stop called")))
+    monkeypatch.setattr(st, "cache_data", types.SimpleNamespace(clear=lambda: None))
+    monkeypatch.setattr(st, "secrets", {})
+
+
+def test_assignment_title_hyperlink(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "student_code": ["abc"],
+            "name": ["Alice"],
+            "assignment": ["Lesson 1"],
+            "score": ["95"],
+            "date": ["2024-01-01"],
+            "level": ["A1"],
+            "comments": [""],
+            "link": ["https://example.com"],
+        }
+    )
+
+    for rr_page in ["Overview", "My Scores"]:
+        outputs = []
+        setup_streamlit(monkeypatch, rr_page, outputs, df)
+        assignment_ui.render_results_and_resources_tab()
+        assert any("href=\"https://example.com\"" in o and "Lesson 1</a>" in o for o in outputs)


### PR DESCRIPTION
## Summary
- Hyperlink assignment titles to valid reference URLs in results overview and detailed lists
- Add regression test ensuring assignments with links render as anchors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c53fe39c548321b8c3226c3f0cd9ae