### PR TITLE
Refactor course book discussion block

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2149,8 +2149,12 @@ if tab == "My Course":
 
         # ---- Lesson info ----
         info = schedule[idx]
+        chapter = info.get("chapter")
         title_txt = f"Day {info['day']}: {info['topic']}"
-        st.markdown(f"### {highlight_terms(title_txt, search_terms)} (Chapter {info['chapter']})", unsafe_allow_html=True)
+        st.markdown(
+            f"### {highlight_terms(title_txt, search_terms)} (Chapter {chapter or '?'})",
+            unsafe_allow_html=True,
+        )
         if info.get("grammar_topic"):
             st.markdown(f"**🔤 Grammar Focus:** {highlight_terms(info['grammar_topic'], search_terms)}", unsafe_allow_html=True)
         if info.get("goal") or info.get("instruction"):
@@ -2165,35 +2169,33 @@ if tab == "My Course":
 
         if not class_name:
             st.warning("Missing class name for discussion board.")
+        elif not chapter:
+            st.warning("Missing chapter for discussion board.")
         else:
-            chapter = info.get("chapter")
-            if not chapter:
-                st.warning("Missing chapter for discussion board.")
-            else:
-                board_base = (
-                    db.collection("class_board")
-                    .document(student_level)
-                    .collection("classes")
-                    .document(class_name)
-                    .collection("posts")
-                )
-                post_count = sum(
-                    1 for _ in board_base.where("chapter", "==", chapter).stream()
-                )
-                link_key = CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)
-                count_txt = f" ({post_count})" if post_count else ""
-                st.info(
-                    f"📣 For group practice and class notes: "
-                    f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_key})"
-                )
-                st.button(
-                    CLASS_DISCUSSION_LABEL,
-                    key=link_key,
-                    on_click=_go_class_thread,
-                    args=(info["chapter"],),
-                )
-                if post_count == 0:
-                    st.caption("No posts yet. Clicking will show the full board.")
+            board_base = (
+                db.collection("class_board")
+                .document(student_level)
+                .collection("classes")
+                .document(class_name)
+                .collection("posts")
+            )
+            post_count = sum(
+                1 for _ in board_base.where("chapter", "==", chapter).stream()
+            )
+            link_key = CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)
+            count_txt = f" ({post_count})" if post_count else ""
+            st.info(
+                f"📣 For group practice and class notes: "
+                f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_key})"
+            )
+            st.button(
+                CLASS_DISCUSSION_LABEL,
+                key=link_key,
+                on_click=_go_class_thread,
+                args=(chapter,),
+            )
+            if post_count == 0:
+                st.caption("No posts yet. Clicking will show the full board.")
 
         st.divider()
 

--- a/tests/test_class_discussion_link.py
+++ b/tests/test_class_discussion_link.py
@@ -27,20 +27,8 @@ def test_lesson_includes_class_discussion_button():
                     and len(args_kw.elts) == 1
                 ):
                     arg = args_kw.elts[0]
-                    if (
-                        isinstance(arg, ast.Subscript)
-                        and isinstance(arg.value, ast.Name)
-                        and arg.value.id == "info"
-                    ):
-                        slice_node = arg.slice
-                        if isinstance(slice_node, ast.Constant):
-                            slice_value = slice_node.value
-                        elif hasattr(slice_node, "value") and isinstance(slice_node.value, ast.Constant):
-                            slice_value = slice_node.value.value
-                        else:
-                            slice_value = None
-                        if slice_value == "chapter":
-                            found = True
+                    if isinstance(arg, ast.Name) and arg.id == "chapter":
+                        found = True
             self.generic_visit(node)
 
     Visitor().visit(tree)

--- a/tests/test_coursebook_discussion_links.py
+++ b/tests/test_coursebook_discussion_links.py
@@ -4,5 +4,5 @@ from pathlib import Path
 def test_coursebook_discussion_link_present():
     src = Path("a1sprechen.py").read_text(encoding="utf-8")
     assert "Class Discussion & Notes" in src
-    assert "go_discussion_{info['chapter']}" in src
+    assert "go_discussion_{chapter}" in src
     assert "Check the group discussion for this chapter and class notes." in src


### PR DESCRIPTION
## Summary
- capture chapter once and reuse for course-book discussion link and button
- skip link/button creation when chapter missing
- update tests for new chapter variable usage

## Testing
- `ruff check a1sprechen.py` *(fails: existing 108 errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5870f785c8321a9d881a53ae7594f