### PR TITLE
Track class thread counts and switch to Classroom view

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1061,8 +1061,16 @@ def _go_class_thread(topic: str) -> None:
         .document(class_name)
         .collection("posts")
     )
-    posts = list(board_base.stream())
-    if not posts:
+    posts = [
+        snap
+        for snap in board_base.stream()
+        if snap.to_dict().get("topic") == topic
+        or snap.to_dict().get("chapter") == topic
+    ]
+    count = len(posts)
+    st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
+    st.session_state["q_search_count"] = count
+    if count == 0:
         st.session_state["q_search"] = ""
         st.session_state["q_search_warning"] = True
     else:

--- a/tests/test_class_thread_no_posts.py
+++ b/tests/test_class_thread_no_posts.py
@@ -79,11 +79,18 @@ def test_go_class_thread_clears_search_when_no_posts():
     fn("9")
     assert st.session_state.get("q_search") == ""
     assert "q_search_warning" in st.session_state
+    assert st.session_state.get("q_search_count") == 0
+    assert st.session_state.get("coursebook_subtab") == "🧑‍🏫 Classroom"
 
 
 def test_go_class_thread_keeps_search_when_posts_exist():
-    posts = {"p1": {"lesson": "Day 1: Topic", "topic": "9", "content": ""}}
+    posts = {
+        "p1": {"lesson": "Day 1: Topic", "topic": "9", "content": ""},
+        "p2": {"lesson": "Day 2: Other", "topic": "8", "content": ""},
+    }
     fn, st, db = setup_env(posts)
     fn("9")
     assert st.session_state.get("q_search") == "9"
     assert "q_search_warning" not in st.session_state
+    assert st.session_state.get("q_search_count") == 1
+    assert st.session_state.get("coursebook_subtab") == "🧑‍🏫 Classroom"


### PR DESCRIPTION
## Summary
- Count class discussion posts for the selected chapter and store the total
- Always switch to the Classroom subtab when opening a class thread
- Test that matching post counts are recorded and subtab changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c56505fc208321a2b36b16b19fe4e2