### PR TITLE
Secure auth credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,35 @@
 
 ## Deployment
 The app uses `streamlit-cookies-controller` to persist session and student-code
-cookies. The controller transparently handles encryption and browser synchronisation,
-so no cookie password or additional environment configuration is required. Simply
-deploy the app and the controller will manage cookies automatically.
+cookies. The controller transparently handles encryption and browser
+synchronisation.
+
+### Authentication configuration
+
+- Set the `JWT_SECRET` environment variable. A fallback development value is
+  used when running locally, but deploying with the default secret raises a
+  runtime error. Pick a long, random string for production.
+- Provide user login credentials via one of the following environment
+  variables:
+  - `AUTH_USER_CREDENTIALS`: JSON mapping of login identifiers to hashed
+    passwords.
+  - `AUTH_USER_CREDENTIALS_FILE`: Path to a JSON file with the same structure.
+
+  Hash passwords before storing them. The Flask helper can generate suitable
+  hashes:
+
+  ```bash
+  python - <<'PY'
+  from werkzeug.security import generate_password_hash
+  print(generate_password_hash("super-secret-password"))
+  PY
+  ```
+
+  Store the resulting string in the JSON payload, for example:
+
+  ```json
+  {"admin@example.com": "pbkdf2:sha256:600000$..."}
+  ```
 
 ### Refresh token storage
 

--- a/auth.py
+++ b/auth.py
@@ -1,11 +1,14 @@
 # auth.py
 from datetime import UTC, datetime, timedelta
 from flask import Blueprint, request, jsonify, make_response
+import json
 import os
 import jwt
 import uuid
 import sqlite3
 from pathlib import Path
+
+from werkzeug.security import check_password_hash
 
 auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
 
@@ -34,12 +37,97 @@ def _set_cookie(resp, token: str):
     return resp
 
 # --- JWT helpers and refresh-token persistence ---
-JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret")
+_DEFAULT_JWT_SECRET = "dev-secret"
+_PRODUCTION_VALUES = {"prod", "production", "live"}
+_ENV_NAMES = ("AUTH_ENV", "APP_ENV", "ENV", "FLASK_ENV", "PYTHON_ENV", "STREAMLIT_ENV")
+
+
+def _is_production_env() -> bool:
+    for name in _ENV_NAMES:
+        value = os.getenv(name)
+        if value and value.strip().lower() in _PRODUCTION_VALUES:
+            return True
+    return os.getenv("AUTH_FORCE_PRODUCTION", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _load_jwt_secret() -> str:
+    secret = os.getenv("JWT_SECRET")
+    if secret:
+        if secret == _DEFAULT_JWT_SECRET and _is_production_env():
+            raise RuntimeError("JWT_SECRET must not use the default value in production.")
+        return secret
+
+    if _is_production_env():
+        raise RuntimeError("JWT_SECRET environment variable is required in production.")
+
+    return _DEFAULT_JWT_SECRET
+
+
+JWT_SECRET = _load_jwt_secret()
 JWT_ALG = "HS256"
 ACCESS_TTL = 3600
 
-# Demo credentials (in lieu of a real user database)
-USER_PASSWORDS = {"u": "pw"}
+_CREDENTIALS_ENV = "AUTH_USER_CREDENTIALS"
+_CREDENTIALS_FILE_ENV = "AUTH_USER_CREDENTIALS_FILE"
+
+
+def _load_user_credentials() -> dict[str, str]:
+    raw = os.getenv(_CREDENTIALS_ENV)
+    creds_path = os.getenv(_CREDENTIALS_FILE_ENV)
+
+    if raw and creds_path:
+        raise RuntimeError(
+            "Specify only one of AUTH_USER_CREDENTIALS or AUTH_USER_CREDENTIALS_FILE."
+        )
+
+    if creds_path:
+        try:
+            raw = Path(creds_path).read_text(encoding="utf-8")
+        except OSError as exc:  # pragma: no cover - defensive guard for deployment issues
+            raise RuntimeError(f"Unable to read credentials file: {creds_path}") from exc
+
+    if not raw:
+        return {}
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "AUTH_USER_CREDENTIALS must be valid JSON mapping usernames to password hashes."
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError(
+            "AUTH_USER_CREDENTIALS must be a JSON object mapping usernames to password hashes."
+        )
+
+    credentials: dict[str, str] = {}
+    for key, value in parsed.items():
+        if value is None:
+            continue
+        value_str = str(value).strip()
+        if not value_str:
+            raise RuntimeError(
+                "AUTH_USER_CREDENTIALS entries must contain non-empty password hashes."
+            )
+        credentials[str(key)] = value_str
+
+    return credentials
+
+
+USER_CREDENTIAL_HASHES = _load_user_credentials()
+
+
+def _verify_password(user_id: str, supplied_password: str) -> bool:
+    hashed = USER_CREDENTIAL_HASHES.get(user_id)
+    if not hashed:
+        hashed = USER_CREDENTIAL_HASHES.get(user_id.lower())
+    if not hashed:
+        return False
+    try:
+        return check_password_hash(hashed, supplied_password)
+    except (ValueError, TypeError):
+        return False
 
 # SQLite-backed refresh token store
 _BASE_DIR = Path(__file__).resolve().parent
@@ -124,7 +212,7 @@ def login():
     data = request.get_json(silent=True) or {}
     user_id = data.get("user_id") or data.get("email")
     password = data.get("password") or data.get("pw")
-    if not user_id or user_id not in USER_PASSWORDS or USER_PASSWORDS[user_id] != password:
+    if not user_id or password is None or not _verify_password(user_id, password):
         return jsonify(error="invalid credentials"), 401
 
     access = _issue_access(user_id)

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -1,15 +1,28 @@
+import json
+import os
 from importlib import reload
 import sys
 from pathlib import Path
 
 import jwt
 from flask import Flask
+from werkzeug.security import generate_password_hash
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import auth
 
 
+TEST_SECRET = "test-secret"
+TEST_HASHES = {"u": generate_password_hash("pw")}
+
+
+def _configure_env() -> None:
+    os.environ["JWT_SECRET"] = TEST_SECRET
+    os.environ["AUTH_USER_CREDENTIALS"] = json.dumps(TEST_HASHES)
+
+
 def create_app():
+    _configure_env()
     reload(auth)
     app = Flask(__name__)
     app.register_blueprint(auth.auth_bp)

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -1,3 +1,5 @@
+import json
+import os
 from http.cookies import SimpleCookie
 from email.utils import parsedate_to_datetime
 import time
@@ -6,12 +8,23 @@ from flask import Flask
 from importlib import reload
 import sys
 from pathlib import Path
+from werkzeug.security import generate_password_hash
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import auth
 
 
+TEST_SECRET = "test-secret"
+TEST_HASHES = {"u": generate_password_hash("pw")}
+
+
+def _configure_env() -> None:
+    os.environ["JWT_SECRET"] = TEST_SECRET
+    os.environ["AUTH_USER_CREDENTIALS"] = json.dumps(TEST_HASHES)
+
+
 def create_app():
+    _configure_env()
     reload(auth)
     app = Flask(__name__)
     app.register_blueprint(auth.auth_bp)


### PR DESCRIPTION
## Summary
- load JWT signing secret from the environment and fail fast if the default value is used in production
- pull login credentials from JSON provided through environment variables and validate passwords against stored hashes
- document the new authentication configuration requirements for deployments and update auth tests to configure hashed credentials

## Testing
- `pytest tests/test_auth_flow.py tests/test_auth_refresh.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8a24c82548321b2511237414c27a2