### PR TITLE
Handle None drafts in autosave

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4904,6 +4904,8 @@ if tab == "My Course":
                     ai_flag = f"q_ai_busy_{q_id}"
 
                     current_text = st.session_state.get(draft_key, "")
+                    if not isinstance(current_text, str):
+                        current_text = ""
                     if st.session_state.get(ai_flag):
                         with st.spinner("Correcting with AI..."):
                             apply_ai_correction(q_id, draft_key, current_text)
@@ -4911,6 +4913,8 @@ if tab == "My Course":
                         st.session_state["need_rerun"] = True
                         st.session_state[active_thread_state_key] = q_id
                         current_text = st.session_state.get(draft_key, "")
+                        if not isinstance(current_text, str):
+                            current_text = ""
 
                     composer_value = st.chat_input(
                         "Reply to this thread…",
@@ -4920,6 +4924,8 @@ if tab == "My Course":
                     )
 
                     current_text = st.session_state.get(draft_key, "")
+                    if not isinstance(current_text, str):
+                        current_text = ""
                     autosave_maybe(student_code, draft_key, current_text, min_secs=2.0, min_delta=12)
 
                     if current_text:

--- a/src/draft_management.py
+++ b/src/draft_management.py
@@ -68,10 +68,15 @@ def autosave_maybe(
     if locked:
         return
 
+    if not isinstance(text, str):
+        text = ""
+
     last_val_key, last_ts_key, saved_flag_key, saved_at_key = _draft_state_keys(
         lesson_field_key
     )
     last_val = st.session_state.get(last_val_key, "")
+    if not isinstance(last_val, str):
+        last_val = ""
     last_ts = float(st.session_state.get(last_ts_key, 0.0))
     now = time.time()
 

--- a/tests/test_draft_management.py
+++ b/tests/test_draft_management.py
@@ -30,3 +30,28 @@ def test_autosave_learning_note_requires_student_code(monkeypatch):
     dm.autosave_learning_note("", "notes_key")
     assert errors
     save_mock.assert_not_called()
+
+
+def test_autosave_maybe_handles_none_state(monkeypatch):
+    draft_key = "lesson_field"
+    last_val_key, last_ts_key, saved_flag_key, saved_at_key = dm._draft_state_keys(draft_key)
+    session_state = {
+        last_val_key: None,
+        last_ts_key: 0.0,
+        "falowen_chat_draft_key": "other",
+    }
+    mock_st = types.SimpleNamespace(session_state=session_state)
+    monkeypatch.setattr(dm, "st", mock_st)
+
+    save_mock = MagicMock()
+    monkeypatch.setattr(dm, "save_draft_to_db", save_mock)
+    monkeypatch.setattr(dm, "save_chat_draft_to_db", MagicMock())
+
+    dm.autosave_maybe("code", draft_key, None, min_secs=0)
+    dm.autosave_maybe("code", draft_key, "New text", min_secs=0)
+
+    save_mock.assert_called_once_with("code", draft_key, "New text")
+    assert session_state[last_val_key] == "New text"
+    assert session_state[last_ts_key] >= 0.0
+    assert session_state[saved_flag_key] is True
+    assert saved_at_key in session_state


### PR DESCRIPTION
## Summary
- normalize autosave inputs so `None` drafts are treated as empty strings before comparing lengths
- coerce classroom comment drafts to strings before invoking the autosave helper
- add a regression test that exercises autosave with `None` values in session state

## Testing
- pytest tests/test_draft_management.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3d98b08c83218d45e48cf6468e78