### PR TITLE
Normalize student code comparisons

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1208,7 +1208,8 @@ if tab == "Dashboard":
         if student_code and not df_students.empty and "StudentCode" in df_students.columns:
             try:
                 matches = df_students[
-                    df_students["StudentCode"].astype(str).str.lower() == student_code
+                    df_students["StudentCode"].astype(str).str.strip().str.lower()
+                    == student_code
                 ]
                 if not matches.empty:
                     student_row = matches.iloc[0].to_dict()
@@ -1258,7 +1259,9 @@ if tab == "Dashboard":
     _df_level = _df_level[_df_level['completed'] >= _min_assignments]
     _df_level = _df_level.sort_values(['total_score', 'completed'], ascending=[False, False]).reset_index(drop=True)
     _df_level['Rank'] = _df_level.index + 1
-    _your_row = _df_level[_df_level['studentcode'].str.lower() == _student_code.lower()]
+    _your_row = _df_level[
+        _df_level['studentcode'].astype(str).str.strip().str.lower() == _student_code
+    ]
     _total_students = len(_df_level)
 
     _streak_line = (

--- a/src/services/contracts.py
+++ b/src/services/contracts.py
@@ -20,7 +20,12 @@ def contract_active(student_code: str, roster: Optional[pd.DataFrame]) -> bool:
     """
     if roster is None or "StudentCode" not in roster.columns:
         return True
-    match = roster[roster["StudentCode"].str.lower() == student_code.lower()]
+
+    normalized_code = str(student_code or "").strip().lower()
+    roster_codes = (
+        roster["StudentCode"].astype(str).str.strip().str.lower()
+    )
+    match = roster[roster_codes == normalized_code]
     if match.empty:
         return True
     row = match.iloc[0]

--- a/tests/test_contract_active.py
+++ b/tests/test_contract_active.py
@@ -12,6 +12,18 @@ def test_contract_inactive_when_expired():
     assert contract_active("abc", df) is False
 
 
+def test_contract_lookup_ignores_case_and_whitespace():
+    df = pd.DataFrame(
+        [
+            {
+                "StudentCode": " AbC ",
+                "ContractEnd": "2020-01-01",
+            }
+        ]
+    )
+    assert contract_active("abc", df) is False
+
+
 def test_contract_inactive_when_balance_over_30_days():
     start = (pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=40)).strftime("%Y-%m-%d")
     end = (pd.Timestamp.now(tz="UTC") + pd.Timedelta(days=20)).strftime("%Y-%m-%d")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -153,6 +153,13 @@ def test_get_student_level_returns_none_when_missing(monkeypatch):
     assert level is None
 
 
+def test_get_student_level_matches_mixed_case(monkeypatch):
+    df = stats.pd.DataFrame({"student_code": [" AbC "], "level": [" b1 "]})
+    monkeypatch.setattr(stats, "load_student_levels", lambda: df)
+    level = stats.get_student_level("aBc", default=None)
+    assert level == "B1"
+
+
 def test_get_student_level_handles_load_failure(monkeypatch):
     def boom():
         raise OSError("fail")


### PR DESCRIPTION
## Summary
- normalize student code lookups so both roster values and inputs are compared using lower-case stripped strings
- ensure cached dashboard leaderboard comparisons normalize student codes before matching
- add regression coverage for mixed-case student code matches in contract and level lookups

## Testing
- pytest tests/test_contract_active.py
- pytest tests/test_stats.py::test_get_student_level_matches_mixed_case

------
https://chatgpt.com/codex/tasks/task_e_68c866e039108321828b38f4f94875b5