### PR TITLE
Include chapter in lesson selector

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2135,7 +2135,7 @@ if tab == "My Course":
                 "Lesson selection",
                 list(range(len(schedule))),
                 index=default_idx,
-                format_func=lambda i: f"Day {schedule[i]['day']} - {schedule[i]['topic']}",
+                format_func=lambda i: f"Day {schedule[i]['day']} - {schedule[i]['topic']} (Chapter {schedule[i].get('chapter', '?')})",
                 label_visibility="collapsed",
             )
 

--- a/tests/test_schedule_module.py
+++ b/tests/test_schedule_module.py
@@ -52,5 +52,5 @@ def test_day15_title_normalized():
 def test_day6_coursebook_entry():
     schedule = get_a1_schedule()
     day6 = next(d for d in schedule if d["day"] == 6)
-    label = f"Day {day6['day']} - {day6['topic']} {day6['chapter']}".strip()
-    assert label == "Day 6 - Schreiben & Sprechen 2.3"
+    label = f"Day {day6['day']} - {day6['topic']} (Chapter {day6.get('chapter', '?')})"
+    assert label == "Day 6 - Schreiben & Sprechen (Chapter 2.3)"


### PR DESCRIPTION
## Summary
- show chapter information in lesson selection dropdown labels
- adjust schedule module test for updated lesson label format

## Testing
- `pytest tests/test_schedule_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ee43751083219380659da313a710