### PR TITLE
Add falowen dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ rapidfuzz==3.13.0
 flake8==7.1.1
 extra-streamlit-components>=0.1.63
 rich==14.1.0
+falowen==0.1.0


### PR DESCRIPTION
## Summary
- Include `falowen` package in requirements for installation with other dependencies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas', others)*

------
https://chatgpt.com/codex/tasks/task_e_68c700f085b48321bae347a3a991998c