### PR TITLE
Open QnA lesson links in same tab

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4345,7 +4345,7 @@ if tab == "My Course":
                         course_link = build_course_day_link(day)
                         lesson_html = (
                             f"<div style='font-size:1.1rem;font-weight:600;color:#0f172a;'>📘 {lesson} – "
-                            f"<a href='{course_link}' target='_blank'>View page</a></div>"
+                            f"<a href='{course_link}'>View page</a></div>"
                         )
                     else:
                         lesson_html = ""

--- a/tests/test_qna_lesson_link_target.py
+++ b/tests/test_qna_lesson_link_target.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_qna_lesson_link_opens_in_same_tab():
+    src = Path("a1sprechen.py").read_text(encoding="utf-8")
+    assert "<a href='{course_link}'>View page</a></div>" in src
+    assert "target='_blank'>View page</a>" not in src


### PR DESCRIPTION
## Summary
- remove the `target="_blank"` attribute from the class board lesson link so it opens in the current tab
- add a regression test that ensures the rendered lesson link no longer includes the `_blank` target

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9333c8d00832185492c0c0ffe7332