### PR TITLE
Fetch blog feed at module load for announcements

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -803,9 +803,6 @@ def dashboard_page() -> None:
     # Sidebar (no logout; logout lives in the header)
     render_sidebar_published()
 
-    # Falowen blog updates (render once)
-    new_posts = fetch_blog_feed()
-
     st.markdown("---")
     st.markdown("**You’re logged in.** Continue to your lessons and tools from the navigation.")
 
@@ -1126,7 +1123,7 @@ try:
 except Exception as e:
     st.warning(f"Navigation init issue: {e}. Falling back to Dashboard.")
     tab = "Dashboard"
-render_announcements_once(new_posts, tab == "Dashboard")
+render_announcements_once(fetch_blog_feed(), tab == "Dashboard")
 
 
 # =========================================================


### PR DESCRIPTION
## Summary
- Load blog feed when module loads and pass directly to `render_announcements_once`
- Remove redundant blog feed fetch inside `dashboard_page`

## Testing
- `streamlit run a1sprechen.py --server.headless true --server.port 8501`
- `pytest -q` *(fails: ImportError: cannot import name 'create_session_token' from '<unknown module name>' (unknown location))*
- `pytest tests/test_ui_widgets_announcements.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71e247f5c8321958eee206f523776