### PR TITLE
Reset Falowen turn counter for new chats

### DIFF
--- a/tests/test_turn_count.py
+++ b/tests/test_turn_count.py
@@ -7,8 +7,12 @@ def _load_increment_fn():
         src = f.read()
     mod = ast.parse(src)
     wanted = []
+    target_names = {
+        'increment_turn_count_and_maybe_close',
+        'reset_falowen_chat_flow',
+    }
     for node in mod.body:
-        if isinstance(node, ast.FunctionDef) and node.name == 'increment_turn_count_and_maybe_close':
+        if isinstance(node, ast.FunctionDef) and node.name in target_names:
             wanted.append(node)
     module_ast = ast.Module(body=wanted, type_ignores=[])
     code = compile(module_ast, 'a1sprechen.py', 'exec')
@@ -20,11 +24,16 @@ def _load_increment_fn():
 
     glb = {'st': st, 'generate_summary': dummy_summary}
     exec(code, glb)
-    return glb['increment_turn_count_and_maybe_close'], dummy_summary, st
+    return (
+        glb['increment_turn_count_and_maybe_close'],
+        dummy_summary,
+        st,
+        glb['reset_falowen_chat_flow'],
+    )
 
 
 def test_increment_and_finalize_after_six():
-    inc, dummy, st = _load_increment_fn()
+    inc, dummy, st, _ = _load_increment_fn()
     ss = st.session_state
     ss['falowen_turn_count'] = 5
     ss['falowen_messages'] = [
@@ -40,7 +49,7 @@ def test_increment_and_finalize_after_six():
 
 
 def test_increment_when_below_limit():
-    inc, dummy, st = _load_increment_fn()
+    inc, dummy, st, _ = _load_increment_fn()
     ss = st.session_state
     ss['falowen_turn_count'] = 2
     ss['falowen_messages'] = [{'role': 'user', 'content': 'Hallo'}]
@@ -52,7 +61,7 @@ def test_increment_when_below_limit():
 
 
 def test_no_increment_in_exam_mode():
-    inc, dummy, st = _load_increment_fn()
+    inc, dummy, st, _ = _load_increment_fn()
     ss = st.session_state
     ss['falowen_turn_count'] = 4
     ss['falowen_messages'] = []
@@ -61,3 +70,22 @@ def test_no_increment_in_exam_mode():
     assert ss['falowen_turn_count'] == 4
     assert ss['falowen_messages'] == []
     assert not hasattr(dummy, 'called_with')
+
+
+def test_new_chat_reset_unlocks_after_limit():
+    inc, dummy, st, reset_chat = _load_increment_fn()
+    ss = st.session_state
+    ss['falowen_turn_count'] = 6
+    ss['falowen_messages'] = [{'role': 'user', 'content': 'Hallo'}]
+    ss['custom_topic_intro_done'] = True
+
+    chat_locked = (not False) and ss.get('falowen_turn_count', 0) >= 6
+    assert chat_locked is True
+
+    reset_chat()
+
+    assert ss['falowen_turn_count'] == 0
+    assert ss['falowen_messages'] == []
+    assert ss['custom_topic_intro_done'] is False
+    chat_locked = (not False) and ss.get('falowen_turn_count', 0) >= 6
+    assert chat_locked is False


### PR DESCRIPTION
## Summary
- add a helper to reset Falowen chat bookkeeping and reuse it whenever a new conversation starts
- reset the turn counter when Stage 4 loads or seeds a fresh conversation so the chat unlocks correctly
- extend the turn-count regression test to cover starting a new chat after hitting the limit

## Testing
- pytest tests/test_turn_count.py

------
https://chatgpt.com/codex/tasks/task_e_68cd77495b5883219cb6b89cae50e504