### PR TITLE
Handle nested lesson assignments

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -296,7 +296,15 @@ def get_assignment_summary(
         chapter_field = lesson.get("chapter", "")
         lesson_nums = _extract_all_nums(chapter_field)
         day = lesson.get("day", "")
-        has_assignment = lesson.get("assignment", False)
+        lesen_horen = lesson.get("lesen_hören", [])
+        if isinstance(lesen_horen, dict):
+            lh_items = [lesen_horen]
+        elif isinstance(lesen_horen, list):
+            lh_items = [item for item in lesen_horen if isinstance(item, dict)]
+        else:
+            lh_items = []
+        nested_assignment = any(item.get("assignment", False) for item in lh_items)
+        has_assignment = lesson.get("assignment", False) or nested_assignment
         for chap_num in lesson_nums:
             if has_assignment and chap_num < last_num and chap_num not in completed_nums:
                 skipped_assignments.append(

--- a/tests/test_assignment_summary_filters.py
+++ b/tests/test_assignment_summary_filters.py
@@ -46,3 +46,29 @@ def test_missed_assignments_skip_goethe(monkeypatch):
     summary = assignment_ui.get_assignment_summary("s1", "A1", df)
     assert summary["missed"] == []
     assert summary["next"]["day"] == 3
+
+
+def test_skipped_detection_includes_nested_assignments(monkeypatch):
+    schedule = [
+        {"day": 1, "chapter": "1.0", "assignment": True, "topic": "Ch1"},
+        {
+            "day": 2,
+            "chapter": "1.5",
+            "topic": "Ch1.5",
+            "lesen_hören": [{"chapter": "1.5", "assignment": True}],
+        },
+        {"day": 3, "chapter": "2.0", "assignment": True, "topic": "Ch2"},
+    ]
+    df = pd.DataFrame(
+        {
+            "studentcode": ["s1", "s1"],
+            "assignment": ["1.0", "2.0"],
+            "level": ["A1", "A1"],
+            "score": ["90", "95"],
+            "date": ["2024-01-01", "2024-01-02"],
+        }
+    )
+    monkeypatch.setattr(assignment_ui, "_get_level_schedules", lambda: {"A1": schedule})
+
+    summary = assignment_ui.get_assignment_summary("s1", "A1", df)
+    assert summary["missed"] == ["Day 2: Chapter 1.5 – Ch1.5"]


### PR DESCRIPTION
## Summary
- detect assignments nested under `lesen_hören` when summarizing student work
- add regression test ensuring skipped nested assignments are flagged

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5f7c224bc8321bf5323523146b77d