### PR TITLE
Use FieldFilter for Firestore where queries

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2207,7 +2207,10 @@ if tab == "My Course":
                 .collection("posts")
             )
             post_count = sum(
-                1 for _ in board_base.where("chapter", "==", chapter).stream()
+                1
+                for _ in board_base.where(
+                    filter=FieldFilter("chapter", "==", chapter)
+                ).stream()
             )
             link_key = CLASS_DISCUSSION_LINK_TMPL.format(chapter=chapter)
             count_txt = f" ({post_count})" if post_count else ""

--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -14,6 +14,7 @@ import html  # noqa: F401
 
 import bcrypt
 import streamlit as st
+from google.cloud.firestore_v1 import FieldFilter
 from falowen.email_utils import send_reset_email, build_gas_reset_link
 from falowen.sessions import create_session_token, destroy_session_token
 from src.auth import persist_session_client
@@ -310,9 +311,13 @@ def render_forgot_password_panel() -> None:
                     return db
 
             db = get_db()
-            user_query = db.collection("students").where("email", "==", e).get()
+            user_query = db.collection("students").where(
+                filter=FieldFilter("email", "==", e)
+            ).get()
             if not user_query:
-                user_query = db.collection("students").where("Email", "==", e).get()
+                user_query = db.collection("students").where(
+                    filter=FieldFilter("Email", "==", e)
+                ).get()
             if not user_query:
                 st.error("No account found with that email.")
             else:


### PR DESCRIPTION
## Summary
- replace the class discussion post count Firestore query with the FieldFilter-based form to silence positional where warnings
- update the forgot password email lookup to use FieldFilter and import the helper

## Testing
- pytest tests/test_forgot_password_link.py tests/test_class_discussion_link.py

------
https://chatgpt.com/codex/tasks/task_e_68c89ed61bfc8321818162e9a5b911a8