### PR TITLE
Limit class board auto refresh to active comment panel

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4623,6 +4623,18 @@ if tab == "My Course":
                 st.success("Comment sent!")
                 refresh_with_toast()
 
+            comment_panel_active = (
+                st.session_state.get("coursebook_subtab") == "🧑‍🏫 Classroom"
+                and st.session_state.get("classroom_page") == "Class Notes & Q&A"
+            )
+            if comment_panel_active:
+                try:
+                    from streamlit_autorefresh import st_autorefresh
+                except ImportError:
+                    pass
+                else:
+                    st_autorefresh(interval=5000, key="classboard_comment_refresh")
+
             if not questions:
                 st.info("No posts yet.")
             else:
@@ -4959,13 +4971,6 @@ if tab == "My Course":
                         ):
                             st.session_state[ai_flag] = True
                             st.session_state["need_rerun"] = True
-
-                    try:
-                        from streamlit_autorefresh import st_autorefresh
-
-                        st_autorefresh(interval=5000, key=f"comment_refresh_{q_id}")
-                    except ImportError:
-                        pass
 
                     if idx < len(questions) - 1:
                         st.divider()


### PR DESCRIPTION
## Summary
- move the class board auto-refresh trigger out of the per-question loop so it only runs once per render
- gate the refresh on the Class Notes & Q&A panel state and reuse a single stable widget key

## Testing
- not run (streamlit app)


------
https://chatgpt.com/codex/tasks/task_e_68cd4deda4e48321a8d6d8ee5b095b38