### PR TITLE
Shorten announcement snippet truncation limit

### DIFF
--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -193,7 +193,7 @@ def render_announcements(announcements: list) -> None:
         if (c.body){
           const tmp=document.createElement('div'); tmp.innerHTML=c.body;
           let text=(tmp.textContent||'').trim();
-          if (text.length>120){ text=text.slice(0,120).trimEnd()+'…'; }
+          if (text.length>80){ text=text.slice(0,80).trimEnd()+'…'; }
           bodyEl.textContent=text; bodyEl.style.display='';
         } else { bodyEl.textContent=''; bodyEl.style.display='none'; }
         if (c.tag){ tagEl.textContent = c.tag; tagEl.style.display=''; } else { tagEl.style.display='none'; }


### PR DESCRIPTION
## Summary
- reduce the announcement body truncation limit from 120 to 80 characters to display a shorter preview without affecting the link element

## Testing
- pytest tests/test_ui_widgets_announcements.py

------
https://chatgpt.com/codex/tasks/task_e_68c95441b1948321bd9807390a403a65