### PR TITLE
Persist selected level in exam mode step

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5888,13 +5888,21 @@ if tab == "Exams Mode & Custom Chat":
 
 
     # ——— Step 2: Level ———
-    if st.session_state["falowen_stage"] == 2 and not st.session_state.get("falowen_level"):
+    if st.session_state["falowen_stage"] == 2:
         st.subheader("Step 2: Choose Your Level")
-        level = st.radio("Select your level:", ["A1","A2","B1","B2","C1"], key="falowen_level_center")
+        level = st.radio(
+            "Select your level:",
+            ["A1", "A2", "B1", "B2", "C1"],
+            key="falowen_level_center",
+        )
+        if level:
+            st.session_state["falowen_level"] = level
         col1, col2 = st.columns(2)
         with col1:
             if st.button("⬅️ Back", key="falowen_back1"):
                 st.session_state["falowen_stage"] = 1
+                st.session_state["falowen_level"] = None
+                st.session_state.pop("falowen_level_center", None)
                 st.session_state["falowen_messages"] = []
                 st.session_state["_falowen_loaded"] = False
                 refresh_with_toast()


### PR DESCRIPTION
## Summary
- ensure the exams/custom chat level picker always mirrors its selection into `st.session_state["falowen_level"]`
- allow the step 2 UI to render whenever stage 2 is active and reset level/session radio state when backing out

## Testing
- `pytest` *(fails: tests/test_class_discussion_link.py::test_lesson_includes_class_discussion_button, tests/test_class_discussion_missing_classname.py::test_class_discussion_skips_without_classname, tests/test_load_student_classname.py::{test_class_column_variants[Class],test_class_column_variants[classname],test_class_column_variants[Classroom],test_class_column_variants[class_name],test_class_column_variants[Group],test_class_column_variants[Course],test_missing_class_column_raises}, tests/test_load_student_data_refresh.py::test_force_refresh_clears_cache)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6f76c4f88321ad73c598f0adad4f