### PR TITLE
Add rich dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ rapidfuzz==3.13.0
 flake8==7.1.1
 extra-streamlit-components>=0.1.63
 beautifulsoup4>=4.12
+rich==14.1.0


### PR DESCRIPTION
## Summary
- add rich library to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit-cookies-controller==0.0.5)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'streamlit_cookies_controller')*

------
https://chatgpt.com/codex/tasks/task_e_68c6f02ad3008321aa6c6a60b7f750b7