### PR TITLE
Handle missing streamlit cookie controller

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,10 +9,33 @@ manager without pulling in the whole application.
 
 from __future__ import annotations
 
+import logging
 import os
 
 import streamlit as st
-from streamlit_cookies_controller import CookieController
+
+try:  # pragma: no cover - import guarded for missing optional dependency
+    from streamlit_cookies_controller import CookieController
+except ImportError:  # pragma: no cover - executed when dependency missing
+    logging.warning(
+        "streamlit-cookies-controller not installed; using in-memory cookie"
+        " manager. Install with `pip install streamlit-cookies-controller`"
+        " for full functionality."
+    )
+
+    class CookieController(dict):
+        """Minimal in-memory fallback for :class:`CookieController`."""
+
+        ready = True
+
+        def set(self, key: str, value: object, **kwargs: object) -> None:
+            self[key] = value
+
+        def delete(self, key: str) -> None:  # pragma: no cover - simple
+            self.pop(key, None)
+
+        def save(self) -> None:  # pragma: no cover - no-op for fallback
+            return None
 
 from .session_management import bootstrap_cookie_manager
 


### PR DESCRIPTION
## Summary
- Gracefully handle missing `streamlit_cookies_controller` by logging a warning and providing an in-memory fallback
- Ensure `get_cookie_manager` works even when the dependency is absent

## Testing
- `ruff check src/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6f61226488321baa8ed03b6b58324