### PR TITLE
Refactor Firestore client initialization

### DIFF
--- a/src/attendance_utils.py
+++ b/src/attendance_utils.py
@@ -14,9 +14,16 @@ import logging
 from .firestore_utils import format_record
 
 try:  # Firestore client is optional in test environments
-    from falowen.sessions import db  # pragma: no cover - runtime side effect
+    from falowen.sessions import get_db  # pragma: no cover - runtime side effect
 except Exception:  # pragma: no cover - Firestore may be unavailable
-    db = None  # type: ignore
+    def get_db():  # type: ignore
+        return None
+
+db = None  # type: ignore
+
+
+def _get_db():
+    return db if db is not None else get_db()
 
 
 def load_attendance_records(
@@ -33,6 +40,7 @@ def load_attendance_records(
     ``([], 0, 0.0)``.
     """
 
+    db = _get_db()
     if db is None:
         return [], 0, 0.0
 

--- a/src/progress_utils.py
+++ b/src/progress_utils.py
@@ -12,14 +12,21 @@ import logging
 import streamlit as st
 
 try:  # Firestore is optional in certain environments
-    from firebase_admin import firestore  # type: ignore
-    from falowen.sessions import db  # pragma: no cover - side effect import
+    from falowen.sessions import get_db
 except Exception:  # pragma: no cover - Firestore may be unavailable
-    db = None  # type: ignore
+    def get_db():  # type: ignore
+        return None
+
+db = None  # type: ignore
+
+
+def _get_db():
+    return db if db is not None else get_db()
 
 
 def _progress_doc_ref(student_code: str):
     """Return the Firestore document reference for the student's progress."""
+    db = _get_db()
     if db is None:
         return None
     return db.collection("falowen_progress").document(student_code)

--- a/src/schreiben.py
+++ b/src/schreiben.py
@@ -16,9 +16,16 @@ from google.cloud.firestore_v1 import FieldFilter
 from firebase_admin import firestore
 
 try:  # Firestore may be unavailable in tests
-    from falowen.sessions import db  # pragma: no cover - runtime side effect
+    from falowen.sessions import get_db  # pragma: no cover - runtime side effect
 except Exception:  # pragma: no cover - handle missing Firestore gracefully
-    db = None  # type: ignore
+    def get_db():  # type: ignore
+        return None
+
+db = None  # type: ignore
+
+
+def _get_db():
+    return db if db is not None else get_db()
 
 
 # ---------------------------------------------------------------------------
@@ -32,6 +39,7 @@ def update_schreiben_stats(student_code: str) -> None:
     if not student_code:
         st.warning("No student code provided; skipping stats update.")
         return
+    db = _get_db()
     if db is None:
         st.warning("Firestore not initialized; skipping stats update.")
         return
@@ -95,6 +103,7 @@ def get_schreiben_stats(student_code: str):
     if not student_code:
         st.warning("No student code provided; cannot load stats.")
         return default_stats
+    db = _get_db()
     if db is None:
         st.warning("Firestore not initialized; cannot load stats.")
         return default_stats
@@ -141,6 +150,7 @@ def save_submission(
     if not student_code:
         st.warning("No student code provided; submission not saved.")
         return
+    db = _get_db()
     if db is None:
         st.warning("Firestore not initialized; submission not saved.")
         return
@@ -168,6 +178,7 @@ def save_schreiben_feedback(student_code: str, feedback: str, letter: str) -> No
     if not student_code:
         st.warning("No student code provided; feedback not saved.")
         return
+    db = _get_db()
     if db is None:
         st.warning("Firestore not initialized; feedback not saved.")
         return
@@ -189,6 +200,7 @@ def load_schreiben_feedback(student_code: str) -> Tuple[str, str]:
     if not student_code:
         st.warning("No student code provided; feedback not loaded.")
         return "", ""
+    db = _get_db()
     if db is None:
         st.warning("Firestore not initialized; feedback not loaded.")
         return "", ""
@@ -206,6 +218,7 @@ def delete_schreiben_feedback(student_code: str) -> None:
     if not student_code:
         st.warning("No student code provided; feedback not cleared.")
         return
+    db = _get_db()
     if db is None:
         st.warning("Firestore not initialized; feedback not cleared.")
         return

--- a/src/stats.py
+++ b/src/stats.py
@@ -14,9 +14,12 @@ import pandas as pd
 import streamlit as st
 
 try:  # Firestore access is optional in tests
-    from falowen.sessions import db  # pragma: no cover - runtime side effect
+    from falowen.sessions import get_db  # pragma: no cover - runtime side effect
 except Exception:  # pragma: no cover - Firestore may be unavailable
-    db = None  # type: ignore
+    def get_db():  # type: ignore
+        return None
+
+db = None  # type: ignore
 
 # Maximum number of vocab practice attempts to retain per student
 MAX_HISTORY = 100
@@ -30,7 +33,10 @@ MAX_HISTORY = 100
 def _get_db():
     """Return the Firestore client if initialised, otherwise ``None``."""
 
-    return db  # may be ``None``
+    try:
+        return db if db is not None else get_db()
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- centralize Firestore setup in `get_db()` with caching and error handling
- switch session and helper modules to call `get_db()` instead of global `db`
- allow tests to monkeypatch `db` while using lazy client initialization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c603887f1c83219e6f411dc5a38382