### PR TITLE
Refactor session store to use Streamlit session state

### DIFF
--- a/tests/test_session_renew_helper.py
+++ b/tests/test_session_renew_helper.py
@@ -3,7 +3,8 @@ import types
 import logging
 from datetime import datetime, timedelta, UTC
 
-import streamlit as st
+import pytest
+from src.auth import st
 
 # Stub falowen.sessions before importing module under test
 stub_sessions = types.SimpleNamespace(
@@ -23,8 +24,9 @@ from src.auth import (  # noqa: E402
 from src.ui.auth import renew_session_if_needed  # noqa: E402
 
 
-def setup_function(function):
-    st.session_state.clear()
+@pytest.fixture(autouse=True)
+def _reset_session(monkeypatch):
+    monkeypatch.setattr(st, "session_state", {})
     clear_session_clients()
 
 

--- a/tests/test_session_restore.py
+++ b/tests/test_session_restore.py
@@ -2,15 +2,11 @@ import sys
 import types
 
 import pandas as pd
-import streamlit as st
-
+import pytest
 from src.contracts import is_contract_expired
 
-# Stub ``falowen.sessions`` before importing ``src.auth`` to avoid network calls.
-stub_sessions = types.SimpleNamespace(validate_session_token=lambda *a, **k: None)
-sys.modules.setdefault("falowen.sessions", stub_sessions)
-
-from src.auth import (  # noqa: E402
+from src.auth import (
+    st,
     create_cookie_manager,
     set_student_code_cookie,
     set_session_token_cookie,
@@ -22,8 +18,18 @@ from src.auth import (  # noqa: E402
     clear_session_clients,
     recover_session_from_qp_token,
 )
+# Stub ``falowen.sessions`` before importing ``src.auth`` to avoid network calls.
+stub_sessions = types.SimpleNamespace(validate_session_token=lambda *a, **k: None)
+sys.modules.setdefault("falowen.sessions", stub_sessions)
 
 cookie_manager = create_cookie_manager()
+
+
+@pytest.fixture(autouse=True)
+def _reset_session(monkeypatch):
+    monkeypatch.setattr(st, "session_state", {})
+    monkeypatch.setattr(st, "query_params", {})
+    clear_session_clients()
 
 def test_cookies_keep_user_logged_in_after_reload():
     """User with valid cookies should remain logged in after a reload."""

--- a/tests/test_session_store_threading.py
+++ b/tests/test_session_store_threading.py
@@ -1,10 +1,11 @@
 import threading
 
-from src.auth import persist_session_client, get_session_client, clear_session_clients
+from src.auth import st, persist_session_client, get_session_client, clear_session_clients
 
 
-def test_session_store_thread_safety():
+def test_session_store_thread_safety(monkeypatch):
     """Concurrent writes and reads should be thread safe."""
+    monkeypatch.setattr(st, "session_state", {})
     clear_session_clients()
     tokens = [f"tok{i}" for i in range(100)]
 


### PR DESCRIPTION
## Summary
- Swap global session store for a `get_session_store` helper using `st.session_state`
- Patch session client helpers to use `get_session_store`
- Update tests to patch Streamlit's session state via the auth module

## Testing
- `pytest tests/test_session_store_threading.py -q`
- `pytest tests/test_session_restore.py tests/test_session_store_threading.py tests/test_session_renew_helper.py -q` *(fails: No module named 'pandas', No module named 'requests')*
- `pip install pandas streamlit -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fafc6934832198a3ad07cab5794c