### PR TITLE
Ensure refresh toast triggers rerun

### DIFF
--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -86,4 +86,5 @@ def refresh_with_toast(msg: str = "Saved!") -> None:
         The message to display in the success toast. Defaults to ``"Saved!"``.
     """
     st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+    st.session_state["need_rerun"] = True
     toast_ok(msg)

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -38,6 +38,7 @@ def test_refresh_with_toast(monkeypatch):
     toasts.refresh_with_toast()
     mock_st.toast.assert_called_once_with("Saved!", icon="✅")
     assert mock_st.session_state["__refresh"] == 1
+    assert mock_st.session_state["need_rerun"] is True
 
 
 def test_refresh_with_toast_custom_msg(monkeypatch):
@@ -46,6 +47,7 @@ def test_refresh_with_toast_custom_msg(monkeypatch):
     toasts.refresh_with_toast("Updated!")
     mock_st.toast.assert_called_once_with("Updated!", icon="✅")
     assert mock_st.session_state["__refresh"] == 1
+    assert mock_st.session_state["need_rerun"] is True
 
 
 def test_toast_once_suppresses_duplicates(monkeypatch):


### PR DESCRIPTION
## Summary
- set `refresh_with_toast` to flag the Streamlit session for reruns in addition to bumping the refresh counter
- extend toast tests to confirm the rerun flag is written when the helper runs

## Testing
- `pytest` *(fails: tests/test_class_discussion_link.py::test_lesson_includes_class_discussion_button, tests/test_class_discussion_missing_classname.py::test_class_discussion_skips_without_classname)*

------
https://chatgpt.com/codex/tasks/task_e_68caa4f884988321a464376652feee62