### PR TITLE
Fix transcript download anchor and test

### DIFF
--- a/src/assignment_ui.py
+++ b/src/assignment_ui.py
@@ -1632,7 +1632,7 @@ def render_results_and_resources_tab() -> None:
                 )
                 b64 = _b64.b64encode(pdf_bytes).decode()
                 st.markdown(
-                    f"<a href\"data:application/pdf;base64,{b64}\" download=\"{file_name}\" "
+                    f"<a href=\"data:application/pdf;base64,{b64}\" download=\"{file_name}\" "
                     f"style=\"font-size:1.1em;font-weight:600;color:#2563eb;\">📥 Click here to download transcript PDF (manual)</a>",
                     unsafe_allow_html=True,
                 )


### PR DESCRIPTION
## Summary
- fix the manual transcript download link to emit a valid data URL anchor
- extend the transcript PDF test to capture and verify the rendered anchor markup

## Testing
- pytest tests/test_results_pdf_populated.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cbe5e177448321bd513e3baf8bcdd4