### PR TITLE
Add refresh button for assignment scores

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -106,7 +106,12 @@ def load_assignment_scores(force_refresh: bool = False) -> pd.DataFrame:
 def fetch_scores(*_args, **_kwargs) -> pd.DataFrame:
     """Compatibility shim so tests can monkeypatch score fetching."""
 
-    return load_assignment_scores()
+    force_refresh = bool(_kwargs.pop("force_refresh", False))
+    if _args:
+        first_arg = _args[0]
+        if isinstance(first_arg, dict) and not force_refresh:
+            force_refresh = bool(first_arg.get("force_refresh", False))
+    return load_assignment_scores(force_refresh=force_refresh)
 
 
 def get_assignment_summary(student_code: str, level: str, df: pd.DataFrame) -> dict:
@@ -579,6 +584,11 @@ def render_results_and_resources_tab() -> None:
 
     # ... (omitted: upstream UI and data prep code)
 
+    force_refresh = False
+    if st.button("🔄 Refresh scores"):
+        refresh_with_toast("Refreshing scores…")
+        force_refresh = True
+
     student_row_state = st.session_state.get("student_row")
     if not isinstance(student_row_state, dict) or not student_row_state:
         student_code_raw = st.session_state.get("student_code", "")
@@ -693,10 +703,17 @@ def render_results_and_resources_tab() -> None:
     selected_level = _row_str("Level", default=_session_str("student_level", "")).strip()
 
     fetch_payload = {"student_code": selected_code, "level": selected_level}
+    if force_refresh:
+        fetch_payload["force_refresh"] = True
     try:
-        df_scores_raw = fetch_scores(student_code=selected_code, level=selected_level)
+        df_scores_raw = fetch_scores(**fetch_payload)
     except TypeError as exc:  # compat with simple lambda replacements in tests
-        if "student_code" in str(exc) or "level" in str(exc):
+        message = str(exc)
+        if (
+            "student_code" in message
+            or "level" in message
+            or "force_refresh" in message
+        ):
             df_scores_raw = fetch_scores(fetch_payload)
         else:  # pragma: no cover - propagate unexpected type errors
             raise

--- a/tests/test_results_tab_refresh_scores.py
+++ b/tests/test_results_tab_refresh_scores.py
@@ -1,0 +1,106 @@
+import types
+
+import pandas as pd
+import streamlit as st
+
+from src import assignment_ui
+
+
+class DummyTab:
+    def __init__(self, label: str):
+        self.label = label
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_refresh_button_forces_reload(monkeypatch):
+    """Clicking refresh clears caches and reloads uncached scores."""
+
+    st.session_state.clear()
+    st.session_state.update(
+        {
+            "student_code": "abc123",
+            "student_level": "A1",
+            "student_name": "Alice Example",
+            "student_row": {
+                "StudentCode": "abc123",
+                "Name": "Alice Example",
+                "Level": "A1",
+                "Email": "alice@example.com",
+            },
+        }
+    )
+
+    df_scores = pd.DataFrame(
+        {
+            "studentcode": ["abc123"],
+            "assignment": ["Assignment 1"],
+            "score": ["95"],
+            "date": ["2024-01-01"],
+            "level": ["A1"],
+            "feedback": ["Great job"],
+            "answer_link": ["https://example.com"]
+        }
+    )
+
+    calls = {"force_refresh": None}
+
+    def fake_load_assignment_scores(*_args, force_refresh: bool = False, **_kwargs):
+        calls["force_refresh"] = force_refresh
+        return df_scores
+
+    monkeypatch.setattr(
+        assignment_ui, "load_assignment_scores", fake_load_assignment_scores
+    )
+    monkeypatch.setattr(
+        assignment_ui, "get_assignment_summary", lambda *_a, **_k: {"missed": [], "next": None}
+    )
+
+    toasts: list[str] = []
+    monkeypatch.setattr(
+        assignment_ui, "refresh_with_toast", lambda message: toasts.append(message)
+    )
+
+    monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
+    monkeypatch.setattr(st, "divider", lambda *a, **k: None)
+    monkeypatch.setattr(st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
+    monkeypatch.setattr(
+        st,
+        "stop",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("stop called")),
+    )
+    monkeypatch.setattr(st, "cache_data", types.SimpleNamespace(clear=lambda: None))
+
+    button_labels: list[str] = []
+
+    def fake_button(label, *args, **kwargs):
+        button_labels.append(label)
+        return label == "🔄 Refresh scores"
+
+    monkeypatch.setattr(st, "button", fake_button)
+
+    tabs_calls: list[list[str]] = []
+
+    def fake_tabs(labels, *args, **kwargs):
+        tabs_calls.append(list(labels))
+        return [DummyTab(label) for label in labels]
+
+    monkeypatch.setattr(st, "tabs", fake_tabs)
+
+    monkeypatch.setattr(st, "radio", lambda *_a, **_k: "Results PDF")
+
+    assignment_ui.render_results_and_resources_tab()
+
+    assert calls["force_refresh"] is True
+    assert toasts == ["Refreshing scores…"]
+    assert button_labels[0] == "🔄 Refresh scores"
+    assert tabs_calls == [["Overview", "Missed & Next", "Feedback", "Achievements", "Downloads"]]


### PR DESCRIPTION
## Summary
- add a Refresh scores button to the results tab and trigger cache-busting reloads when clicked
- plumb a force_refresh flag through the score loader shim so fresh data is fetched on demand
- cover the refresh workflow with a regression test that verifies the tab layout remains intact

## Testing
- pytest tests/test_results_tab_refresh_scores.py
- pytest tests/test_results_tab_missing_scores.py tests/test_results_downloads_only.py tests/test_enrollment_letter_balance_block.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d46e665083218c72dc2c7e44b343