### PR TITLE
Add chat closure flag and update turn count flow

### DIFF
--- a/tests/test_back_step.py
+++ b/tests/test_back_step.py
@@ -41,6 +41,7 @@ def test_back_step_clears_chat_state():
         'falowen_chat_draft_key': 'chat_draft_123',
         'custom_topic_intro_done': True,
         'falowen_turn_count': 5,
+        'falowen_chat_closed': True,
         '__refresh': 0,
     })
     draft_key = ss['falowen_chat_draft_key']
@@ -60,6 +61,7 @@ def test_back_step_clears_chat_state():
         'falowen_messages',
         'falowen_loaded_key', 'falowen_conv_key',
         'falowen_chat_draft_key', 'custom_topic_intro_done',
-        'falowen_turn_count', draft_key, *_draft_state_keys(draft_key)
+        'falowen_turn_count', 'falowen_chat_closed',
+        draft_key, *_draft_state_keys(draft_key)
     ]:
         assert key not in ss


### PR DESCRIPTION
## Summary
- add a dedicated `falowen_chat_closed` flag and wire it into the turn counter, resets, and history deletion logic
- keep the custom chat input enabled until the assistant posts its closing summary and surface a restart button afterwards
- refresh the turn-count unit tests to assert the new flag behaviour and guard against duplicate summaries

## Testing
- pytest tests/test_turn_count.py tests/test_back_step.py

------
https://chatgpt.com/codex/tasks/task_e_68cd7b64a2948321a67cf725f1ecec59