### PR TITLE
Guard sidebar hiding until login

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -75,15 +75,19 @@ html, body { overscroll-behavior-y: none; }
 </style>
 """, unsafe_allow_html=True)
 
-st.markdown(
-    """
-    <style>
-        div[data-testid="stSidebarNav"] {display: none;}
-        div[data-testid="stSidebarHeader"] {display: none;}
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
+
+def hide_sidebar() -> None:
+    """Hide Streamlit's sidebar for pages where it isn't needed."""
+    st.markdown(
+        """
+        <style>
+            div[data-testid="stSidebarNav"] {display: none;}
+            div[data-testid="stSidebarHeader"] {display: none;}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
 
 
 # Ensure the latest lesson schedule is loaded
@@ -314,6 +318,10 @@ def login_page():
         except Exception:
             pass
         return
+
+    hide_fn = globals().get("hide_sidebar")
+    if callable(hide_fn):
+        hide_fn()
 
     try:
         renew_session_if_needed()


### PR DESCRIPTION
## Summary
- Move sidebar hiding CSS into new `hide_sidebar()` helper
- Call `hide_sidebar()` only on the login page to avoid hiding the sidebar post-login

## Testing
- `ruff check a1sprechen.py` *(fails: E402 Module level import not at top of file, F401 `resolve_current_content` imported but unused, plus other pre-existing errors)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7bf69004c8321a873f388348adf6a