### PR TITLE
feat: add context label to vocab lookup

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2367,7 +2367,10 @@ if tab == "My Course":
                     if workbook_link:
                         st.markdown(f"- [📒 Workbook (Assignment)]({workbook_link})")
                         with st.expander("📖 Dictionary"):
-                            render_vocab_lookup(f"{key}-{idx_part}")
+                            render_vocab_lookup(
+                                f"{key}-{idx_part}",
+                                f"Day {day_info.get('day')} Chapter {chapter}",
+                            )
                         render_assignment_reminder()
                     if extras:
                         for ex in _as_list(extras):
@@ -2396,7 +2399,10 @@ if tab == "My Course":
                 if info.get("workbook_link"):
                     st.markdown(f"- [📒 Workbook (Assignment)]({info['workbook_link']})")
                     with st.expander("📖 Dictionary"):
-                        render_vocab_lookup(f"fallback-{info.get('day', '')}")
+                        render_vocab_lookup(
+                            f"fallback-{info.get('day', '')}",
+                            f"Day {info.get('day')} Chapter {info.get('chapter', '')}",
+                        )
                     render_assignment_reminder()
                     showed = True
                 for ex in _as_list(info.get("extra_resources")):

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -142,16 +142,21 @@ def render_audio_player(source: Union[str, bytes], *, verified: bool = False) ->
     components.html(html, height=80)
 
 
-def render_vocab_lookup(key: str) -> None:
+def render_vocab_lookup(key: str, context_label: Optional[str] = None) -> None:
     """Render a small vocabulary lookup widget.
 
     Parameters
     ----------
     key:
         Unique key so Streamlit state doesn't clash across lessons.
+    context_label:
+        Optional label providing context (e.g. lesson info) for the lookup.
     """
 
-    st.markdown("#### 📖 Mini Dictionary")
+    header = "#### 📖 Mini Dictionary"
+    if context_label:
+        header += f" – {context_label}"
+    st.markdown(header)
     st.caption("Search words from this assignment")
 
     translate_caption = (

--- a/tests/test_render_vocab_lookup.py
+++ b/tests/test_render_vocab_lookup.py
@@ -1,0 +1,36 @@
+import src.ui_components as ui
+
+
+class ST:
+    def __init__(self):
+        self.markdowns = []
+        self.captions = []
+        self.infos = []
+
+    def markdown(self, text, **kwargs):  # pragma: no cover - trivial
+        self.markdowns.append(text)
+
+    def caption(self, text, **kwargs):  # pragma: no cover - trivial
+        self.captions.append(text)
+
+    def info(self, text, **kwargs):  # pragma: no cover - trivial
+        self.infos.append(text)
+
+
+def _setup(monkeypatch):
+    st = ST()
+    monkeypatch.setattr(ui, "st", st)
+    monkeypatch.setattr(ui, "_load_vocab_sheet", lambda *a, **k: None)
+    return st
+
+
+def test_vocab_lookup_context_label(monkeypatch):
+    st = _setup(monkeypatch)
+    ui.render_vocab_lookup("k", context_label="Day 1 Chapter 2")
+    assert st.markdowns[0] == "#### 📖 Mini Dictionary – Day 1 Chapter 2"
+
+
+def test_vocab_lookup_no_label(monkeypatch):
+    st = _setup(monkeypatch)
+    ui.render_vocab_lookup("k")
+    assert st.markdowns[0] == "#### 📖 Mini Dictionary"


### PR DESCRIPTION
## Summary
- allow `render_vocab_lookup` to display an optional context label in its header
- pass lesson context from `render_section_any`
- test dictionary label rendering and call integration

## Testing
- `ruff check a1sprechen.py src/ui_components.py tests/test_render_section_any.py tests/test_render_vocab_lookup.py`
- `pytest tests/test_render_section_any.py tests/test_render_vocab_lookup.py`

------
https://chatgpt.com/codex/tasks/task_e_68c80b830188832191e4d881676533b6