### PR TITLE
Switch to streamlit-cookies-controller

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ streamlit==1.49.0
 openai==1.55.3
 pandas==2.3.2
 fpdf==1.7.2
-streamlit-cookies-manager==0.2.0
+streamlit-cookies-controller==0.0.5
 requests==2.32.5
 firebase-admin==7.1.0
 python-docx==1.2.0


### PR DESCRIPTION
## Summary
- replace deprecated streamlit-cookies-manager with streamlit-cookies-controller

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit-cookies-controller==0.0.5)*
- `ruff check .` *(fails: Found 139 errors)*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e94e8fa08321a3fe34c18ae84c8b