### PR TITLE
Use timezone-aware datetime.now for UTC timestamps

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -465,10 +465,10 @@ def login_page():
     </div>
     """, unsafe_allow_html=True)
 
-    from datetime import datetime as _dt_now
+    from datetime import UTC, datetime as _dt_now
     st.markdown(f"""
     <div class="page-wrap" style="text-align:center;color:#64748b; margin-bottom:16px;">
-      © {_dt_now.utcnow().year} Learn Language Education Academy • Accra, Ghana<br>
+      © {_dt_now.now(UTC).year} Learn Language Education Academy • Accra, Ghana<br>
       Need help? <a href="mailto:learngermanghana@gmail.com">Email</a> •
       <a href="https://api.whatsapp.com/send?phone=233205706589" target="_blank" rel="noopener">WhatsApp</a>
     </div>
@@ -4220,7 +4220,7 @@ if tab == "My Course":
                         "content": formatted_q,
                         "asked_by_name": student_name,
                         "asked_by_code": student_code,
-                        "timestamp": _dt.utcnow(),
+                        "timestamp": _dt.now(UTC),
                         "lesson": lesson,
                         "topic": (topic or "").strip(),
                         "link": (link or "").strip(),
@@ -4232,7 +4232,7 @@ if tab == "My Course":
                     _notify_slack(
                         f"📝 *New Class Board post* — {class_name}{topic_tag}\n",
                         f"*From:* {student_name} ({student_code})\n",
-                        f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC\n",
+                        f"*When:* {_dt.now(UTC).strftime('%Y-%m-%d %H:%M')} UTC\n",
                         f"*Content:* {preview}"
                     )
                     st.session_state["__clear_q_form"] = True
@@ -4393,7 +4393,7 @@ if tab == "My Course":
                                 _notify_slack(
                                     f"🗑️ *Class Board post deleted* — {class_name}\n"
                                     f"*By:* {student_name} ({student_code}) • QID: {q_id}\n"
-                                    f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC"
+                                    f"*When:* {_dt.now(UTC).strftime('%Y-%m-%d %H:%M')} UTC"
                                 )
                                 st.success("Post deleted.")
                                 refresh_with_toast()
@@ -4453,7 +4453,7 @@ if tab == "My Course":
                                     _notify_slack(
                                         f"✏️ *Class Board post edited* — {class_name}\n",
                                         f"*By:* {student_name} ({student_code}) • QID: {q_id}\n",
-                                        f"*When:* {_dt.utcnow().strftime('%Y-%m-%d %H:%M')} UTC\n",
+                                        f"*When:* {_dt.now(UTC).strftime('%Y-%m-%d %H:%M')} UTC\n",
                                         f"*New:* {(formatted_edit[:180] + '…') if len(formatted_edit) > 180 else formatted_edit}",
                                     )
                                     st.session_state[f"q_editing_{q_id}"] = False

--- a/auth.py
+++ b/auth.py
@@ -1,5 +1,5 @@
 # auth.py
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from flask import Blueprint, request, jsonify, make_response
 import os
 import jwt
@@ -85,7 +85,7 @@ def _delete_refresh(conn: sqlite3.Connection, user_id: str) -> None:
 
 
 def _issue_access(user_id: str) -> str:
-    payload = {"sub": user_id, "exp": datetime.utcnow() + timedelta(seconds=ACCESS_TTL)}
+    payload = {"sub": user_id, "exp": datetime.now(UTC) + timedelta(seconds=ACCESS_TTL)}
     return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALG)
 
 
@@ -93,8 +93,8 @@ def _issue_refresh(user_id: str) -> str:
     payload = {
         "sub": user_id,
         "type": "refresh",
-        "exp": datetime.utcnow() + timedelta(seconds=MAX_AGE),
-        "iat": datetime.utcnow(),
+        "exp": datetime.now(UTC) + timedelta(seconds=MAX_AGE),
+        "iat": datetime.now(UTC),
         "jti": uuid.uuid4().hex,
     }
     token = jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALG)

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
@@ -57,7 +57,7 @@ def last_modified(path: str) -> str:
         return result.split("T")[0]
     except subprocess.CalledProcessError:
         # Fallback to current date if file is not tracked.
-        return datetime.utcnow().date().isoformat()
+        return datetime.now(UTC).date().isoformat()
 
 
 def generate_sitemap(destination: Path) -> None:


### PR DESCRIPTION
## Summary
- replace the remaining uses of `utcnow()` with `datetime.now(UTC)` in the sitemap generator and authentication helpers so tokens and fallbacks remain timezone-aware
- adjust the login footer and class board updates to rely on timezone-aware timestamps while preserving ISO 8601 formatting

## Testing
- pytest tests/test_login_page_blog_announcements.py
- ruff check *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c898bc711083219d1a861a7c0334a9