### PR TITLE
Normalize roster ClassName variants and validate

### DIFF
--- a/tests/data/roster_base.csv
+++ b/tests/data/roster_base.csv
@@ -1,0 +1,2 @@
+StudentCode,ClassName,ContractEnd
+sc1,Test Class,2025-01-01

--- a/tests/test_load_student_classname.py
+++ b/tests/test_load_student_classname.py
@@ -1,5 +1,7 @@
 import types
+from pathlib import Path
 
+import pytest
 from src import data_loading
 
 
@@ -7,15 +9,46 @@ def _make_response(text: str):
     return types.SimpleNamespace(text=text, raise_for_status=lambda: None)
 
 
-def test_class_column_renamed(monkeypatch):
-    csv = "StudentCode,Class,ContractEnd\nsc1,Test Class,2025-01-01\n"
+BASE_ROSTER = Path(__file__).with_name("data").joinpath("roster_base.csv")
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "Class",
+        "classname",
+        "Classroom",
+        "class_name",
+        "Group",
+        "Course",
+    ],
+)
+def test_class_column_variants(monkeypatch, label):
+    csv = BASE_ROSTER.read_text().replace("ClassName", label)
 
     # ensure cache is clear so our patched request is used
     data_loading._load_student_data_cached.clear()
 
-    monkeypatch.setattr(data_loading.requests, "get", lambda url, timeout=12: _make_response(csv))
+    monkeypatch.setattr(
+        data_loading.requests,
+        "get",
+        lambda url, timeout=12: _make_response(csv),
+    )
 
     df = data_loading.load_student_data()
     assert df is not None
     assert "ClassName" in df.columns
     assert df.loc[0, "ClassName"] == "Test Class"
+
+
+def test_missing_class_column_raises(monkeypatch):
+    csv = BASE_ROSTER.read_text().replace("ClassName", "Room")
+    data_loading._load_student_data_cached.clear()
+    monkeypatch.setattr(
+        data_loading.requests,
+        "get",
+        lambda url, timeout=12: _make_response(csv),
+    )
+    with pytest.raises(ValueError) as exc:
+        data_loading.load_student_data()
+    assert "Supported column names" in str(exc.value)


### PR DESCRIPTION
## Summary
- expand class name column normalization to support more aliases and raise a clear error if missing
- add roster dataset and tests to ensure different column labels map to ClassName

## Testing
- `ruff check src/data_loading.py tests/test_load_student_classname.py`
- `pytest tests/test_load_student_classname.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7b8e9af7c8321b361ad7e6bbb79c5