### PR TITLE
Switch downloads selector to radio buttons

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -594,8 +594,10 @@ def render_results_and_resources_tab() -> None:
     if not isinstance(student_row, dict):
         student_row = {}
 
-    choice = st.selectbox(
-        "Select a download", ["Results PDF", "Enrollment Letter", "Receipt", "Attendance PDF"]
+    choice = st.radio(
+        "Select a download",
+        ["Results PDF", "Enrollment Letter", "Receipt", "Attendance PDF"],
+        horizontal=True,
     )
 
     def _read_money(x):

--- a/tests/test_attendance_pdf_unicode.py
+++ b/tests/test_attendance_pdf_unicode.py
@@ -57,7 +57,7 @@ def test_attendance_pdf_truncates_long_session_names(monkeypatch):
         lambda code, class_name: (records, [], 0),
     )
     monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
-    monkeypatch.setattr(st, "selectbox", lambda *a, **k: "Attendance PDF")
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Attendance PDF")
     monkeypatch.setattr(st, "info", lambda *a, **k: None)
 
     captured_download: dict[str, object] = {}

--- a/tests/test_results_downloads_only.py
+++ b/tests/test_results_downloads_only.py
@@ -49,11 +49,18 @@ def test_downloads_option_rendered_when_no_scores(monkeypatch):
     calls = []
 
     def fake_radio(label, options, *args, **kwargs):
-        calls.append(options)
+        calls.append({"options": options, "kwargs": kwargs})
         return options[-1]
 
     monkeypatch.setattr(st, "radio", fake_radio)
 
     assignment_ui.render_results_and_resources_tab()
 
-    assert calls[0] == ["Downloads"]
+    expected_options = [
+        "Results PDF",
+        "Enrollment Letter",
+        "Receipt",
+        "Attendance PDF",
+    ]
+    assert calls[0]["options"] == expected_options
+    assert calls[0]["kwargs"].get("horizontal") is True


### PR DESCRIPTION
## Summary
- replace the downloads selectbox with a horizontal radio group so every option is visible at once
- adjust downloads-only and attendance tests to mock `st.radio` and verify the new layout parameters

## Testing
- pytest tests/test_results_downloads_only.py tests/test_attendance_pdf_unicode.py

------
https://chatgpt.com/codex/tasks/task_e_68c960e8aeb88321b3e9c900db5c4c2e