### PR TITLE
Add anchor for class discussion notes

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1044,6 +1044,7 @@ if "build_course_day_link" not in globals():
 # Strings used for course discussion links
 CLASS_DISCUSSION_LABEL = "Class Discussion & Notes"
 CLASS_DISCUSSION_LINK_TMPL = "go_discussion_{chapter}"
+CLASS_DISCUSSION_ANCHOR = "#classnotes"
 CLASS_DISCUSSION_PROMPT = "Check the group discussion for this chapter and class notes."
 
 
@@ -1075,6 +1076,7 @@ def _go_class_thread(topic: str) -> None:
         st.session_state["q_search_warning"] = True
     else:
         st.session_state["q_search"] = topic
+    st.session_state["__scroll_to_classnotes"] = True
 # --- Nav dropdown (mobile-friendly, simple text) ---
 def render_dropdown_nav():
     tabs = [
@@ -2183,10 +2185,11 @@ if tab == "My Course":
                 1 for _ in board_base.where("chapter", "==", chapter).stream()
             )
             link_key = CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)
+            link_url = f"{link_key}{CLASS_DISCUSSION_ANCHOR}"
             count_txt = f" ({post_count})" if post_count else ""
             st.info(
                 f"📣 For group practice and class notes: "
-                f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_key})"
+                f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_url})"
             )
             st.button(
                 CLASS_DISCUSSION_LABEL,
@@ -2380,7 +2383,7 @@ if tab == "My Course":
             if chapter:
                 st.info(
                     f"[{CLASS_DISCUSSION_PROMPT}]"
-                    f"({CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)})"
+                    f"({CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)}{CLASS_DISCUSSION_ANCHOR})"
                 )
             else:
                 st.warning("Missing chapter for discussion board.")
@@ -3965,6 +3968,12 @@ if tab == "My Course":
 
         # ===================== Class Board =====================
         elif classroom_section == "Class Notes & Q&A":
+            st.markdown("<div id='classnotes'></div>", unsafe_allow_html=True)
+            if st.session_state.pop("__scroll_to_classnotes", False):
+                st.markdown(
+                    "<script>window.location.hash='classnotes';</script>",
+                    unsafe_allow_html=True,
+                )
             board_base = (
                 db.collection("class_board")
                 .document(student_level)

--- a/tests/test_class_discussion_link.py
+++ b/tests/test_class_discussion_link.py
@@ -5,6 +5,7 @@ from pathlib import Path
 def test_lesson_includes_class_discussion_button():
     src = Path("a1sprechen.py").read_text(encoding="utf-8")
     assert "CLASS_DISCUSSION_LABEL" in src
+    assert "CLASS_DISCUSSION_ANCHOR" in src
     tree = ast.parse(src)
     found = False
 

--- a/tests/test_coursebook_discussion_links.py
+++ b/tests/test_coursebook_discussion_links.py
@@ -6,3 +6,4 @@ def test_coursebook_discussion_link_present():
     assert "Class Discussion & Notes" in src
     assert "go_discussion_{chapter}" in src
     assert "Check the group discussion for this chapter and class notes." in src
+    assert "#classnotes" in src


### PR DESCRIPTION
## Summary
- Append `#classnotes` anchor to class discussion URLs
- Auto-scroll to the notes section when navigating to the discussion
- Test for anchor usage in discussion links

## Testing
- ⚠️ `ruff check a1sprechen.py tests/test_class_discussion_link.py tests/test_coursebook_discussion_links.py` (style violations in repository)
- ✅ `ruff check tests/test_class_discussion_link.py tests/test_coursebook_discussion_links.py`
- ✅ `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c58d55d944832198e7e08122d3ecdd