### PR TITLE
Add cache buster to assignment score sheet fetch

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -6,12 +6,13 @@ bundled DejaVu fonts are unavailable.
 """
 from __future__ import annotations
 
-import html
 import base64 as _b64
+import html
 import io
 import os
 import re
 import tempfile
+import time
 from datetime import date
 from typing import Callable, NamedTuple
 
@@ -77,9 +78,12 @@ def _load_assignment_scores_cached(force_refresh: bool = False) -> pd.DataFrame:
             pass
 
     SHEET_ID = "1BRb8p3Rq0VpFCLSwL4eS9tSgXBo9hSWzfW_J_7W36NQ"
-    url = (
+    base_url = (
         f"https://docs.google.com/spreadsheets/d/{SHEET_ID}/gviz/tq?tqx=out:csv&sheet=Sheet1"
     )
+    cache_buster = int(time.time()) if force_refresh else int(time.time() // 60)
+    sep = "&" if "?" in base_url else "?"
+    url = f"{base_url}{sep}cb={cache_buster}"
     df = pd.read_csv(url)
 
     # Normalize column headers immediately for downstream lookups.


### PR DESCRIPTION
## Summary
- append a time-based cache-buster when reading the assignment scores CSV so responses bypass stale caches
- keep the manual refresh path by still clearing the Streamlit cache and generating a fresh cache-buster when force refreshing

## Testing
- `pytest tests/test_results_tab_refresh_scores.py tests/test_assignment_summary_filters.py tests/test_assignment_url.py tests/test_results_tab_assignment_target.py`


------
https://chatgpt.com/codex/tasks/task_e_68cb2c596dcc8321b44051dce81cbc2b