### PR TITLE
Normalize leaderboard scores to best attempts

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -392,6 +392,7 @@ from src.assignment_ui import (
     load_assignment_scores,
     render_results_and_resources_tab,
     get_assignment_summary,
+    select_best_assignment_attempts,
 )
 from src.session_management import (
     bootstrap_state,
@@ -1501,9 +1502,10 @@ if tab == "Dashboard":
 
     _df_assign['level'] = _df_assign['level'].astype(str).str.upper().str.strip()
     _df_assign['score'] = pd.to_numeric(_df_assign['score'], errors='coerce')
+    _df_assign_best = select_best_assignment_attempts(_df_assign)
     _min_assignments = 3
     _df_level = (
-        _df_assign[_df_assign['level'] == _level]
+        _df_assign_best[_df_assign_best['level'] == _level]
         .groupby(['studentcode', 'name'], as_index=False)
         .agg(total_score=('score', 'sum'), completed=('assignment', 'nunique'))
     )

--- a/tests/test_assignment_leaderboard.py
+++ b/tests/test_assignment_leaderboard.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from src.assignment_ui import select_best_assignment_attempts
+
+
+def test_leaderboard_ignores_lower_duplicate_scores():
+    df = pd.DataFrame(
+        {
+            "studentcode": ["s1", "s1", "s1", "s2", "s2"],
+            "assignment": ["A", "A", "B", "A", "A"],
+            "score": ["40", "85", "90", "50", "65"],
+            "level": ["A1", "A1", "A1", "A1", "A1"],
+            "name": ["Student 1", "Student 1", "Student 1", "Student 2", "Student 2"],
+        }
+    )
+
+    deduped = select_best_assignment_attempts(df)
+    deduped["score"] = pd.to_numeric(deduped["score"], errors="coerce")
+
+    leaderboard = (
+        deduped[deduped["level"] == "A1"]
+        .groupby(["studentcode", "name"], as_index=False)
+        .agg(total_score=("score", "sum"), completed=("assignment", "nunique"))
+        .set_index("studentcode")
+    )
+
+    assert len(deduped) == 3  # Only one row per student/assignment pair
+    assert leaderboard.loc["s1", "total_score"] == 175.0
+    assert leaderboard.loc["s1", "completed"] == 2
+    assert leaderboard.loc["s2", "total_score"] == 65.0
+    assert leaderboard.loc["s2", "completed"] == 1


### PR DESCRIPTION
## Summary
- add a helper that collapses assignment attempts down to the highest score per student/assignment pair
- update the dashboard leaderboard aggregation to rely on the deduplicated data
- add a regression test covering duplicate attempts counting in the leaderboard totals

## Testing
- pytest tests/test_assignment_leaderboard.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe5ccea8c8321b043cb72ebc8ca99