### PR TITLE
Add meta description and canonical link to HTML heads

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#25317e" />
+  <meta name="description" content="Falowen is an all-in-one German learning platform with courses from A1 to C1, live tutor support, and tools that keep you on track." />
+  <link rel="canonical" href="https://www.falowen.app/" />
   <title>Falowen Login</title>
   <link rel="icon" href="/static/icons/falowen-180.png">
   <link rel="apple-touch-icon" href="/static/icons/falowen-180.png">

--- a/templates/falowen_login.html
+++ b/templates/falowen_login.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0ea5e9" />
+  <meta name="description" content="Falowen is an all-in-one German learning platform with courses from A1 to C1, live tutor support, and tools that keep you on track." />
+  <link rel="canonical" href="https://www.falowen.app/" />
   <title>Falowen</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add SEO description meta tag to public and template login pages
- add canonical link to public and template login pages

## Testing
- `ruff check .` *(fails: Found 151 errors)*
- `pytest` *(fails: ImportError: cannot import name 'create_session_token' from '<unknown module name>' (unknown location))*

------
https://chatgpt.com/codex/tasks/task_e_68c71649d49c83218e87c3c2a38a849d