### PR TITLE
Allow configuring vocab sheet source

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ The vocabulary sheet must include the following columns:
 |-------|--------|---------|
 | A1    | Haus   | house   |
 
+#### Configuring the source sheet
+
+By default the app reads from the shared sheet used during development.
+Deployments can point to another document by providing configuration at runtime:
+
+- Environment variables: set `VOCAB_SHEET_ID` and `VOCAB_SHEET_GID`.
+- Streamlit secrets: add `vocab_sheet_id`/`vocab_sheet_gid` (or the upper-case
+  variants) to `st.secrets`.
+
+The sheet *id* identifies the document while the *gid* selects a specific tab
+within the workbook. The gid must be an integer. Any configuration mechanism can
+override one or both values; unspecified fields fall back to the built-in
+defaults.
+
 ## Keychain Helper
 
 The application uses a small Swift utility to read and write OAuth tokens from

--- a/tests/test_vocab_default_level.py
+++ b/tests/test_vocab_default_level.py
@@ -2,26 +2,28 @@ import pandas as pd
 import src.services.vocab as vocab
 
 
+class DummyStreamlit:
+    def __init__(self, secrets=None):
+        self.errors = []
+        self.warnings = []
+        self.secrets = secrets or {}
+
+    def error(self, msg):
+        self.errors.append(msg)
+
+    def warning(self, msg):
+        self.warnings.append(msg)
+
+    def cache_data(self, func=None, **kwargs):
+        if func is None:
+            def wrapper(f):
+                return f
+            return wrapper
+        return func
+
+
 def test_missing_level_defaults_to_a1(monkeypatch):
     df = pd.DataFrame({"German": ["Hallo"], "English": ["Hello"]})
-
-    class DummyStreamlit:
-        def __init__(self):
-            self.errors = []
-            self.warnings = []
-
-        def error(self, msg):
-            self.errors.append(msg)
-
-        def warning(self, msg):
-            self.warnings.append(msg)
-
-        def cache_data(self, func=None, **kwargs):
-            if func is None:
-                def wrapper(f):
-                    return f
-                return wrapper
-            return func
 
     st = DummyStreamlit()
     monkeypatch.setattr(vocab, "st", st)
@@ -35,3 +37,56 @@ def test_missing_level_defaults_to_a1(monkeypatch):
     assert not st.errors, "Should not report errors when Level is missing"
     assert vocab_lists == {"A1": [("Hallo", "Hello")]}
     assert audio[("A1", "Hallo")] == {"normal": "", "slow": ""}
+
+
+def test_vocab_sheet_config_defaults(monkeypatch):
+    st = DummyStreamlit()
+    monkeypatch.setattr(vocab, "st", st)
+    monkeypatch.delenv("VOCAB_SHEET_ID", raising=False)
+    monkeypatch.delenv("VOCAB_SHEET_GID", raising=False)
+
+    sheet_id, sheet_gid = vocab.get_vocab_sheet_config()
+
+    assert sheet_id == vocab.DEFAULT_SHEET_ID
+    assert sheet_gid == vocab.DEFAULT_SHEET_GID
+
+
+def test_vocab_sheet_config_from_secrets(monkeypatch):
+    st = DummyStreamlit({"vocab_sheet_id": "secret-id", "vocab_sheet_gid": 7})
+    monkeypatch.setattr(vocab, "st", st)
+    monkeypatch.delenv("VOCAB_SHEET_ID", raising=False)
+    monkeypatch.delenv("VOCAB_SHEET_GID", raising=False)
+
+    sheet_id, sheet_gid = vocab.get_vocab_sheet_config()
+
+    assert sheet_id == "secret-id"
+    assert sheet_gid == 7
+
+
+def test_vocab_sheet_config_from_env(monkeypatch):
+    st = DummyStreamlit()
+    monkeypatch.setattr(vocab, "st", st)
+    monkeypatch.setenv("VOCAB_SHEET_ID", "env-sheet")
+    monkeypatch.setenv("VOCAB_SHEET_GID", "42")
+    monkeypatch.setattr(vocab, "SHEET_ID", vocab.SHEET_ID, raising=False)
+    monkeypatch.setattr(vocab, "SHEET_GID", vocab.SHEET_GID, raising=False)
+
+    df = pd.DataFrame({"Level": ["A1"], "German": ["Hallo"], "English": ["Hello"]})
+    captured = {}
+
+    def fake_read_csv(url):
+        captured["url"] = url
+        return df
+
+    monkeypatch.setattr(vocab, "pd", pd)
+    monkeypatch.setattr(vocab.pd, "read_csv", fake_read_csv)
+    vocab.load_vocab_lists.clear()
+
+    vocab.load_vocab_lists()
+
+    assert captured["url"].startswith(
+        "https://docs.google.com/spreadsheets/d/env-sheet/export?format=csv&gid="
+    )
+    assert captured["url"].endswith("gid=42")
+    assert vocab.SHEET_ID == "env-sheet"
+    assert vocab.SHEET_GID == 42


### PR DESCRIPTION
## Summary
- add helpers that resolve the vocab sheet id and gid from environment variables or Streamlit secrets
- use the resolved values when building the Google Sheets CSV URL and expose the resolver for reuse
- document the new configuration options and cover them with unit tests

## Testing
- pytest tests/test_vocab_default_level.py

------
https://chatgpt.com/codex/tasks/task_e_68cd652e4ea0832199f7feff48cba78f