### PR TITLE
Handle missing discussion database gracefully

### DIFF
--- a/src/discussion_board.py
+++ b/src/discussion_board.py
@@ -51,6 +51,14 @@ def go_class_thread(topic: str, db: Optional[object] = None) -> None:
     if db is None:
         db = get_db()
 
+    if db is None:
+        st.warning(
+            "Class discussion database is currently unavailable. "
+            "Please try again later."
+        )
+        st.session_state["class_discussion_warning"] = True
+        return
+
     student_level = st.session_state.get("student_level", "A1")
     class_name = (
         str(st.session_state.get("student_row", {}).get("ClassName", ""))

--- a/tests/test_class_thread_no_posts.py
+++ b/tests/test_class_thread_no_posts.py
@@ -41,6 +41,10 @@ class DummyStreamlit:
     def __init__(self):
         self.session_state = {}
         self.query_params = {}
+        self.warnings = []
+
+    def warning(self, message):
+        self.warnings.append(message)
 
 
 
@@ -87,3 +91,16 @@ def test_go_class_thread_keeps_search_when_posts_exist():
     assert st.session_state.get("q_search_count") == 1
     assert st.session_state.get("coursebook_subtab") == "🧑‍🏫 Classroom"
     assert st.session_state.get("classroom_page") == "Class Notes & Q&A"
+
+
+def test_go_class_thread_warns_when_db_missing():
+    fn, st, db = setup_env()
+    original_get_db = fn.__globals__["get_db"]
+    fn.__globals__["get_db"] = lambda: None
+    try:
+        fn("9", db=None)
+    finally:
+        fn.__globals__["get_db"] = original_get_db
+
+    assert st.session_state.get("class_discussion_warning") is True
+    assert st.warnings[-1].startswith("Class discussion database is currently unavailable")


### PR DESCRIPTION
## Summary
- detect when the Firestore client is unavailable in `go_class_thread` and surface a warning instead of querying collections
- extend the discussion board regression tests to capture warnings and cover the missing-db scenario

## Testing
- pytest tests/test_class_thread_no_posts.py

------
https://chatgpt.com/codex/tasks/task_e_68cd648b9d9c8321adedaa28263fb1f0