### PR TITLE
Show chapters in lesson select

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4094,7 +4094,7 @@ if tab == "My Course":
                     day = item.get("day")
                     topic = item.get("topic")
                     if day is not None and topic:
-                        lesson_choices.append(f"Day {day}: {topic}")
+                        lesson_choices.append(_schedule.full_lesson_title(item))
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- show full lesson titles including chapter in "Add a new post" selection

## Testing
- `pytest` *(fails: KeyboardInterrupt after 156 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c80e533f2883219e1977321aeabb31