### PR TITLE
Handle single-section chapter headings in render_section_any

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2349,7 +2349,11 @@ if tab == "My Course":
                     extras = part.get('extra_resources')
 
                     if len(items) > 1:
-                        st.markdown(f"###### {icon} Part {idx_part+1} of {len(items)}: Chapter {chapter}")
+                        st.markdown(
+                            f"###### {icon} Part {idx_part+1} of {len(items)}: Chapter {chapter}"
+                        )
+                    else:
+                        st.markdown(f"###### {icon} Chapter {chapter}")
                     # videos (embed once)
                     for maybe_vid in [video, youtube_link]:
                         if _is_url(maybe_vid):

--- a/tests/test_render_section_any.py
+++ b/tests/test_render_section_any.py
@@ -58,7 +58,7 @@ def test_single_dict():
     render_section_any, st = _load_render_section_any()
     day_info = {"lesen": {"chapter": "1"}}
     render_section_any(day_info, "lesen", "Lesen", "📖", set())
-    assert st.markdowns == ["#### 📖 Lesen"]
+    assert st.markdowns == ["#### 📖 Lesen", "###### 📖 Chapter 1"]
 
 
 def test_list_of_dicts_with_invalid(caplog):


### PR DESCRIPTION
## Summary
- Display chapter subheading when a section has only one item
- Keep part numbering when multiple items exist
- Adjust tests to assert chapter heading output

## Testing
- `pytest tests/test_render_section_any.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80be3dac483219f1a4f52dec31749