### PR TITLE
log fetch failures in blog feed

### DIFF
--- a/src/blog_feed.py
+++ b/src/blog_feed.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 from typing import List, Dict, Optional
+import logging
 import re
 
 import requests
@@ -26,7 +27,8 @@ def _get(url: str) -> Optional[str]:
         )
         r.raise_for_status()
         return r.text
-    except Exception:
+    except Exception as exc:
+        logging.exception("Failed to fetch %s: %s", url, exc)
         return None
 
 


### PR DESCRIPTION
## Summary
- log network fetch failures in `blog_feed._get` via `logging.exception`
- import logging to support error logging

## Testing
- `ruff check src/blog_feed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6834620e083219456df808c43bb8d