### PR TITLE
Use CLASS_DISCUSSION_PROMPT for discussion link prompt

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2379,8 +2379,8 @@ if tab == "My Course":
             chapter = info.get("chapter")
             if chapter:
                 st.info(
-                    f"[Click here to read the group discussion for this chapter]"
-                    f"({CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)}) — includes class notes and Q&A."
+                    f"[{CLASS_DISCUSSION_PROMPT}]"
+                    f"({CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)})"
                 )
             else:
                 st.warning("Missing chapter for discussion board.")


### PR DESCRIPTION
## Summary
- Use `CLASS_DISCUSSION_PROMPT` when rendering course discussion link to avoid duplicate hardcoded strings

## Testing
- `python -m pytest tests/test_coursebook_discussion_links.py -q`
- `ruff check a1sprechen.py tests/test_coursebook_discussion_links.py` *(fails: E402, F401, E701, etc. - pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c58c781ccc832193e5d8b8eddeffcf