### PR TITLE
Revamp results aggregation and transcript export

### DIFF
--- a/tests/test_results_achievements.py
+++ b/tests/test_results_achievements.py
@@ -74,7 +74,7 @@ def test_results_tab_awards_gold_and_star(monkeypatch):
     monkeypatch.setattr(
         st, "tabs", lambda labels, *a, **k: [DummyTab(label) for label in labels]
     )
-    monkeypatch.setattr(st, "radio", lambda *a, **k: "Results PDF")
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Transcript PDF")
 
     achievements_output: list[str] = []
 

--- a/tests/test_results_downloads_only.py
+++ b/tests/test_results_downloads_only.py
@@ -75,7 +75,7 @@ def test_downloads_option_rendered_when_no_scores(monkeypatch):
 
     assert tabs_calls == [["Overview", "Missed & Next", "Feedback", "Achievements", "Downloads"]]
     expected_options = [
-        "Results PDF",
+        "Transcript PDF",
         "Enrollment Letter",
         "Receipt",
         "Attendance PDF",

--- a/tests/test_results_feedback_links.py
+++ b/tests/test_results_feedback_links.py
@@ -80,7 +80,7 @@ def test_feedback_tab_shows_feedback_and_roster_links(monkeypatch):
     monkeypatch.setattr(st, "error", lambda *a, **k: None)
     monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
-    monkeypatch.setattr(st, "radio", lambda *a, **k: "Results PDF")
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Transcript PDF")
     monkeypatch.setattr(st, "cache_data", types.SimpleNamespace(clear=lambda: None))
     monkeypatch.setattr(st, "secrets", {})
     monkeypatch.setattr(

--- a/tests/test_results_pdf_populated.py
+++ b/tests/test_results_pdf_populated.py
@@ -1,4 +1,5 @@
 import re
+import re
 import types
 import zlib
 
@@ -27,6 +28,7 @@ def test_results_pdf_contains_student_scores(monkeypatch):
                 "StudentCode": "abc123",
                 "Name": "Alice Example",
                 "Level": "B1",
+                "ClassName": "Evening A",
                 "Email": "alice@example.com",
             },
         }
@@ -42,30 +44,6 @@ def test_results_pdf_contains_student_scores(monkeypatch):
         }
     )
     monkeypatch.setattr(assignment_ui, "fetch_scores", lambda *_a, **_k: df_scores)
-
-    df_display = pd.DataFrame(
-        {
-            "assignment": ["Assignment 1"],
-            "score": ["95"],
-            "date": ["2024-01-01"],
-        }
-    )
-    monkeypatch.setattr(assignment_ui, "df_display", df_display, raising=False)
-    monkeypatch.setattr(
-        assignment_ui,
-        "df_user",
-        pd.DataFrame({"name": ["Alice Example"]}),
-        raising=False,
-    )
-    monkeypatch.setattr(assignment_ui, "total", 1, raising=False)
-    monkeypatch.setattr(assignment_ui, "completed", 1, raising=False)
-    monkeypatch.setattr(assignment_ui, "avg_score", 95.0, raising=False)
-    monkeypatch.setattr(assignment_ui, "best_score", 95.0, raising=False)
-
-    def fake_score_label(score, plain=False):
-        return f"Score {score}"
-
-    monkeypatch.setattr(assignment_ui, "score_label_fmt", fake_score_label, raising=False)
     monkeypatch.setattr(assignment_ui, "load_school_logo", lambda: None, raising=False)
 
     monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
@@ -80,10 +58,10 @@ def test_results_pdf_contains_student_scores(monkeypatch):
     monkeypatch.setattr(st, "secrets", {})
     monkeypatch.setattr(st, "stop", lambda *a, **k: (_ for _ in ()).throw(AssertionError("stop called")))
 
-    monkeypatch.setattr(st, "radio", lambda *a, **k: "Results PDF")
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Transcript PDF")
 
     def fake_button(label, *args, **kwargs):
-        return label == "⬇️ Create & Download Results PDF"
+        return label == "⬇️ Create & Download Transcript PDF"
 
     monkeypatch.setattr(st, "button", fake_button)
 
@@ -112,3 +90,6 @@ def test_results_pdf_contains_student_scores(monkeypatch):
 
     assert "Assignment 1".encode("utf-16-be") in extracted
     assert "95".encode("utf-16-be") in extracted
+    assert "Tries".encode("utf-16-be") in extracted
+    assert "Try 1".encode("utf-16-be") in extracted
+    assert "Class:".encode("utf-16-be") in extracted

--- a/tests/test_results_tab_assignment_target.py
+++ b/tests/test_results_tab_assignment_target.py
@@ -80,7 +80,7 @@ def test_results_tab_uses_level_target(monkeypatch):
     monkeypatch.setattr(st, "error", lambda *a, **k: None)
     monkeypatch.setattr(st, "write", fake_write)
     monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "radio", lambda *a, **k: "Results PDF")
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Transcript PDF")
     monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
     monkeypatch.setattr(st, "info", lambda *a, **k: None)
     monkeypatch.setattr(st, "cache_data", types.SimpleNamespace(clear=lambda: None))
