### PR TITLE
feat: add social meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,14 @@
   <meta name="theme-color" content="#25317e" />
   <meta name="description" content="Falowen is an all-in-one German learning platform with courses from A1 to C1, live tutor support, and tools that keep you on track." />
   <link rel="canonical" href="https://www.falowen.app/" />
+  <meta property="og:title" content="Falowen Login" />
+  <meta property="og:description" content="Falowen is an all-in-one German learning platform with courses from A1 to C1, live tutor support, and tools that keep you on track." />
+  <meta property="og:url" content="https://www.falowen.app/" />
+  <meta property="og:image" content="https://www.falowen.app/static/icons/falowen-512.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Falowen Login" />
+  <meta name="twitter:description" content="Falowen is an all-in-one German learning platform with courses from A1 to C1, live tutor support, and tools that keep you on track." />
+  <meta name="twitter:image" content="https://www.falowen.app/static/icons/falowen-512.png" />
   <title>Falowen Login</title>
   <link rel="icon" href="/static/icons/falowen-180.png">
   <link rel="apple-touch-icon" href="/static/icons/falowen-180.png">

--- a/templates/falowen_login.html
+++ b/templates/falowen_login.html
@@ -6,6 +6,14 @@
   <meta name="theme-color" content="#0ea5e9" />
   <meta name="description" content="Falowen is an all-in-one German learning platform with courses from A1 to C1, live tutor support, and tools that keep you on track." />
   <link rel="canonical" href="https://www.falowen.app/" />
+  <meta property="og:title" content="Falowen" />
+  <meta property="og:description" content="Falowen is an all-in-one German learning platform with courses from A1 to C1, live tutor support, and tools that keep you on track." />
+  <meta property="og:url" content="https://www.falowen.app/" />
+  <meta property="og:image" content="https://www.falowen.app/static/icons/falowen-512.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Falowen" />
+  <meta name="twitter:description" content="Falowen is an all-in-one German learning platform with courses from A1 to C1, live tutor support, and tools that keep you on track." />
+  <meta name="twitter:image" content="https://www.falowen.app/static/icons/falowen-512.png" />
   <title>Falowen</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card metadata to Falowen login pages using existing icon

## Testing
- `pytest` *(fails: ImportError: cannot import name 'create_session_token')*

------
https://chatgpt.com/codex/tasks/task_e_68c71be49b248321abfe098c9f5ed252