### PR TITLE
Remove sidebar hiding logic

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -69,25 +69,14 @@ st.set_page_config(
 # Load global CSS classes and variables
 inject_global_styles()
 
-st.markdown("""
+st.markdown(
+    """
 <style>
 html, body { overscroll-behavior-y: none; }
 </style>
-""", unsafe_allow_html=True)
-
-
-def hide_sidebar() -> None:
-    """Hide Streamlit's sidebar for pages where it isn't needed."""
-    st.markdown(
-        """
-        <style>
-            div[data-testid="stSidebarNav"] {display: none;}
-            div[data-testid="stSidebarHeader"] {display: none;}
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
-
+""",
+    unsafe_allow_html=True,
+)
 
 
 # Ensure the latest lesson schedule is loaded
@@ -318,10 +307,6 @@ def login_page():
         except Exception:
             pass
         return
-
-    hide_fn = globals().get("hide_sidebar")
-    if callable(hide_fn):
-        hide_fn()
 
     try:
         renew_session_if_needed()

--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -8,10 +8,9 @@ st.set_page_config(
 )
 
 from src.styles import inject_global_styles
-from a1sprechen import hide_streamlit_header, hide_sidebar, dashboard_page
+from a1sprechen import hide_streamlit_header, dashboard_page
 
 hide_streamlit_header()
-hide_sidebar()
 inject_global_styles()
 st.markdown(
     """


### PR DESCRIPTION
## Summary
- drop hide_sidebar utility and associated CSS
- stop calling hide_sidebar during login flow and dashboard startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7d9ed3f048321a2d8b9995c03555f