### PR TITLE
Add roster refresh capability and tests

### DIFF
--- a/src/data_loading.py
+++ b/src/data_loading.py
@@ -137,12 +137,17 @@ def _load_student_data_cached() -> Optional[pd.DataFrame]:
     return df
 
 
-def load_student_data() -> Optional[pd.DataFrame]:
+def load_student_data(force_refresh: bool = False) -> Optional[pd.DataFrame]:
     """Load student roster.
 
     Returns ``None`` if the roster contains no usable rows. Any errors during
     loading are propagated to the caller.
     """
+    if force_refresh:
+        try:
+            _load_student_data_cached.clear()
+        except Exception:
+            logging.exception("Unable to clear cached student roster")
     return _load_student_data_cached()
 
 

--- a/tests/test_load_student_data_refresh.py
+++ b/tests/test_load_student_data_refresh.py
@@ -1,0 +1,15 @@
+from unittest.mock import MagicMock
+
+from src import data_loading
+
+
+def test_force_refresh_clears_cache(monkeypatch):
+    loader = MagicMock(return_value={"data": "fresh"})
+    loader.clear = MagicMock()
+    monkeypatch.setattr(data_loading, "_load_student_data_cached", loader)
+
+    result = data_loading.load_student_data(force_refresh=True)
+
+    assert result == {"data": "fresh"}
+    loader.clear.assert_called_once_with()
+    loader.assert_called_once_with()

--- a/tests/test_login_roster_refresh.py
+++ b/tests/test_login_roster_refresh.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pandas as pd
+
+from src.ui import auth
+
+
+@dataclass
+class DummyStreamlit:
+    errors: list[str] = field(default_factory=list)
+    session_state: dict[str, Any] = field(default_factory=dict)
+    query_params: dict[str, Any] = field(default_factory=dict)
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+
+def test_login_refreshes_roster_on_initial_miss(monkeypatch):
+    dummy_st = DummyStreamlit()
+    monkeypatch.setattr(auth, "st", dummy_st)
+    monkeypatch.setattr(auth, "renew_session_if_needed", lambda: None)
+    monkeypatch.setattr(auth, "is_contract_expired", lambda row: False)
+
+    captured_df: dict[str, Any] = {}
+
+    def fake_contract_active(student_code: str, df: pd.DataFrame) -> bool:
+        captured_df["df"] = df
+        return False
+
+    monkeypatch.setattr(auth, "contract_active", fake_contract_active)
+
+    df_initial = pd.DataFrame(
+        [
+            {
+                "StudentCode": "someoneelse",
+                "Email": "other@example.com",
+                "Name": "Other",
+                "ContractEnd": "2024-01-01",
+            }
+        ]
+    )
+    df_refreshed = pd.DataFrame(
+        [
+            {
+                "StudentCode": "matchcode",
+                "Email": "target@example.com",
+                "Name": "Target",
+                "ContractEnd": "2025-01-01",
+            }
+        ]
+    )
+
+    calls: list[bool] = []
+
+    def fake_loader(force_refresh: bool = False):
+        calls.append(force_refresh)
+        return df_refreshed.copy() if force_refresh else df_initial.copy()
+
+    monkeypatch.setattr(auth, "load_student_data", fake_loader)
+
+    ok = auth.render_login_form("target@example.com", "pw")
+
+    assert ok is False
+    assert calls == [False, True]
+    assert dummy_st.errors[-1] == "Outstanding balance past due. Contact the office."
+    assert "df" in captured_df
+    assert captured_df["df"].iloc[0]["Email"] == "target@example.com"


### PR DESCRIPTION
## Summary
- add an optional `force_refresh` flag to `load_student_data` so callers can invalidate the cached roster before fetching fresh data.【F:src/data_loading.py†L140-L151】
- ensure the signup, login, and Google OAuth flows normalize roster data and retry with a forced refresh when an initial lookup is empty so newly added students are recognized immediately.【F:src/ui/auth.py†L70-L145】【F:src/ui/auth.py†L167-L220】【F:src/ui/auth.py†L440-L499】
- add unit tests that cover cache clearing and the login retry path after an initial roster miss.【F:tests/test_load_student_data_refresh.py†L1-L15】【F:tests/test_login_roster_refresh.py†L1-L70】

## Testing
- pytest tests/test_load_student_data_refresh.py tests/test_login_roster_refresh.py【0418f9†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68ca781edd8883219a9551c94513f995