### PR TITLE
Add class discussion link with post count

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2159,6 +2159,32 @@ if tab == "My Course":
                 f"📝 **Instruction:** {info.get('instruction','')}"
             )
 
+        # ---- Class discussion count & link ----
+        board_base = (
+            db.collection("class_board")
+            .document(student_level)
+            .collection("classes")
+            .document(class_name)
+            .collection("posts")
+        )
+        post_count = sum(
+            1 for _ in board_base.where("chapter", "==", info["chapter"]).stream()
+        )
+        link_key = CLASS_DISCUSSION_LINK_TMPL.format(info=info)
+        count_txt = f" ({post_count})" if post_count else ""
+        st.info(
+            f"📣 For group practice and class notes: "
+            f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_key})"
+        )
+        st.button(
+            CLASS_DISCUSSION_LABEL,
+            key=link_key,
+            on_click=_go_class_thread,
+            args=(info["chapter"],),
+        )
+        if post_count == 0:
+            st.caption("No posts yet. Clicking will show the full board.")
+
         st.divider()
 
         # ---------- mini-tabs inside Course Book ----------

--- a/tests/test_class_discussion_link.py
+++ b/tests/test_class_discussion_link.py
@@ -1,0 +1,47 @@
+import ast
+from pathlib import Path
+
+
+def test_lesson_includes_class_discussion_button():
+    src = Path("a1sprechen.py").read_text(encoding="utf-8")
+    assert "CLASS_DISCUSSION_LABEL" in src
+    tree = ast.parse(src)
+    found = False
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Call(self, node):
+            nonlocal found
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "button"
+                and node.args
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id == "CLASS_DISCUSSION_LABEL"
+            ):
+                on_click = next((kw.value for kw in node.keywords if kw.arg == "on_click"), None)
+                args_kw = next((kw.value for kw in node.keywords if kw.arg == "args"), None)
+                if (
+                    isinstance(on_click, ast.Name)
+                    and on_click.id == "_go_class_thread"
+                    and isinstance(args_kw, ast.Tuple)
+                    and len(args_kw.elts) == 1
+                ):
+                    arg = args_kw.elts[0]
+                    if (
+                        isinstance(arg, ast.Subscript)
+                        and isinstance(arg.value, ast.Name)
+                        and arg.value.id == "info"
+                    ):
+                        slice_node = arg.slice
+                        if isinstance(slice_node, ast.Constant):
+                            slice_value = slice_node.value
+                        elif hasattr(slice_node, "value") and isinstance(slice_node.value, ast.Constant):
+                            slice_value = slice_node.value.value
+                        else:
+                            slice_value = None
+                        if slice_value == "chapter":
+                            found = True
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    assert found, "Class discussion button missing or has wrong arguments"


### PR DESCRIPTION
## Summary
- show a class discussion link on lessons with post count and navigation button
- cover class discussion button with regression test

## Testing
- `ruff check a1sprechen.py tests/test_class_discussion_link.py` *(fails: E402 Module level import not at top of file, and 107 more)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c576b486108321bdf24fddbd33316b