### PR TITLE
Normalize class column to ClassName in student roster

### DIFF
--- a/src/data_loading.py
+++ b/src/data_loading.py
@@ -68,6 +68,19 @@ def _load_student_data_cached() -> Optional[pd.DataFrame]:
         raise
 
     df.columns = df.columns.str.strip().str.replace(" ", "")
+
+    # Normalize common variants of the class name column so downstream
+    # components can reliably access ``ClassName`` regardless of how the
+    # roster labels it.  Some spreadsheets use ``Class`` or a lowercase
+    # ``classname``; unify these to ``ClassName``.
+    lower_cols = {c.lower(): c for c in df.columns}
+    if "classname" in lower_cols and lower_cols["classname"] != "ClassName":
+        df.rename(columns={lower_cols["classname"]: "ClassName"}, inplace=True)
+    elif "class" in lower_cols and "classname" not in lower_cols:
+        df.rename(columns={lower_cols["class"]: "ClassName"}, inplace=True)
+    elif "classroom" in lower_cols and "classname" not in lower_cols:
+        df.rename(columns={lower_cols["classroom"]: "ClassName"}, inplace=True)
+
     for col in df.columns:
         s = df[col]
         df[col] = s.where(s.isna(), s.astype(str).str.strip())

--- a/tests/test_load_student_classname.py
+++ b/tests/test_load_student_classname.py
@@ -1,0 +1,21 @@
+import types
+
+from src import data_loading
+
+
+def _make_response(text: str):
+    return types.SimpleNamespace(text=text, raise_for_status=lambda: None)
+
+
+def test_class_column_renamed(monkeypatch):
+    csv = "StudentCode,Class,ContractEnd\nsc1,Test Class,2025-01-01\n"
+
+    # ensure cache is clear so our patched request is used
+    data_loading._load_student_data_cached.clear()
+
+    monkeypatch.setattr(data_loading.requests, "get", lambda url, timeout=12: _make_response(csv))
+
+    df = data_loading.load_student_data()
+    assert df is not None
+    assert "ClassName" in df.columns
+    assert df.loc[0, "ClassName"] == "Test Class"


### PR DESCRIPTION
## Summary
- standardize class column names to `ClassName` when loading student roster
- add regression test ensuring class column is normalized

## Testing
- `ruff check .` *(fails: 148 errors)*
- `pytest -q` *(passes: 143 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c74fa39f488321a11064ff750af65f