### PR TITLE
Show chapter numbers in learning-note lesson dropdown

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4653,7 +4653,7 @@ if tab == "My Course":
                     day = item.get("day")
                     topic = item.get("topic")
                     if day is not None and topic:
-                        lesson_choices.append(f"Day {day}: {topic}")
+                        lesson_choices.append(_schedule.full_lesson_title(item))
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- Use `schedule.full_lesson_title` when building learning-note lesson choices so dropdown includes chapter numbers

## Testing
- `pytest -q`
- Confirmed sample lesson choices show chapters via `schedule.full_lesson_title`


------
https://chatgpt.com/codex/tasks/task_e_68c803937c608321894079263d98595a