### PR TITLE
Avoid overriding submit student code widget state

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2713,7 +2713,6 @@ if tab == "My Course":
                     updated_row["StudentCode"] = code
                     st.session_state["student_row"] = updated_row
                     st.session_state["student_code"] = code
-                    st.session_state[code_input_key] = code
                     student_row = updated_row
                     st.success("Student code saved. You can now submit your work.")
 


### PR DESCRIPTION
## Summary
- stop writing to the submit student code text input's session state after the widget has rendered to prevent Streamlit conflicts

## Testing
- not run (Streamlit UI requires interactive verification)


------
https://chatgpt.com/codex/tasks/task_e_68c9e0a7a25c8321a7586162e063607b