### PR TITLE
Ensure class thread navigation sets classroom page

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1074,6 +1074,7 @@ def _go_class_thread(topic: str) -> None:
     ]
     count = len(posts)
     st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
+    st.session_state["classroom_page"] = "Class Notes & Q&A"
     st.session_state["q_search_count"] = count
     if count == 0:
         st.session_state["q_search"] = ""

--- a/tests/test_class_thread_no_posts.py
+++ b/tests/test_class_thread_no_posts.py
@@ -81,6 +81,7 @@ def test_go_class_thread_clears_search_when_no_posts():
     assert "q_search_warning" in st.session_state
     assert st.session_state.get("q_search_count") == 0
     assert st.session_state.get("coursebook_subtab") == "🧑‍🏫 Classroom"
+    assert st.session_state.get("classroom_page") == "Class Notes & Q&A"
 
 
 def test_go_class_thread_keeps_search_when_posts_exist():
@@ -94,3 +95,4 @@ def test_go_class_thread_keeps_search_when_posts_exist():
     assert "q_search_warning" not in st.session_state
     assert st.session_state.get("q_search_count") == 1
     assert st.session_state.get("coursebook_subtab") == "🧑‍🏫 Classroom"
+    assert st.session_state.get("classroom_page") == "Class Notes & Q&A"


### PR DESCRIPTION
## Summary
- Set `classroom_page` to "Class Notes & Q&A" when jumping to a class discussion
- Test that `_go_class_thread` updates classroom navigation state

## Testing
- `pytest tests/test_class_discussion_link.py tests/test_class_thread_no_posts.py`
- `ruff check a1sprechen.py tests/test_class_thread_no_posts.py tests/test_class_discussion_link.py` *(fails: Found 108 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f69a76708321aeff13c915e6dedc