### PR TITLE
Handle missed assignments before recommending next work

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1322,6 +1322,9 @@ if tab == "Dashboard":
         )
         _next_chip = f"<span class='pill pill-purple'>{_next_title}</span>"
         _next_sub = _next_lesson.get("goal", "")
+    elif _missed_list:
+        _next_chip = "<span class='pill pill-amber'>Finish missed work</span>"
+        _next_sub = "Complete skipped assignments first"
     else:
         _next_chip = "<span class='pill pill-green'>All caught up</span>"
         _next_sub = ""

--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -255,7 +255,6 @@ def get_assignment_summary(
                     f"Day {day}: Chapter {chapter_field} – {lesson.get('topic','')}"
                 )
                 break
-
     def _is_recommendable(lesson: dict) -> bool:
         topic = str(lesson.get("topic", "")).lower()
         return not ("schreiben" in topic and "sprechen" in topic)
@@ -268,13 +267,14 @@ def get_assignment_summary(
     last_num2 = max(completed_chapters) if completed_chapters else 0.0
 
     next_assignment = None
-    for lesson in schedule:
-        chap_num = _extract_max_num(lesson.get("chapter", ""))
-        if not _is_recommendable(lesson):
-            continue
-        if chap_num and chap_num > last_num2:
-            next_assignment = lesson
-            break
+    if not skipped_assignments:
+        for lesson in schedule:
+            chap_num = _extract_max_num(lesson.get("chapter", ""))
+            if not _is_recommendable(lesson):
+                continue
+            if chap_num and chap_num > last_num2:
+                next_assignment = lesson
+                break
 
     return {"missed": skipped_assignments, "next": next_assignment}
 
@@ -708,7 +708,7 @@ def render_results_and_resources_tab() -> None:
                     f"{level}. Your completion certificate will be emailed to you."
                 )
             else:
-                st.success("🎉 You’re up to date!")
+                st.info("Complete your missed assignments before moving on.")
 
     elif rr_page == "Downloads":
         st.subheader("Downloads")


### PR DESCRIPTION
## Summary
- Avoid suggesting a new lesson when earlier assignments were skipped, returning `None` for the next assignment
- Prompt students to finish skipped work in the "Missed & Next" section instead of celebrating being up-to-date
- Nudge users on the dashboard to complete missed assignments when no next lesson is available

## Testing
- `ruff check src/assignment_ui.py a1sprechen.py` *(fails: unrecognized command and style errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5f26ecf8c8321a7bb567661ea9b88