### PR TITLE
feat: display Falowen logo on page

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -74,6 +74,19 @@ st.set_page_config(
 # Load global CSS classes and variables
 inject_global_styles()
 
+st.markdown(
+    """
+    <style>
+        .header-logo {display:flex;justify-content:center;margin-bottom:1rem;}
+        .header-logo img {height:40px;}
+    </style>
+    <div class="header-logo">
+        <img src="static/icons/falowen-512.png" alt="Falowen" />
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
+
 st.markdown("""
 <style>
 html, body { overscroll-behavior-y: none; }


### PR DESCRIPTION
## Summary
- add Streamlit markdown to show Falowen logo below global styles

## Testing
- `ruff check a1sprechen.py` *(fails: E402 Module level import not at top of file, etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c713458090832185c0498e4433481d