### PR TITLE
Update class discussion board unavailable message

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2451,9 +2451,10 @@ if tab == "My Course":
             if post_count == 0:
                 st.caption("No posts yet. Clicking will show the full board.")
         elif not class_name_lookup:
-            st.info(
-                "This class discussion board is unavailable. "
-                "Please contact support to add your class to the roster."
+            st.error(
+                "This class discussion board is unavailable. Select another "
+                "classroom tab and return, or log out and back in to refresh "
+                "your roster."
             )
         else:
             st.warning("Missing chapter for discussion board.")


### PR DESCRIPTION
## Summary
- change the Class Notes & Q&A fallback for missing class name to use an error message
- provide refreshed instructions guiding learners to reload their roster

## Testing
- streamlit run a1sprechen.py --server.headless true --server.port 8501


------
https://chatgpt.com/codex/tasks/task_e_68ca8eb314d08321ae7c3617dfb083e2