### PR TITLE
Add umlaut helper to Schreiben inputs

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -7295,6 +7295,8 @@ if tab == "Schreiben Trainer":
             st.session_state[f"{student_code}_last_feedback"] = existing_feedback
             st.session_state[f"{student_code}_last_user_letter"] = existing_letter
 
+        letter_disabled = daily_so_far >= SCHREIBEN_DAILY_LIMIT
+
         user_letter = st.text_area(
             "Paste or type your German letter/essay here.",
             key=draft_key,
@@ -7302,7 +7304,13 @@ if tab == "Schreiben Trainer":
             on_change=lambda: save_now(draft_key, student_code),
             height=400,
             placeholder="Write your German letter here...",
-            disabled=(daily_so_far >= SCHREIBEN_DAILY_LIMIT),
+            disabled=letter_disabled,
+        )
+
+        render_umlaut_pad(
+            draft_key,
+            context=f"schreiben_mark_{student_code}",
+            disabled=letter_disabled,
         )
 
         autosave_maybe(student_code, draft_key, user_letter, min_secs=2.0, min_delta=20)
@@ -7840,6 +7848,12 @@ if tab == "Schreiben Trainer":
                 on_change=lambda: save_now(draft_key, student_code),
             )
 
+            render_umlaut_pad(
+                draft_key,
+                context=f"letter_coach_prompt_{student_code}",
+                disabled=False,
+            )
+
             autosave_maybe(
                 student_code,
                 draft_key,
@@ -7954,6 +7968,12 @@ if tab == "Schreiben Trainer":
                 placeholder="Type your reply, ask about a section, or paste your draft here...",
                 label_visibility="collapsed",
 
+            )
+
+            render_umlaut_pad(
+                draft_key,
+                context=f"letter_coach_chat_{student_code}",
+                disabled=False,
             )
             
             autosave_maybe(


### PR DESCRIPTION
## Summary
- add the shared umlaut helper below the Mark My Letter textarea with matching disabled state
- surface the umlaut helper for Letter Coach prompt and chat drafts so each Schreiben editor exposes umlaut keys

## Testing
- pytest *(fails: tests/test_class_discussion_link.py::test_lesson_includes_class_discussion_button, tests/test_class_discussion_missing_classname.py::test_class_discussion_skips_without_classname, tests/test_load_student_classname.py::test_class_column_variants[Class], tests/test_load_student_classname.py::test_class_column_variants[classname], tests/test_load_student_classname.py::test_class_column_variants[Classroom], tests/test_load_student_classname.py::test_class_column_variants[class_name], tests/test_load_student_classname.py::test_class_column_variants[Group], tests/test_load_student_classname.py::test_class_column_variants[Course], tests/test_load_student_classname.py::test_missing_class_column_raises, tests/test_load_student_data_refresh.py::test_force_refresh_clears_cache)*

------
https://chatgpt.com/codex/tasks/task_e_68cd751aec90832184630aadcb4667b3