### PR TITLE
Handle top result fallback for ungraded assignments

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -841,6 +841,7 @@ def render_results_and_resources_tab() -> None:
     avg_score = 0.0
     best_score = 0.0
     df_display = pd.DataFrame(columns=["assignment", "score", "date"])
+    top_result: dict[str, object] | None = None
 
     if isinstance(df_user, pd.DataFrame) and not df_user.empty:
         assignment_series = _first_series(
@@ -910,6 +911,27 @@ def render_results_and_resources_tab() -> None:
         ).reset_index(drop=True)
 
         numeric_nonnull = numeric_series.dropna()
+        if not numeric_nonnull.empty:
+            try:
+                best_index = numeric_nonnull.idxmax()
+            except ValueError:
+                best_index = None
+            if best_index is not None and best_index in numeric_series.index:
+                assignment_value = _clean_text(assignment_display.get(best_index))
+                raw_value: object | None = None
+                if score_series is not None and best_index in score_series.index:
+                    raw_value = score_series.get(best_index)
+                    try:
+                        if pd.isna(raw_value):
+                            raw_value = None
+                    except Exception:
+                        pass
+                if raw_value is None:
+                    raw_value = numeric_series.get(best_index)
+                top_result = {
+                    "assignment": assignment_value,
+                    "raw": raw_value,
+                }
         completed = int(numeric_nonnull.count())
         if completed:
             avg_score = float(numeric_nonnull.mean())
@@ -1141,7 +1163,7 @@ def render_results_and_resources_tab() -> None:
                 f"Top performance: **{assignment_display}** — "
                 f"{score_label_fmt(top_result.get('raw'))}"
             )
-        elif total and completed:
+        elif total and not completed:
             st.markdown("---")
             st.info("Scores will appear once assignments have been graded.")
 

--- a/tests/test_results_tab_missing_scores.py
+++ b/tests/test_results_tab_missing_scores.py
@@ -1,0 +1,81 @@
+import types
+
+import pandas as pd
+import streamlit as st
+
+from src import assignment_ui
+
+
+class DummyTab:
+    def __init__(self, label: str):
+        self.label = label
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_results_tab_handles_missing_scores(monkeypatch):
+    """Ensure achievements fallback renders when no graded scores are present."""
+
+    st.session_state.clear()
+    st.session_state.update(
+        {
+            "student_code": "abc123",
+            "student_name": "Alice Example",
+            "student_level": "A1",
+            "student_row": {
+                "StudentCode": "abc123",
+                "Name": "Alice Example",
+                "Level": "A1",
+                "Email": "alice@example.com",
+            },
+        }
+    )
+
+    df_scores = pd.DataFrame(
+        {
+            "studentcode": ["abc123"],
+            "assignment": ["Assignment 1"],
+            "score": [""],
+            "date": ["2024-01-01"],
+            "level": ["A1"],
+        }
+    )
+
+    monkeypatch.setattr(assignment_ui, "fetch_scores", lambda *_a, **_k: df_scores)
+
+    monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
+    monkeypatch.setattr(st, "divider", lambda *a, **k: None)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
+    monkeypatch.setattr(st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Results PDF")
+    monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
+    monkeypatch.setattr(
+        st,
+        "stop",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("stop called")),
+    )
+    monkeypatch.setattr(st, "cache_data", types.SimpleNamespace(clear=lambda: None))
+    monkeypatch.setattr(st, "secrets", {})
+
+    info_messages: list[str] = []
+
+    def fake_info(message, *args, **kwargs):
+        info_messages.append(message)
+        return None
+
+    monkeypatch.setattr(st, "info", fake_info)
+
+    monkeypatch.setattr(
+        st, "tabs", lambda labels, *a, **k: [DummyTab(label) for label in labels]
+    )
+
+    assignment_ui.render_results_and_resources_tab()
+
+    assert "Scores will appear once assignments have been graded." in info_messages


### PR DESCRIPTION
## Summary
- compute a top_result record for the highest assignment score and carry it through the achievements tab
- default top_result to None and show the existing "Scores will appear" message when no assignments are graded
- add a regression test covering a dataset without scores to ensure the achievements fallback renders

## Testing
- pytest tests/test_results_tab_missing_scores.py

------
https://chatgpt.com/codex/tasks/task_e_68c9cc3c8a14832184c5e52851d15796