### PR TITLE
Adjust chat draft navigation toasts

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -326,7 +326,7 @@ from src.contracts import (
 )
 from src.services.contracts import contract_active
 from src.utils.currency import format_cedis
-from src.utils.toasts import toast_ok, refresh_with_toast, toast_once
+from src.utils.toasts import toast_ok, refresh_with_toast, toast_once, request_rerun
 from src.firestore_utils import (
     _draft_doc_ref,
     load_chat_draft_from_db,
@@ -5422,7 +5422,7 @@ def back_step():
             st.session_state.pop(extra, None)
     st.session_state["_falowen_loaded"] = False
     st.session_state["falowen_stage"] = 1
-    refresh_with_toast()
+    request_rerun()
 
 # --- CONFIG (same doc, no duplicate db init) ---
 exam_sheet_id = "1zaAT5NjRGKiITV7EpuSHvYMBHHENMs9Piw3pNcyQtho"
@@ -5934,7 +5934,7 @@ if tab == "Exams Mode & Custom Chat":
                     st.session_state["falowen_stage"] = 3 if mode == "Exams Mode" else 4
                     st.session_state["falowen_teil"] = None
                     reset_falowen_chat_flow()
-                    refresh_with_toast()
+                    request_rerun()
 
 
 
@@ -5956,14 +5956,14 @@ if tab == "Exams Mode & Custom Chat":
                 st.session_state.pop("falowen_level_center", None)
                 st.session_state["falowen_messages"] = []
                 st.session_state["_falowen_loaded"] = False
-                refresh_with_toast()
+                request_rerun()
         with col2:
             if st.button("Next ➡️", key="falowen_next_level"):
                 if st.session_state.get("falowen_level"):
                     st.session_state["falowen_stage"] = 3 if st.session_state["falowen_mode"] == "Exams Mode" else 4
                     st.session_state["falowen_teil"] = None
                     reset_falowen_chat_flow()
-                    refresh_with_toast()
+                    request_rerun()
         st.stop()
 
     # ——— Step 3: Exam Part or Lesen/Hören links ———
@@ -6026,7 +6026,7 @@ if tab == "Exams Mode & Custom Chat":
             if st.button("⬅️ Back", key="lesen_hoeren_back"):
                 st.session_state["falowen_stage"] = 2
                 st.session_state["falowen_messages"] = []
-                refresh_with_toast()
+                request_rerun()
 
         else:
             # Topic picker (your format: "Topic/Prompt" + "Keyword/Subtopic")
@@ -6086,7 +6086,7 @@ if tab == "Exams Mode & Custom Chat":
                 if st.button("⬅️ Back", key="falowen_back_part"):
                     st.session_state["falowen_stage"]    = 2
                     st.session_state["falowen_messages"] = []
-                    refresh_with_toast()
+                    request_rerun()
             with col_start:
                 start_disabled = not topic
                 if st.button("Start Practice", key="falowen_start_practice", disabled=start_disabled) and topic:
@@ -6248,7 +6248,7 @@ if tab == "Exams Mode & Custom Chat":
         col_in, col_btn = st.columns([8, 1])
         if st.session_state.pop("falowen_clear_draft", False):
             st.session_state[draft_key] = ""
-            save_now(draft_key, student_code)
+            save_now(draft_key, student_code, show_toast=False)
         with col_in:
             st.text_area(
                 "Type your answer...",
@@ -6404,7 +6404,7 @@ if tab == "Exams Mode & Custom Chat":
                     refresh_with_toast()
         with col2:
             if st.button("⬅️ Back", key=_wkey("btn_back_stage4")):
-                save_now(draft_key, student_code)
+                save_now(draft_key, student_code, show_toast=False)
                 back_step()
 
         st.divider()

--- a/src/draft_management.py
+++ b/src/draft_management.py
@@ -36,7 +36,7 @@ def _draft_state_keys(draft_key: str) -> Tuple[str, str, str, str]:
     )
 
 
-def save_now(draft_key: str, code: str) -> None:
+def save_now(draft_key: str, code: str, *, show_toast: bool = True) -> None:
     """Immediately persist the draft associated with ``draft_key``."""
     text = st.session_state.get(draft_key, "") or ""
     if st.session_state.get("falowen_chat_draft_key") == draft_key:
@@ -52,7 +52,8 @@ def save_now(draft_key: str, code: str) -> None:
     st.session_state[last_ts_key] = time.time()
     st.session_state[saved_flag_key] = True
     st.session_state[saved_at_key] = datetime.now(_timezone.utc)
-    toast_ok("Saved!")
+    if show_toast:
+        toast_ok("Saved!")
 
 
 def autosave_maybe(

--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -73,6 +73,13 @@ def toast_info(msg: str) -> None:
     st.toast(msg, icon="ℹ️")
 
 
+def request_rerun() -> None:
+    """Flag the next Streamlit run without displaying a toast."""
+
+    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
+    st.session_state["need_rerun"] = True
+
+
 def refresh_with_toast(msg: str = "Saved!") -> None:
     """Increment ``__refresh`` and show a saved toast.
 
@@ -85,6 +92,5 @@ def refresh_with_toast(msg: str = "Saved!") -> None:
     msg:
         The message to display in the success toast. Defaults to ``"Saved!"``.
     """
-    st.session_state["__refresh"] = st.session_state.get("__refresh", 0) + 1
-    st.session_state["need_rerun"] = True
+    request_rerun()
     toast_ok(msg)

--- a/tests/test_back_step.py
+++ b/tests/test_back_step.py
@@ -19,7 +19,7 @@ def _load_back_step():
     glb = {
         "st": st,
         "_draft_state_keys": _draft_state_keys,
-        "refresh_with_toast": toasts.refresh_with_toast,
+        "request_rerun": toasts.request_rerun,
     }
     exec(code, glb)
     return glb["back_step"], st


### PR DESCRIPTION
## Summary
- add an optional `show_toast` flag to `save_now` so non-saving flows can suppress the success toast
- introduce a `request_rerun` helper and switch the chat setup back buttons to use it for toast-free navigation reruns
- update the chat workflow and `back_step` test harness to use the new helpers when clearing or navigating away

## Testing
- pytest *(fails: test_class_discussion_link.py::test_lesson_includes_class_discussion_button, test_class_discussion_missing_classname.py::test_class_discussion_skips_without_classname, tests/test_load_student_classname.py::test_class_column_variants[Class|classname|Classroom|class_name|Group|Course], tests/test_load_student_classname.py::test_missing_class_column_raises, tests/test_load_student_data_refresh.py::test_force_refresh_clears_cache)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7f22c28c83218a0732d0d0306958