### PR TITLE
Expose feedback details and links in results tab

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -6,6 +6,7 @@ bundled DejaVu fonts are unavailable.
 """
 from __future__ import annotations
 
+import html
 import base64 as _b64
 import io
 import os
@@ -840,7 +841,10 @@ def render_results_and_resources_tab() -> None:
     completed = 0
     avg_score = 0.0
     best_score = 0.0
-    df_display = pd.DataFrame(columns=["assignment", "score", "date"])
+    top_result: dict[str, object] | None = None
+    df_display = pd.DataFrame(
+        columns=["assignment", "score", "date", "feedback", "answer_link"]
+    )
 
     if isinstance(df_user, pd.DataFrame) and not df_user.empty:
         assignment_series = _first_series(
@@ -867,6 +871,35 @@ def render_results_and_resources_tab() -> None:
                 "submitted_on",
                 "completed_on",
                 "timestamp",
+            ],
+        )
+        feedback_series = _first_series(
+            df_user,
+            [
+                "feedback",
+                "feedback_text",
+                "feedbackbody",
+                "feedback_body",
+                "comment",
+                "comments",
+                "notes",
+                "remarks",
+                "remark",
+            ],
+        )
+        answer_series = _first_series(
+            df_user,
+            [
+                "answer_link",
+                "answer",
+                "answers",
+                "assignment_link",
+                "attachment",
+                "attachments",
+                "resource",
+                "resource_link",
+                "resources",
+                "link",
             ],
         )
 
@@ -901,11 +934,21 @@ def render_results_and_resources_tab() -> None:
                 [""] * len(df_user), index=df_user.index, dtype=object
             )
 
+        def _series_to_text(series: pd.Series | None) -> pd.Series:
+            if series is None:
+                return pd.Series([""] * len(df_user), index=df_user.index, dtype=object)
+            return series.map(_clean_text)
+
+        feedback_display = _series_to_text(feedback_series)
+        answer_display = _series_to_text(answer_series)
+
         df_display = pd.DataFrame(
             {
                 "assignment": assignment_display.astype(str),
                 "score": score_display.astype(str),
                 "date": date_display.astype(str),
+                "feedback": feedback_display.astype(str),
+                "answer_link": answer_display.astype(str),
             }
         ).reset_index(drop=True)
 
@@ -918,6 +961,25 @@ def render_results_and_resources_tab() -> None:
                 avg_score = 0.0
             if pd.isna(best_score):
                 best_score = 0.0
+
+            try:
+                top_idx = numeric_series.idxmax(skipna=True)
+            except (ValueError, TypeError):
+                top_idx = None
+            if top_idx in numeric_series.index:
+                assignment_value = (
+                    assignment_display.loc[top_idx]
+                    if top_idx in assignment_display.index
+                    else ""
+                )
+                if score_series is not None and top_idx in score_series.index:
+                    raw_value = score_series.loc[top_idx]
+                else:
+                    raw_value = score_display.loc[top_idx]
+                top_result = {
+                    "assignment": _clean_text(assignment_value),
+                    "raw": raw_value,
+                }
 
     def score_label_fmt(score_value: object, plain: bool = False) -> str:
         cleaned_text = _clean_text(score_value)
@@ -1014,6 +1076,48 @@ def render_results_and_resources_tab() -> None:
         if not display_records:
             st.info("No feedback available yet.")
         else:
+            def _extract_record_text(
+                record_dict: dict[str, object],
+                preferred_keys: tuple[str, ...],
+                keyword_tokens: tuple[str, ...],
+            ) -> str:
+                for key in preferred_keys:
+                    if key in record_dict:
+                        text = _clean_text(record_dict.get(key))
+                        if text:
+                            return text
+                for key, value in record_dict.items():
+                    key_lower = str(key).lower()
+                    if any(token in key_lower for token in keyword_tokens):
+                        text = _clean_text(value)
+                        if text:
+                            return text
+                return ""
+
+            def _linkified_html(text: str) -> str:
+                return linkify_html(text).replace("\n", "<br />")
+
+            feedback_keys = (
+                "feedback",
+                "comment",
+                "comments",
+                "notes",
+                "remarks",
+                "remark",
+            )
+            feedback_tokens = ("feedback", "comment", "note", "remark")
+            answer_keys = (
+                "answer_link",
+                "answers",
+                "answer",
+                "attachment",
+                "attachments",
+                "resource",
+                "resource_link",
+                "link",
+            )
+            answer_tokens = ("answer", "attachment", "resource", "link")
+
             for idx, record in enumerate(display_records):
                 assignment_name = str(record.get("assignment") or "Assignment")
                 st.markdown(f"**{assignment_name}**")
@@ -1021,6 +1125,52 @@ def render_results_and_resources_tab() -> None:
                 date_value = record.get("date")
                 if date_value:
                     st.write(f"Date: {date_value}")
+
+                seen_texts: set[str] = set()
+
+                feedback_text = _extract_record_text(record, feedback_keys, feedback_tokens)
+                if feedback_text:
+                    seen_texts.add(feedback_text)
+                    st.markdown(
+                        f"<div style='margin-top:4px;'>{_linkified_html(feedback_text)}</div>",
+                        unsafe_allow_html=True,
+                    )
+
+                answer_text = _extract_record_text(record, answer_keys, answer_tokens)
+                fallback_refs: list[tuple[str, str]] = []
+                if not answer_text and isinstance(student_row, dict) and student_row:
+                    seen_values = set(seen_texts)
+                    for key, raw_value in student_row.items():
+                        if raw_value is None:
+                            continue
+                        key_lower = str(key).lower()
+                        if "answer" not in key_lower and "feedback" not in key_lower:
+                            continue
+                        text_value = _clean_text(raw_value)
+                        if not text_value or text_value in seen_values:
+                            continue
+                        seen_values.add(text_value)
+                        fallback_refs.append((str(key), text_value))
+
+                if answer_text:
+                    st.markdown(
+                        "<div style='margin-top:4px;'><strong>Resources:</strong> "
+                        f"{_linkified_html(answer_text)}</div>",
+                        unsafe_allow_html=True,
+                    )
+                elif fallback_refs:
+                    st.markdown(
+                        "<div style='margin-top:4px;'><strong>Resources:</strong></div>",
+                        unsafe_allow_html=True,
+                    )
+                    for label, text_value in fallback_refs:
+                        label_text = html.escape(str(label).strip() or "Reference")
+                        st.markdown(
+                            "<div style='margin-left:12px;'>• <strong>"
+                            f"{label_text}:</strong> {_linkified_html(text_value)}</div>",
+                            unsafe_allow_html=True,
+                        )
+
                 if idx < len(display_records) - 1:
                     st.markdown("---")
 

--- a/tests/test_results_feedback_links.py
+++ b/tests/test_results_feedback_links.py
@@ -1,0 +1,113 @@
+import types
+
+import pandas as pd
+import streamlit as st
+
+from src import assignment_ui
+
+
+def test_feedback_tab_shows_feedback_and_roster_links(monkeypatch):
+    st.session_state.clear()
+    st.session_state.update(
+        {
+            "student_code": "abc123",
+            "student_name": "Test Student",
+            "student_level": "B2",
+            "student_row": {
+                "StudentCode": "abc123",
+                "Name": "Test Student",
+                "Level": "B2",
+                "Answer PDF": "https://example.com/roster-answer.pdf",
+                "Feedback Notes": "See folder https://example.com/extra",
+            },
+        }
+    )
+
+    df_scores = pd.DataFrame(
+        {
+            "studentcode": ["abc123"],
+            "assignment": ["Lesson 1"],
+            "score": ["90"],
+            "date": ["2024-02-01"],
+            "level": ["B2"],
+            "comment": ["Great work! Review https://example.com/rubric"],
+        }
+    )
+
+    def fake_fetch_scores(*_args, **_kwargs):
+        return df_scores
+
+    monkeypatch.setattr(assignment_ui, "fetch_scores", fake_fetch_scores)
+    monkeypatch.setattr(
+        assignment_ui,
+        "get_assignment_summary",
+        lambda *a, **k: {"missed": [], "next": None},
+    )
+
+    markdown_calls: list[dict[str, object]] = []
+    current_tab = {"label": None}
+
+    class DummyTab:
+        def __init__(self, label: str):
+            self.label = label
+
+        def __enter__(self):
+            current_tab["label"] = self.label
+            return self
+
+        def __exit__(self, *exc):
+            current_tab["label"] = None
+            return False
+
+    def fake_tabs(labels, *args, **kwargs):
+        return [DummyTab(label) for label in labels]
+
+    monkeypatch.setattr(st, "tabs", fake_tabs)
+
+    def record_markdown(body, *args, **kwargs):
+        markdown_calls.append({
+            "body": body,
+            "tab": current_tab["label"],
+            "kwargs": kwargs,
+        })
+        return None
+
+    monkeypatch.setattr(st, "markdown", record_markdown)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
+    monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Results PDF")
+    monkeypatch.setattr(st, "cache_data", types.SimpleNamespace(clear=lambda: None))
+    monkeypatch.setattr(st, "secrets", {})
+    monkeypatch.setattr(
+        st,
+        "stop",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("stop called")),
+    )
+
+    assignment_ui.render_results_and_resources_tab()
+
+    feedback_bodies = [
+        call["body"]
+        for call in markdown_calls
+        if call["tab"] == "Feedback"
+        and call["kwargs"].get("unsafe_allow_html")
+        and "Great work! Review" in call["body"]
+    ]
+    assert feedback_bodies, "Feedback body with link should be rendered"
+    assert "https://example.com/rubric" in feedback_bodies[0]
+    assert "target=\"_blank\"" in feedback_bodies[0]
+
+    resource_calls = [
+        call["body"]
+        for call in markdown_calls
+        if call["tab"] == "Feedback"
+        and call["kwargs"].get("unsafe_allow_html")
+        and "https://example.com/roster-answer.pdf" in call["body"]
+    ]
+    assert resource_calls, "Roster reference link should be rendered"
+    assert "Answer PDF" in resource_calls[0]


### PR DESCRIPTION
## Summary
- extend the score display pipeline to preserve feedback text and attachment URLs returned by the sheet
- render feedback entries with linkified HTML and roster-based fallbacks for missing answer references
- add regression coverage that exercises feedback rendering with narrative text and accessible download links

## Testing
- `pytest tests/test_results_feedback_links.py tests/test_results_downloads_only.py tests/test_results_pdf_populated.py tests/test_enrollment_letter_balance_block.py tests/test_attendance_pdf_unicode.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9ccef7dbc8321917f84dc9ccbe3c7