### PR TITLE
Preserve chat messages when Firestore unavailable

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6392,8 +6392,16 @@ if tab == "Exams Mode & Custom Chat":
         draft_key = _wkey("chat_draft")
         st.session_state["falowen_chat_draft_key"] = draft_key
 
+        current_messages = st.session_state.get("falowen_messages", [])
+        loaded_key = st.session_state.get("falowen_loaded_key")
         chats = (doc_data.get("chats", {}) or {})
-        st.session_state["falowen_messages"] = chats.get(conv_key, [])
+        remote_messages = chats.get(conv_key)
+        if loaded_key != conv_key:
+            current_messages = []
+        if isinstance(remote_messages, list):
+            st.session_state["falowen_messages"] = remote_messages
+        else:
+            st.session_state["falowen_messages"] = current_messages
 
         draft_text = load_chat_draft_from_db(student_code, conv_key)
         st.session_state[draft_key] = draft_text


### PR DESCRIPTION
## Summary
- keep the current in-memory chat messages before attempting to load from Firestore
- only replace the local chat history when Firestore returns a list, and clear state when switching to a new conversation key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd74a1ada48321b9491e38540953a8