### PR TITLE
Handle implicit decimals in assignment chapters

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -259,10 +259,20 @@ def get_assignment_summary(
     def _extract_all_nums(chapter_str: str):
         parts = re.split(r"[_\s,;]+", str(chapter_str))
         nums = []
+        base_int: int | None = None
         for part in parts:
             m = re.search(r"\d+(?:\.\d+)?", part)
-            if m:
-                nums.append(float(m.group()))
+            if not m:
+                continue
+            token = m.group()
+            if "." in token:
+                nums.append(float(token))
+                base_int = int(token.split(".")[0])
+            else:
+                if base_int is not None:
+                    nums.append(float(f"{base_int}.{token}"))
+                else:
+                    nums.append(float(token))
         return nums
 
     def _extract_max_num(chapter: str):

--- a/tests/test_extract_all_nums.py
+++ b/tests/test_extract_all_nums.py
@@ -1,0 +1,28 @@
+import types
+
+import pytest
+
+from src import assignment_ui
+from src.assignment_ui import get_assignment_summary
+
+
+def _get_extract_all_nums():
+    code_obj = next(
+        const
+        for const in get_assignment_summary.__code__.co_consts
+        if isinstance(const, types.CodeType) and const.co_name == "_extract_all_nums"
+    )
+    return types.FunctionType(code_obj, assignment_ui.__dict__)
+
+
+@pytest.mark.parametrize(
+    "chapter_str, expected",
+    [
+        ("0.2 and 1.1", [0.2, 1.1]),
+        ("12.1,2,3", [12.1, 12.2, 12.3]),
+    ],
+)
+def test_extract_all_nums(chapter_str: str, expected: list[float]) -> None:
+    extract = _get_extract_all_nums()
+    assert extract(chapter_str) == expected
+


### PR DESCRIPTION
## Summary
- carry forward the integer part of a chapter when later tokens omit it
- add tests for parsing chapters like `0.2 and 1.1` and `12.1,2,3`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f8e126408321a689c065a9773fb8