### PR TITLE
Remove duplicate BeautifulSoup requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,4 @@ pytest==8.4.1
 rapidfuzz==3.13.0
 flake8==7.1.1
 extra-streamlit-components>=0.1.63
-beautifulsoup4>=4.12
 rich==14.1.0


### PR DESCRIPTION
## Summary
- remove duplicate beautifulsoup4 requirement from requirements.txt

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement streamlit-cookies-controller==0.0.5)
- `pytest` (fails: ModuleNotFoundError: No module named 'streamlit_cookies_controller')

------
https://chatgpt.com/codex/tasks/task_e_68c6f10b25348321b8376f1d1cb2eda3