### PR TITLE
Hide sidebar on dashboard landing page

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -8,9 +8,10 @@ st.set_page_config(
 )
 
 from src.styles import inject_global_styles
-from a1sprechen import hide_streamlit_header, dashboard_page
+from a1sprechen import hide_streamlit_header, hide_sidebar, dashboard_page
 
 hide_streamlit_header()
+hide_sidebar()
 inject_global_styles()
 st.markdown(
     """


### PR DESCRIPTION
## Summary
- Import `hide_sidebar` and call it after `hide_streamlit_header` on dashboard landing page to hide Streamlit's sidebar only on the landing page.

## Testing
- `pytest tests/test_entrypoint_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7d2acdd0c8321b5877107d48cb1a3