### PR TITLE
Update A1 totals in results tab

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -638,7 +638,7 @@ def render_results_and_resources_tab() -> None:
         df_lvl = df_user[df_user.level == level].copy()
         df_lvl["score"] = pd.to_numeric(df_lvl["score"], errors="coerce")
 
-        totals = {"A1": 17, "A2": 28, "B1": 28, "B2": 24, "C1": 24}
+        totals = {"A1": 19, "A2": 28, "B1": 28, "B2": 24, "C1": 24}
         total = int(totals.get(level, 0))
         completed = int(df_lvl["assignment"].nunique())
         avg_score = float(df_lvl["score"].mean() or 0)


### PR DESCRIPTION
## Summary
- Adjust A1 assignment count to 19 in results tab totals

## Testing
- `python - <<'PY' ...` (simulate render_results_and_resources_tab and verify totals)
- `pytest tests/test_results_downloads_only.py::test_downloads_option_rendered_when_no_scores -q`
- `pytest tests/test_enrollment_letter_balance_block.py::test_enrollment_letter_blocked_with_outstanding_balance -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6bbdf1ac08321b96fce2c8bfcc900