### PR TITLE
Add streamlit-autorefresh dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit==1.49.0
+streamlit-autorefresh==1.0.1
 openai==1.55.3
 pandas==2.3.2
 fpdf==1.7.2


### PR DESCRIPTION
## Summary
- add the `streamlit-autorefresh` package to the Python dependencies to match the module used in `a1sprechen.py`

## Testing
- pip install -r requirements.txt *(fails: blocked from fetching streamlit-autorefresh through the proxy)*
- python -c "from streamlit_autorefresh import st_autorefresh" *(fails: module still missing because install did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68cd420b066c8321a19a9434c34d8be8