### PR TITLE
Add umlaut pad note

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -210,9 +210,11 @@ def render_umlaut_pad(widget_key: str, *, context: str, disabled: bool = False) 
     if markdown_fn is None:
         return
 
+    note = "_Umlaut keys (copy or paste):_"
     parts = ["**Umlaute:**", "ä", "ö", "ü", "ß"]
     separator = " · "
-    body = f"{parts[0]} {separator.join(parts[1:])}"
+    buttons = f"{parts[0]} {separator.join(parts[1:])}"
+    body = f"{note} {buttons}"
 
     if disabled:
         body = f"{body} _(copy only)_"


### PR DESCRIPTION
## Summary
- add a short copy/paste note before the umlaut buttons so learners see the hint before the controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd783ead648321afba294193af3537