### PR TITLE
chore: generate sitemap with accurate lastmod

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,57 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <!-- Homepage -->
   <url>
     <loc>https://www.falowen.app/</loc>
-    <lastmod>2025-09-07</lastmod>
+    <lastmod>2025-09-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
-
-  <!-- Register & Legal -->
   <url>
-    <loc>https://www.falowen.app/register</loc>
-    <lastmod>2025-09-07</lastmod>
+    <loc>https://www.falowen.app/login</loc>
+    <lastmod>2025-09-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
-
-  <!-- Payment Agreement -->
+  <url>
+    <loc>https://www.falowen.app/register</loc>
+    <lastmod>2025-09-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
   <url>
     <loc>https://www.falowen.app/payment-agreement</loc>
-    <lastmod>2025-09-07</lastmod>
+    <lastmod>2025-09-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
-
-  <!-- Privacy Policy -->
   <url>
     <loc>https://register.falowen.app/#privacy-policy</loc>
-    <lastmod>2025-09-07</lastmod>
+    <lastmod>2025-09-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
-
-  <!-- Terms of Service -->
   <url>
     <loc>https://register.falowen.app/#terms-of-service</loc>
-    <lastmod>2025-09-07</lastmod>
+    <lastmod>2025-09-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
-
-  <!-- About Us -->
   <url>
     <loc>https://www.falowen.app/about-us</loc>
-    <lastmod>2025-09-07</lastmod>
+    <lastmod>2025-09-14</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>
-
-  <!-- Contact -->
   <url>
     <loc>https://www.falowen.app/contact</loc>
-    <lastmod>2025-09-07</lastmod>
+    <lastmod>2025-09-14</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -1,0 +1,84 @@
+"""Generate sitemap.xml with accurate last modified dates."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from pathlib import Path
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+# (loc, path, changefreq, priority)
+ROUTES = [
+    ("https://www.falowen.app/", "public/index.html", "weekly", "1.0"),
+    ("https://www.falowen.app/login", "pages/login.py", "monthly", "0.9"),
+    ("https://www.falowen.app/register", "public/index.html", "monthly", "0.9"),
+    (
+        "https://www.falowen.app/payment-agreement",
+        "public/index.html",
+        "monthly",
+        "0.8",
+    ),
+    (
+        "https://register.falowen.app/#privacy-policy",
+        "public/index.html",
+        "monthly",
+        "0.8",
+    ),
+    (
+        "https://register.falowen.app/#terms-of-service",
+        "public/index.html",
+        "monthly",
+        "0.8",
+    ),
+    (
+        "https://www.falowen.app/about-us",
+        "public/index.html",
+        "yearly",
+        "0.6",
+    ),
+    (
+        "https://www.falowen.app/contact",
+        "public/index.html",
+        "yearly",
+        "0.6",
+    ),
+]
+
+
+def last_modified(path: str) -> str:
+    """Return last commit date for *path* in ISO-8601 format."""
+    try:
+        result = subprocess.check_output(
+            ["git", "log", "-1", "--format=%cI", path],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return result.split("T")[0]
+    except subprocess.CalledProcessError:
+        # Fallback to current date if file is not tracked.
+        return datetime.utcnow().date().isoformat()
+
+
+def generate_sitemap(destination: Path) -> None:
+    urlset = ET.Element("urlset", xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
+    for loc, path, changefreq, priority in ROUTES:
+        url = ET.SubElement(urlset, "url")
+        ET.SubElement(url, "loc").text = loc
+        ET.SubElement(url, "lastmod").text = last_modified(path)
+        ET.SubElement(url, "changefreq").text = changefreq
+        ET.SubElement(url, "priority").text = priority
+
+    rough_string = ET.tostring(urlset, encoding="utf-8")
+    reparsed = minidom.parseString(rough_string)
+    pretty_xml = reparsed.toprettyxml(indent="  ", encoding="UTF-8")
+    destination.write_bytes(pretty_xml)
+
+
+def main() -> None:
+    base_dir = Path(__file__).resolve().parents[1]
+    generate_sitemap(base_dir / "public" / "sitemap.xml")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/update-sitemap.yml
+++ b/workflows/update-sitemap.yml
@@ -1,0 +1,22 @@
+name: Update sitemap
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Generate sitemap
+        run: python scripts/generate_sitemap.py
+      - name: Commit sitemap
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update sitemap'
+          file_pattern: public/sitemap.xml


### PR DESCRIPTION
## Summary
- add script to regenerate sitemap with git-based lastmod dates
- include login route and refresh sitemap entries
- automate sitemap regeneration via GitHub Action

## Testing
- `pip install -r requirements.txt`
- `flake8 .` *(fails: a1sprechen.py:1129:27 F821)*
- `pytest` *(fails: ImportError: cannot import name 'create_session_token')*

------
https://chatgpt.com/codex/tasks/task_e_68c71c8685c48321b79e44753a021ca7