### PR TITLE
Add streamlit cookies controller dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ rapidfuzz==3.13.0
 flake8==7.1.1
 extra-streamlit-components>=0.1.63
 rich==14.1.0
+streamlit-cookies-controller>=0.0.6


### PR DESCRIPTION
## Summary
- add streamlit-cookies-controller package requirement

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'streamlit_cookies_controller')*

------
https://chatgpt.com/codex/tasks/task_e_68c6f516dfa08321bed373a0736a694e