### PR TITLE
Handle missing class name before class board query

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2160,30 +2160,36 @@ if tab == "My Course":
             )
 
         # ---- Class discussion count & link ----
-        board_base = (
-            db.collection("class_board")
-            .document(student_level)
-            .collection("classes")
-            .document(class_name)
-            .collection("posts")
-        )
-        post_count = sum(
-            1 for _ in board_base.where("chapter", "==", info["chapter"]).stream()
-        )
-        link_key = CLASS_DISCUSSION_LINK_TMPL.format(info=info)
-        count_txt = f" ({post_count})" if post_count else ""
-        st.info(
-            f"📣 For group practice and class notes: "
-            f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_key})"
-        )
-        st.button(
-            CLASS_DISCUSSION_LABEL,
-            key=link_key,
-            on_click=_go_class_thread,
-            args=(info["chapter"],),
-        )
-        if post_count == 0:
-            st.caption("No posts yet. Clicking will show the full board.")
+        student_row = st.session_state.get("student_row") or {}
+        class_name = str(student_row.get("ClassName", "")).strip()
+
+        if not class_name:
+            st.warning("Missing class name for discussion board.")
+        else:
+            board_base = (
+                db.collection("class_board")
+                .document(student_level)
+                .collection("classes")
+                .document(class_name)
+                .collection("posts")
+            )
+            post_count = sum(
+                1 for _ in board_base.where("chapter", "==", info["chapter"]).stream()
+            )
+            link_key = CLASS_DISCUSSION_LINK_TMPL.format(info=info)
+            count_txt = f" ({post_count})" if post_count else ""
+            st.info(
+                f"📣 For group practice and class notes: "
+                f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_key})"
+            )
+            st.button(
+                CLASS_DISCUSSION_LABEL,
+                key=link_key,
+                on_click=_go_class_thread,
+                args=(info["chapter"],),
+            )
+            if post_count == 0:
+                st.caption("No posts yet. Clicking will show the full board.")
 
         st.divider()
 


### PR DESCRIPTION
## Summary
- Safely retrieve `student_row` and determine class name before building class board links
- Warn when class name is missing to avoid invalid Firestore queries

## Testing
- `ruff check a1sprechen.py` *(fails: E402, F401, etc.)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57ffce9208321859eab99eccd7c00