### PR TITLE
Show chapter info in learning note lessons

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4663,7 +4663,9 @@ if tab == "My Course":
                     day = item.get("day")
                     topic = item.get("topic")
                     if day is not None and topic:
-                        lesson_choices.append(f"Day {day}: {topic}")
+                        lesson_choices.append(
+                            f"Day {day} - {topic} (Chapter {item.get('chapter', '?')})"
+                        )
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- Display chapter number alongside day and topic in Learning Notes lesson selector.

## Testing
- `pytest tests/test_schedule_module.py::test_day6_coursebook_entry -q`
- `pytest tests/test_draft_management.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80e70b69c8321afe7f38a4d82b46f