### PR TITLE
Add toast-free rerun helper and use it in Falowen navigation

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -326,7 +326,7 @@ from src.contracts import (
 )
 from src.services.contracts import contract_active
 from src.utils.currency import format_cedis
-from src.utils.toasts import toast_ok, refresh_with_toast, toast_once
+from src.utils.toasts import toast_ok, refresh_with_toast, toast_once, rerun_without_toast
 from src.firestore_utils import (
     _draft_doc_ref,
     load_chat_draft_from_db,
@@ -5422,7 +5422,7 @@ def back_step():
             st.session_state.pop(extra, None)
     st.session_state["_falowen_loaded"] = False
     st.session_state["falowen_stage"] = 1
-    refresh_with_toast()
+    rerun_without_toast()
 
 # --- CONFIG (same doc, no duplicate db init) ---
 exam_sheet_id = "1zaAT5NjRGKiITV7EpuSHvYMBHHENMs9Piw3pNcyQtho"
@@ -5924,7 +5924,7 @@ if tab == "Exams Mode & Custom Chat":
                     st.session_state["falowen_stage"] = 3 if mode == "Exams Mode" else 4
                     st.session_state["falowen_teil"] = None
                     reset_falowen_chat_flow()
-                    refresh_with_toast()
+                    rerun_without_toast()
 
 
 
@@ -5946,14 +5946,14 @@ if tab == "Exams Mode & Custom Chat":
                 st.session_state.pop("falowen_level_center", None)
                 st.session_state["falowen_messages"] = []
                 st.session_state["_falowen_loaded"] = False
-                refresh_with_toast()
+                rerun_without_toast()
         with col2:
             if st.button("Next ➡️", key="falowen_next_level"):
                 if st.session_state.get("falowen_level"):
                     st.session_state["falowen_stage"] = 3 if st.session_state["falowen_mode"] == "Exams Mode" else 4
                     st.session_state["falowen_teil"] = None
                     reset_falowen_chat_flow()
-                    refresh_with_toast()
+                    rerun_without_toast()
         st.stop()
 
     # ——— Step 3: Exam Part or Lesen/Hören links ———
@@ -6016,7 +6016,7 @@ if tab == "Exams Mode & Custom Chat":
             if st.button("⬅️ Back", key="lesen_hoeren_back"):
                 st.session_state["falowen_stage"] = 2
                 st.session_state["falowen_messages"] = []
-                refresh_with_toast()
+                rerun_without_toast()
 
         else:
             # Topic picker (your format: "Topic/Prompt" + "Keyword/Subtopic")
@@ -6076,7 +6076,7 @@ if tab == "Exams Mode & Custom Chat":
                 if st.button("⬅️ Back", key="falowen_back_part"):
                     st.session_state["falowen_stage"]    = 2
                     st.session_state["falowen_messages"] = []
-                    refresh_with_toast()
+                    rerun_without_toast()
             with col_start:
                 start_disabled = not topic
                 if st.button("Start Practice", key="falowen_start_practice", disabled=start_disabled) and topic:
@@ -6088,7 +6088,7 @@ if tab == "Exams Mode & Custom Chat":
                         student_code,
                         [{"level": level, "teil": teil, "topic": topic}],
                     )
-                    refresh_with_toast()
+                    rerun_without_toast()
 
             if not topic:
                 st.warning("Please select a topic before starting your practice session.")

--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -73,6 +73,12 @@ def toast_info(msg: str) -> None:
     st.toast(msg, icon="ℹ️")
 
 
+def rerun_without_toast() -> None:
+    """Increment ``__refresh`` and flag a rerun without notifying the user."""
+    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+    st.session_state["need_rerun"] = True
+
+
 def refresh_with_toast(msg: str = "Saved!") -> None:
     """Increment ``__refresh`` and show a saved toast.
 
@@ -85,6 +91,5 @@ def refresh_with_toast(msg: str = "Saved!") -> None:
     msg:
         The message to display in the success toast. Defaults to ``"Saved!"``.
     """
-    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
-    st.session_state["need_rerun"] = True
+    rerun_without_toast()
     toast_ok(msg)

--- a/tests/test_back_step.py
+++ b/tests/test_back_step.py
@@ -1,5 +1,6 @@
 import ast
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from src.draft_management import _draft_state_keys
 from src.utils import toasts
@@ -14,12 +15,12 @@ def _load_back_step():
     ]
     module_ast = ast.Module(body=funcs, type_ignores=[])
     code = compile(module_ast, "a1sprechen.py", "exec")
-    st = SimpleNamespace(session_state={}, toast=lambda *a, **k: None)
+    st = SimpleNamespace(session_state={}, toast=MagicMock())
     toasts.st = st
     glb = {
         "st": st,
         "_draft_state_keys": _draft_state_keys,
-        "refresh_with_toast": toasts.refresh_with_toast,
+        "rerun_without_toast": toasts.rerun_without_toast,
     }
     exec(code, glb)
     return glb["back_step"], st
@@ -53,6 +54,8 @@ def test_back_step_clears_chat_state():
     assert ss['falowen_stage'] == 1
     assert ss['_falowen_loaded'] is False
     assert ss['__refresh'] == 1
+    assert ss['need_rerun'] is True
+    st.toast.assert_not_called()
 
     for key in [
         'falowen_mode', 'falowen_level', 'falowen_teil',

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -32,6 +32,15 @@ def test_toast_info(monkeypatch):
     mock_st.toast.assert_called_once_with("note", icon="ℹ️")
 
 
+def test_rerun_without_toast(monkeypatch):
+    mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
+    monkeypatch.setattr(toasts, "st", mock_st)
+    toasts.rerun_without_toast()
+    mock_st.toast.assert_not_called()
+    assert mock_st.session_state["__refresh"] == 1
+    assert mock_st.session_state["need_rerun"] is True
+
+
 def test_refresh_with_toast(monkeypatch):
     mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
     monkeypatch.setattr(toasts, "st", mock_st)


### PR DESCRIPTION
## Summary
- add a `rerun_without_toast` helper that bumps the refresh flags without emitting a toast and reuse it inside `refresh_with_toast`
- update Falowen navigation actions to trigger the toast-free rerun when switching steps or starting practice
- expand unit tests to cover the new helper and ensure navigation backtracking doesn't emit a toast

## Testing
- pytest tests/test_back_step.py tests/test_toasts.py

------
https://chatgpt.com/codex/tasks/task_e_68cd7eff6af083218c3f89fabbe957f0