### PR TITLE
Refactor Streamlit app into multi-page layout

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -1,0 +1,24 @@
+import streamlit as st
+
+st.logo("static/icons/falowen-512.png")
+st.set_page_config(
+    page_title="Falowen – Your German Conversation Partner",
+    page_icon="static/icons/falowen-512.png",
+    layout="wide",
+)
+
+from src.styles import inject_global_styles
+from a1sprechen import hide_streamlit_header, dashboard_page
+
+hide_streamlit_header()
+inject_global_styles()
+st.markdown(
+    """
+    <style>
+    html, body { overscroll-behavior-y: none; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+dashboard_page()

--- a/pages/login.py
+++ b/pages/login.py
@@ -1,0 +1,24 @@
+import streamlit as st
+
+st.logo("static/icons/falowen-512.png")
+st.set_page_config(
+    page_title="Falowen – Your German Conversation Partner",
+    page_icon="static/icons/falowen-512.png",
+    layout="wide",
+)
+
+from src.styles import inject_global_styles
+from a1sprechen import hide_streamlit_header, login_page
+
+hide_streamlit_header()
+inject_global_styles()
+st.markdown(
+    """
+    <style>
+    html, body { overscroll-behavior-y: none; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+login_page()


### PR DESCRIPTION
## Summary
- Split monolithic `a1sprechen.py` into Streamlit multi-page structure
- Added `pages/login.py` and `pages/dashboard.py` with new `st.logo` usage
- Introduced `dashboard_page` helper and removed custom logo injection

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit==1.49.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c7141968208321b9042c1d4d99d297