### PR TITLE
Clarify class discussion guidance

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1045,7 +1045,11 @@ if "build_course_day_link" not in globals():
 CLASS_DISCUSSION_LABEL = "Class Discussion & Notes"
 CLASS_DISCUSSION_LINK_TMPL = "go_discussion_{chapter}"
 CLASS_DISCUSSION_ANCHOR = "#classnotes"
-CLASS_DISCUSSION_PROMPT = "Check the group discussion for this chapter and class notes."
+CLASS_DISCUSSION_PROMPT = "Discussion for this class can be found at"
+CLASS_DISCUSSION_REMINDER = (
+    "Your recorded lecture, grammar book, and workbook are saved below. "
+    "Class notes are additional and cover discussions from class."
+)
 
 
 def _go_class_thread(topic: str) -> None:
@@ -2188,8 +2192,9 @@ if tab == "My Course":
             link_url = f"{link_key}{CLASS_DISCUSSION_ANCHOR}"
             count_txt = f" ({post_count})" if post_count else ""
             st.info(
-                f"📣 For group practice and class notes: "
-                f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_url})"
+                f"📣 {CLASS_DISCUSSION_PROMPT} "
+                f"[{CLASS_DISCUSSION_LABEL}{count_txt}]({link_url}). "
+                f"{CLASS_DISCUSSION_REMINDER}"
             )
             st.button(
                 CLASS_DISCUSSION_LABEL,
@@ -2381,9 +2386,14 @@ if tab == "My Course":
             # Student Info: link to class discussion + notes
             chapter = info.get("chapter")
             if chapter:
+                link = (
+                    f"{CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)}"
+                    f"{CLASS_DISCUSSION_ANCHOR}"
+                )
                 st.info(
-                    f"[{CLASS_DISCUSSION_PROMPT}]"
-                    f"({CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)}{CLASS_DISCUSSION_ANCHOR})"
+                    f"📣 {CLASS_DISCUSSION_PROMPT} "
+                    f"[{CLASS_DISCUSSION_LABEL}]({link}). "
+                    f"{CLASS_DISCUSSION_REMINDER}"
                 )
             else:
                 st.warning("Missing chapter for discussion board.")

--- a/tests/test_coursebook_discussion_links.py
+++ b/tests/test_coursebook_discussion_links.py
@@ -5,5 +5,5 @@ def test_coursebook_discussion_link_present():
     src = Path("a1sprechen.py").read_text(encoding="utf-8")
     assert "Class Discussion & Notes" in src
     assert "go_discussion_{chapter}" in src
-    assert "Check the group discussion for this chapter and class notes." in src
+    assert "Discussion for this class can be found at" in src
     assert "#classnotes" in src


### PR DESCRIPTION
## Summary
- Clarify coursebook instructions to point learners to the class discussion page
- Remind students that recorded lectures, grammar notes, and workbook assignments are the primary materials

## Testing
- `ruff check a1sprechen.py tests/test_coursebook_discussion_links.py` *(fails: 108 errors)*
- `pytest tests/test_coursebook_discussion_links.py -q`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ee3caa488321b18d5f64b56259d9