### PR TITLE
Add umlaut pad to class board reply composer

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -4954,6 +4954,10 @@ if tab == "My Course":
                         on_change=save_now,
                         args=(draft_key, student_code),
                     )
+                    render_umlaut_pad(
+                        draft_key,
+                        context=f"classboard_reply_{q_id}",
+                    )
 
                     current_text = st.session_state.get(draft_key, "")
                     if not isinstance(current_text, str):


### PR DESCRIPTION
## Summary
- add the umlaut pad helper next to the class board reply textarea so students have quick umlaut shortcuts

## Testing
- pytest tests/test_comment_box_clears.py

------
https://chatgpt.com/codex/tasks/task_e_68cd783b715c8321835511f99cc609c1