### PR TITLE
Add discussion link to Course Book assignment

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2318,6 +2318,12 @@ if tab == "My Course":
                         for ex in _as_list(extras):
                             st.markdown(f"- [🔗 Extra]({ex})")
 
+            # Student Info: link to class discussion + notes
+            st.info(
+                f"[Click here to read the group discussion for this chapter]"
+                f"({CLASS_DISCUSSION_LINK_TMPL.format(info=info)}) — includes class notes and Q&A."
+            )
+
             # ---------- YOUR WORK (tolerant across levels; embeds each video at most once) ----------
             st.markdown("### 🧪 Your Work")
             seen_videos = set()


### PR DESCRIPTION
## Summary
- Add Student Info panel linking to group discussion, class notes, and Q&A in the Course Book assignment section.

## Testing
- `python3 -m ruff a1sprechen.py` *(fails: No module named ruff)*
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68c5680271a48321bab52f27191b72fc