### PR TITLE
Ensure logged-in topbar on all pages

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -275,6 +275,15 @@ def calc_blog_height(num_posts: int) -> int:
 
 
 def login_page():
+    # Ensure base session fields exist and are hydrated before rendering.
+    bootstrap_state()
+    seed_falowen_state_from_qp()
+    bootstrap_session_from_qp()
+    ensure_student_level()
+
+    if st.session_state.get("logged_in", False):
+        render_logged_in_topbar()
+
     try:
         renew_session_if_needed()
     except Exception:
@@ -777,6 +786,7 @@ def dashboard_page() -> None:
     bootstrap_state()
     seed_falowen_state_from_qp()
     bootstrap_session_from_qp()
+    ensure_student_level()
 
     # If visiting with password-reset token
     if not st.session_state.get("logged_in", False):

--- a/tests/test_render_logged_in_topbar.py
+++ b/tests/test_render_logged_in_topbar.py
@@ -1,0 +1,106 @@
+import ast
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+class DummyCtx:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def load_func(name):
+    src = Path("a1sprechen.py").read_text()
+    module = ast.parse(src, filename="a1sprechen.py")
+    node = next(n for n in module.body if isinstance(n, ast.FunctionDef) and n.name == name)
+    code = compile(ast.Module(body=[node], type_ignores=[]), filename=name, mode="exec")
+    ns = {}
+    exec(code, ns)
+    return ns[name], ns
+
+
+def make_stub_state():
+    def markdown(*a, **k):
+        return None
+
+    def columns(spec, *a, **k):
+        n = spec if isinstance(spec, int) else len(spec)
+        return [DummyCtx() for _ in range(n)]
+
+    st = types.SimpleNamespace(
+        session_state={
+            "logged_in": True,
+            "student_code": "SC",
+            "student_name": "Name",
+            "student_level": "",
+        },
+        query_params={},
+        markdown=markdown,
+        info=lambda *a, **k: None,
+        tabs=lambda labels: [DummyCtx() for _ in labels],
+        columns=columns,
+        divider=lambda: None,
+        container=lambda: DummyCtx(),
+        stop=lambda: None,
+    )
+    return st
+
+
+def test_login_page_invokes_topbar_when_logged_in():
+    login_page, ns = load_func("login_page")
+    st = make_stub_state()
+    topbar = MagicMock()
+    ensure_mock = MagicMock()
+    ns.update(
+        {
+            "st": st,
+            "render_logged_in_topbar": topbar,
+            "bootstrap_state": MagicMock(),
+            "seed_falowen_state_from_qp": MagicMock(),
+            "bootstrap_session_from_qp": MagicMock(),
+            "ensure_student_level": ensure_mock,
+            "renew_session_if_needed": MagicMock(),
+            "render_google_oauth": MagicMock(return_value=""),
+            "render_falowen_login": MagicMock(),
+            "render_returning_login_area": MagicMock(return_value=False),
+            "render_google_brand_button_once": MagicMock(),
+            "render_signup_request_banner": MagicMock(),
+            "render_signup_form": MagicMock(),
+            "fetch_blog_feed": MagicMock(return_value=[]),
+            "render_blog_cards": MagicMock(),
+        }
+    )
+    login_page.__globals__.update(ns)
+    login_page()
+    topbar.assert_called_once()
+    ensure_mock.assert_called_once()
+
+
+def test_dashboard_page_invokes_topbar_when_logged_in():
+    dashboard_page, ns = load_func("dashboard_page")
+    st = make_stub_state()
+    topbar = MagicMock()
+    ensure_mock = MagicMock()
+    ns.update(
+        {
+            "st": st,
+            "render_logged_in_topbar": topbar,
+            "bootstrap_state": MagicMock(),
+            "seed_falowen_state_from_qp": MagicMock(),
+            "bootstrap_session_from_qp": MagicMock(),
+            "ensure_student_level": ensure_mock,
+            "login_page": MagicMock(),
+            "reset_password_page": MagicMock(),
+            "inject_notice_css": MagicMock(),
+            "render_sidebar_published": MagicMock(),
+            "_maybe_rerun": MagicMock(),
+        }
+    )
+    dashboard_page.__globals__.update(ns)
+    dashboard_page()
+    topbar.assert_called_once()
+    ensure_mock.assert_called_once()
+


### PR DESCRIPTION
## Summary
- Bootstrapped login page session state and render logged-in topbar when a user already has an active session
- Populated session state before rendering dashboard by ensuring student level is loaded
- Added tests verifying login and dashboard pages invoke the topbar when logged in

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'create_session_token')*
- `pytest tests/test_render_logged_in_topbar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72284a7e8832187b6e7346f9270a6