### PR TITLE
Hide built-in Streamlit sidebar navigation

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -67,6 +67,16 @@ html, body { overscroll-behavior-y: none; }
 </style>
 """, unsafe_allow_html=True)
 
+st.markdown(
+    """
+    <style>
+        div[data-testid="stSidebarNav"] {display: none;}
+        div[data-testid="stSidebarHeader"] {display: none;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 
 # Ensure the latest lesson schedule is loaded
 if "level_schedules_initialized" not in st.session_state:


### PR DESCRIPTION
## Summary
- Inject CSS after global styles to remove Streamlit's default sidebar navigation/header

## Testing
- `ruff check a1sprechen.py` *(fails: E402 Module level import not at top of file, etc.)*
- `pytest -q`
- `streamlit run a1sprechen.py --server.headless true`


------
https://chatgpt.com/codex/tasks/task_e_68c7b5305e288321abef0cbd911344fb