### PR TITLE
Require explicit student code for submissions

### DIFF
--- a/src/draft_management.py
+++ b/src/draft_management.py
@@ -106,6 +106,9 @@ def save_notes_to_db(student_code, notes):
 
 def autosave_learning_note(student_code: str, key_notes: str) -> None:
     """Autosave the current learning note draft to Firestore."""
+    if not student_code:
+        st.error("Student code is required.")
+        return
     notes = st.session_state.get(key_notes, [])
     idx = st.session_state.get("edit_note_idx")
     draft = st.session_state.get("learning_note_draft", "")

--- a/src/stats.py
+++ b/src/stats.py
@@ -72,15 +72,12 @@ def load_student_levels():
     code_col = next((c for c in code_col_candidates if c in df.columns), None)
     level_col = next((c for c in level_col_candidates if c in df.columns), None)
     if code_col is None or level_col is None:
-        st.error(
+        msg = (
             f"Roster is missing required columns. Found: {list(df.columns)}; "
             f"need one of {code_col_candidates} and one of {level_col_candidates}."
         )
-        df["__dummy_code__"] = "demo001"
-        df["__dummy_level__"] = "A1"
-        return df.rename(
-            columns={"__dummy_code__": "student_code", "__dummy_level__": "level"}
-        )
+        st.error(msg)
+        raise ValueError(msg)
 
     df = df.rename(columns={code_col: "student_code", level_col: "level"})
     return df

--- a/tests/test_draft_management.py
+++ b/tests/test_draft_management.py
@@ -19,3 +19,14 @@ def test_on_cb_subtab_change_save_error(monkeypatch):
     monkeypatch.setattr(dm, "toast_err", toast_mock)
     dm.on_cb_subtab_change()
     toast_mock.assert_called_once_with("Draft save failed")
+
+
+def test_autosave_learning_note_requires_student_code(monkeypatch):
+    errors = []
+    mock_st = types.SimpleNamespace(session_state={}, error=lambda msg: errors.append(msg))
+    monkeypatch.setattr(dm, "st", mock_st)
+    save_mock = MagicMock()
+    monkeypatch.setattr(dm, "save_notes_to_db", save_mock)
+    dm.autosave_learning_note("", "notes_key")
+    assert errors
+    save_mock.assert_not_called()

--- a/tests/test_logout_clears_ann_flag.py
+++ b/tests/test_logout_clears_ann_flag.py
@@ -7,6 +7,7 @@ from src.logout import do_logout
 def test_ann_flag_reset_after_logout():
     mock_st = types.SimpleNamespace(
         session_state={"_ann_hash": "abc"},
+        query_params={},
         success=MagicMock(),
     )
     do_logout(st_module=mock_st, destroy_token=MagicMock(), logger=types.SimpleNamespace(exception=MagicMock()))

--- a/tests/test_logout_rerenders_google_button.py
+++ b/tests/test_logout_rerenders_google_button.py
@@ -8,6 +8,7 @@ from src.logout import do_logout
 def test_logout_rerenders_components():
     mock_st = types.SimpleNamespace(
         session_state={},
+        query_params={},
         success=MagicMock(),
         markdown=MagicMock(),
         link_button=MagicMock(),

--- a/tests/test_session_renew_helper.py
+++ b/tests/test_session_renew_helper.py
@@ -8,6 +8,8 @@ from src.auth import st, clear_session_clients, get_session_client
 stub_sessions = types.SimpleNamespace(
     refresh_or_rotate_session_token=lambda tok: tok,
     validate_session_token=lambda tok, ua_hash="": {"student_code": "abc"},
+    create_session_token=lambda *args, **kwargs: "tok",
+    destroy_session_token=lambda tok: None,
 )
 sys.modules["falowen.sessions"] = stub_sessions
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+import pytest
 import src.stats as stats
 
 
@@ -133,6 +134,17 @@ def test_load_student_levels_handles_failure(monkeypatch):
     assert warnings  # warning was emitted
     assert list(df.columns) == ["student_code", "level"]
     assert df.empty
+
+
+def test_load_student_levels_raises_when_columns_missing(monkeypatch):
+    df = stats.pd.DataFrame({"wrong": []})
+    monkeypatch.setattr(stats.pd, "read_csv", lambda url: df)
+    errors = []
+    monkeypatch.setattr(stats.st, "error", lambda msg: errors.append(msg))
+    stats.load_student_levels.clear()
+    with pytest.raises(ValueError):
+        stats.load_student_levels()
+    assert errors
 
 def test_get_student_level_returns_none_when_missing(monkeypatch):
     df = stats.pd.DataFrame({"student_code": ["x"], "level": ["B1"]})


### PR DESCRIPTION
## Summary
- Avoid defaulting to demo student code in course notes and vocab trainer, requiring a real student code before saving or loading
- Raise errors when roster sheets are missing required columns
- Test student-code validation and roster error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74ad5db10832185756caf51c423c4