### PR TITLE
Persist roster row and simplify course schedule loaders

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1200,27 +1200,28 @@ if tab == "Dashboard":
     inject_notice_css()
 
     # ---------- Ensure we have a student row ----------
-    load_student_data_fn = globals().get("load_student_data")
-    if load_student_data_fn is None:
-        def load_student_data_fn():
-            return pd.DataFrame(columns=["StudentCode"])
+    student_row = st.session_state.get("student_row", {}) or {}
+    if not student_row:
+        # Fallback: load roster CSV and locate the student by code.
+        load_student_data_fn = globals().get("load_student_data")
+        if load_student_data_fn is None:
+            def load_student_data_fn():
+                return pd.DataFrame(columns=["StudentCode"])
 
-    df_students = load_student_data_fn()
-    if df_students is None:
-        df_students = pd.DataFrame(columns=["StudentCode"])
-    student_code = (st.session_state.get("student_code", "") or "").strip().lower()
-
-    student_row = {}
-    if student_code and not df_students.empty and "StudentCode" in df_students.columns:
-        try:
-            matches = df_students[df_students["StudentCode"].astype(str).str.lower() == student_code]
-            if not matches.empty:
-                student_row = matches.iloc[0].to_dict()
-        except Exception:
-            pass
-
-    if (not student_row) and isinstance(st.session_state.get("student_row"), dict) and st.session_state["student_row"]:
-        student_row = st.session_state["student_row"]
+        df_students = load_student_data_fn()
+        if df_students is None:
+            df_students = pd.DataFrame(columns=["StudentCode"])
+        student_code = (st.session_state.get("student_code", "") or "").strip().lower()
+        if student_code and not df_students.empty and "StudentCode" in df_students.columns:
+            try:
+                matches = df_students[
+                    df_students["StudentCode"].astype(str).str.lower() == student_code
+                ]
+                if not matches.empty:
+                    student_row = matches.iloc[0].to_dict()
+                    st.session_state["student_row"] = student_row
+            except Exception:
+                pass
 
     st.markdown("<div style='height:6px'></div>", unsafe_allow_html=True)
 

--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -1,5 +1,11 @@
 """Firestore-related helper functions for the a1spreche app.
 
+Roster data is sourced from the CSV roster during login and is stored in
+``st.session_state['student_row']``.  The helpers in this module only deal
+with dynamic data such as submissions, drafts, attendance records or chat
+profiles and never query Firestore for static roster metadata like class names
+or levels.
+
 This module centralises Firestore draft and chat helpers so they can be
 re-used outside the monolithic :mod:`a1sprechen` module.
 """


### PR DESCRIPTION
## Summary
- Persist full roster row in `st.session_state['student_row']` during login and Google OAuth
- Coursebook/calendar logic now reads class and level from the persisted roster row
- Clarify Firestore helpers only handle dynamic student data, not roster metadata

## Testing
- `ruff check src/ui/auth.py src/firestore_utils.py`
- `ruff check a1sprechen.py` *(fails: E402 etc.)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c75702955883219dcd5976a3ee8c34