@@ -102,3 +102,88 @@ def test_results_tab_uses_level_target(monkeypatch):
     assert trophy_lines, "Completion trophy status was not rendered"
     assert trophy_lines[0].startswith("🔒"), "Trophy should remain locked at 5/19"
     assert "5/19" in trophy_lines[0]
+
+
+def test_results_tab_collapses_duplicate_attempts(monkeypatch):
+    st.session_state.clear()
+    st.session_state.update(
+        {
+            "student_code": "dup-learner",
+            "student_name": "Retry Student",
+            "student_level": "B2",
+            "student_row": {
+                "StudentCode": "dup-learner",
+                "Name": "Retry Student",
+                "Level": "B2",
+                "Email": "retry@example.com",
+            },
+        }
+    )
+
+    df_scores = pd.DataFrame(
+        {
+            "studentcode": ["dup-learner", "dup-learner"],
+            "assignment": ["Speaking Practice", "Speaking Practice"],
+            "score": ["70", "88"],
+            "date": ["2024-02-01", "2024-02-05"],
+            "level": ["B2", "B2"],
+        }
+    )
+
+    monkeypatch.setattr(assignment_ui, "fetch_scores", lambda *_a, **_k: df_scores)
+
+    written_dfs: list[pd.DataFrame] = []
+    write_messages: list[str] = []
+    markdown_messages: list[str] = []
+
+    def fake_write(*args, **_kwargs):
+        for arg in args:
+            if isinstance(arg, pd.DataFrame):
+                written_dfs.append(arg)
+            elif isinstance(arg, str):
+                write_messages.append(arg)
+        return None
+
+    def fake_markdown(message, *args, **_kwargs):
+        if isinstance(message, str):
+            markdown_messages.append(message)
+        return None
+
+    monkeypatch.setattr(st, "markdown", fake_markdown)
+    monkeypatch.setattr(st, "divider", lambda *a, **k: None)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
+    monkeypatch.setattr(st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    monkeypatch.setattr(st, "write", fake_write)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Transcript PDF")
+    monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(st, "cache_data", types.SimpleNamespace(clear=lambda: None))
+    monkeypatch.setattr(st, "secrets", {})
+    monkeypatch.setattr(
+        st,
+        "stop",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("stop called")),
+    )
+    monkeypatch.setattr(
+        st, "tabs", lambda labels, *a, **k: [DummyTab(label) for label in labels]
+    )
+
+    assignment_ui.render_results_and_resources_tab()
+
+    assert written_dfs, "overview table was not rendered"
+    overview_df = None
+    for candidate in written_dfs:
+        lowered = [str(col).lower() for col in candidate.columns]
+        if "tries" in lowered:
+            overview_df = candidate
+            break
+    assert overview_df is not None, "No overview DataFrame with tries column found"
+    tries_col_idx = [str(col).lower() for col in overview_df.columns].index("tries")
+    tries_value = overview_df.iloc[0, tries_col_idx]
+    assert tries_value == 2, f"Expected 2 tries, got {tries_value!r}"
+
+    combined_messages = " ".join(write_messages + markdown_messages)
+    assert "Try 2" in combined_messages
+    assert any("Average score: 88.0%" in msg for msg in write_messages)

--- a/tests/test_results_tab_missing_scores.py
+++ b/tests/test_results_tab_missing_scores.py
@@ -54,7 +54,7 @@ def test_results_tab_handles_missing_scores(monkeypatch):
     monkeypatch.setattr(st, "error", lambda *a, **k: None)
     monkeypatch.setattr(st, "write", lambda *a, **k: None)
     monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "radio", lambda *a, **k: "Results PDF")
+    monkeypatch.setattr(st, "radio", lambda *a, **k: "Transcript PDF")
     monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
     monkeypatch.setattr(
         st,

--- a/tests/test_results_tab_refresh_scores.py
+++ b/tests/test_results_tab_refresh_scores.py
@@ -96,7 +96,7 @@ def test_refresh_button_forces_reload(monkeypatch):
 
     monkeypatch.setattr(st, "tabs", fake_tabs)
 
-    monkeypatch.setattr(st, "radio", lambda *_a, **_k: "Results PDF")
+    monkeypatch.setattr(st, "radio", lambda *_a, **_k: "Transcript PDF")
 
     assignment_ui.render_results_and_resources_tab()
 


### PR DESCRIPTION
## Summary
- add an aggregation helper that normalises assignments, selects the best attempt, and exposes tries/metadata used across the results tab
- update the results tab to display attempt counts, rename the download to a transcript PDF, and feed the richer data into the PDF export
- refresh the unit tests to cover the transcript naming, tries column, and duplicate-attempt handling

## Testing
- pytest tests/test_results_*


------
https://chatgpt.com/codex/tasks/task_e_68cbce9754e083219a9a813862c9a6a6