### PR TITLE
Add debug logging around roster lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,30 @@ The dashboard displays new posts pulled from a JSON feed at
 `src/blog_feed.py` downloads the feed, caches the result for an hour, and
 returns a list of dictionaries containing the post title, description, and
 link.
+
+## Debug Logging
+
+Enable debug logging when you need deeper insight into roster lookups or
+authentication flows:
+
+1. Run Streamlit with debug logging locally:
+
+   ```bash
+   streamlit run a1sprechen.py --logger.level=debug
+   ```
+
+2. Alternatively, set the configuration in a `.streamlit/config.toml` file or
+   via environment variable for deployed environments:
+
+   ```toml
+   # .streamlit/config.toml
+   [logger]
+   level = "debug"
+   ```
+
+   ```bash
+   export STREAMLIT_LOG_LEVEL=debug
+   ```
+
+The debug logs include the student code used for roster lookups, the number of
+rows returned from the roster, and whether a matching row was found.

--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1198,24 +1198,58 @@ if tab == "Dashboard":
         # Fallback: load roster CSV and locate the student by code.
         load_student_data_fn = globals().get("load_student_data")
         if load_student_data_fn is None:
+
             def load_student_data_fn():
                 return pd.DataFrame(columns=["StudentCode"])
 
+        student_code = (st.session_state.get("student_code", "") or "").strip().lower()
+        logging.debug("Attempting roster lookup for student code '%s'", student_code)
         df_students = load_student_data_fn()
         if df_students is None:
+            logging.debug(
+                "Roster fetch returned no data while looking for student code '%s'",
+                student_code,
+            )
             df_students = pd.DataFrame(columns=["StudentCode"])
-        student_code = (st.session_state.get("student_code", "") or "").strip().lower()
-        if student_code and not df_students.empty and "StudentCode" in df_students.columns:
+        else:
+            try:
+                row_count = len(df_students)
+            except Exception:
+                row_count = 0
+            logging.debug(
+                "Roster fetch returned %d rows while looking for student code '%s'",
+                row_count,
+                student_code,
+            )
+        if not student_code:
+            logging.debug("No student code available in session for roster lookup")
+        elif not df_students.empty and "StudentCode" in df_students.columns:
             try:
                 matches = df_students[
                     df_students["StudentCode"].astype(str).str.strip().str.lower()
                     == student_code
                 ]
-                if not matches.empty:
+                match_count = int(matches.shape[0])
+                logging.debug(
+                    "Roster lookup for student code '%s' found=%s (matches=%d)",
+                    student_code,
+                    match_count > 0,
+                    match_count,
+                )
+                if match_count > 0:
                     student_row = matches.iloc[0].to_dict()
                     st.session_state["student_row"] = student_row
-            except Exception:
-                pass
+            except Exception as exc:
+                logging.debug(
+                    "Roster lookup failed for student code '%s': %s",
+                    student_code,
+                    exc,
+                )
+        else:
+            logging.debug(
+                "Roster lookup for student code '%s' skipped because roster is empty or missing StudentCode column",
+                student_code,
+            )
 
     st.markdown("<div style='height:6px'></div>", unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary
- add debug logging in `a1sprechen.py` so roster fallbacks report the student code, row counts, and match results
- log roster fetch details during signup and login flows while remaining safe for AST-based tests
- document how to enable Streamlit debug logging for troubleshooting

## Testing
- pytest tests/test_login_outstanding_balance.py
- pytest tests/test_auth_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68c869ce9848832182152d9ec5f3390a