### PR TITLE
Fix typing annotations for Python 3.8

### DIFF
--- a/src/assignment.py
+++ b/src/assignment.py
@@ -3,10 +3,12 @@
 import html
 import re
 import urllib.parse
+from typing import Union
+
 import pandas as pd
 
 
-def linkify_html(text: str | float | None) -> str:
+def linkify_html(text: Union[str, float, None]) -> str:
     """Escape HTML and convert URLs in plain text to anchor tags."""
     s = "" if text is None or (isinstance(text, float) and pd.isna(text)) else str(text)
     s = html.escape(s)
@@ -17,7 +19,7 @@ def linkify_html(text: str | float | None) -> str:
     )
     return s
 
-def _clean_link(val: str | float | None) -> str:
+def _clean_link(val: Union[str, float, None]) -> str:
     """Return a clean string or '' if empty/NaN/common placeholders."""
     if val is None:
         return ""
@@ -26,7 +28,7 @@ def _clean_link(val: str | float | None) -> str:
     s = str(val).strip()
     return "" if s.lower() in {"", "nan", "none", "null", "0"} else s
 
-def _is_http_url(s: str | float | None) -> bool:
+def _is_http_url(s: Union[str, float, None]) -> bool:
     try:
         u = urllib.parse.urlparse(str(s))
         return u.scheme in ("http", "https") and bool(u.netloc)

--- a/src/firestore_utils.py
+++ b/src/firestore_utils.py
@@ -13,7 +13,7 @@ re-used outside the monolithic :mod:`a1sprechen` module.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import logging
 import re
@@ -33,7 +33,7 @@ try:  # pragma: no cover - schedule/streamlit may be unavailable in some tests
         }
     )
 except Exception:  # pragma: no cover - best effort for offline tests
-    CANONICAL_LABELS: list[str] = []
+    CANONICAL_LABELS: List[str] = []
 
 
 def normalize_label(label: str) -> str:
@@ -386,7 +386,7 @@ def save_response(post_id: str, text: str, responder_code: str) -> None:
         logging.warning("Failed to save response for %s: %s", post_id, exc)
 
 
-def fetch_attendance_summary(student_code: str, class_name: str) -> tuple[int, float]:
+def fetch_attendance_summary(student_code: str, class_name: str) -> Tuple[int, float]:
     """Return ``(sessions, hours)`` attended by ``student_code`` in ``class_name``.
 
     The data is expected under ``attendance/{class_name}/sessions`` where each

--- a/src/keychain.py
+++ b/src/keychain.py
@@ -8,6 +8,7 @@ Swift functions using ``subprocess`` and provides Python-friendly wrappers.
 
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 import json
 import subprocess
 from shutil import which
@@ -46,7 +47,7 @@ def _run_swift(snippet: str) -> None:
         pass
 
 
-def _run_swift_capture(snippet: str) -> str | None:
+def _run_swift_capture(snippet: str) -> Optional[str]:
     """Execute Swift code and return its stdout."""
 
     if not _SWIFT_BIN or not _SWIFT_HELPER.exists():
@@ -84,7 +85,7 @@ def delete_token(key: KeychainKey) -> None:
     _run_swift(snippet)
 
 
-def get_token(key: KeychainKey) -> str | None:
+def get_token(key: KeychainKey) -> Optional[str]:
     """Fetch a token from the platform keychain."""
 
     snippet = f"""

--- a/src/schedule.py
+++ b/src/schedule.py
@@ -1,11 +1,12 @@
 """Course schedule utilities."""
 from __future__ import annotations
 
+from typing import Dict, List
 import re
 import streamlit as st
 
 
-def _strip_topic_chapter(schedule: list[dict]) -> list[dict]:
+def _strip_topic_chapter(schedule: List[Dict[str, object]]) -> List[Dict[str, object]]:
     """Remove trailing chapter references from lesson topics.
 
     Some schedule entries duplicate the chapter number in the ``topic`` field

--- a/src/services/vocab.py
+++ b/src/services/vocab.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 import pandas as pd
 import streamlit as st
@@ -12,7 +12,7 @@ DEFAULT_SHEET_ID = "1I1yAnqzSh3DPjwWRh9cdRSfzNSPsi7o4r5Taj9Y36NU"
 DEFAULT_SHEET_GID = 0  # <-- change this if your Vocab tab uses another gid
 
 
-def _lookup_secret(*keys: str) -> str | int | None:
+def _lookup_secret(*keys: str) -> Union[str, int, None]:
     """Return the first matching value from ``st.secrets`` for ``keys``."""
 
     secrets = getattr(st, "secrets", None)
@@ -29,7 +29,7 @@ def _lookup_secret(*keys: str) -> str | int | None:
     return None
 
 
-def _coerce_gid(raw_value: str | int | None) -> int:
+def _coerce_gid(raw_value: Union[str, int, None]) -> int:
     """Convert a user-provided gid to an ``int`` or fall back to the default."""
 
     if raw_value in (None, ""):

--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
-from typing import Optional
+from typing import Dict, Optional
 import urllib.parse as _urllib
 import secrets
 import urllib.parse
@@ -75,7 +75,9 @@ def _normalize_roster(df):
     return df
 
 
-def _refresh_logged_in_student_row(student_row: dict | None = None) -> None:
+def _refresh_logged_in_student_row(
+    student_row: Optional[Dict[str, object]] = None,
+) -> None:
     """Force-refresh the roster and update the cached ``student_row`` once."""
 
     roster_flag = st.session_state.setdefault("roster_refreshed", True)

--- a/src/ui/login.py
+++ b/src/ui/login.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
+from typing import Dict
 from functools import lru_cache
 
 import streamlit as st
@@ -133,7 +134,7 @@ def render_falowen_login(
         from types import SimpleNamespace
         from .. import ui_widgets
 
-        captured: dict[str, str] = {}
+        captured: Dict[str, str] = {}
 
         def _capture(markup: str, **_: object) -> None:
             captured["html"] = markup

--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 import streamlit as st
 
 
@@ -5,7 +7,7 @@ _RECENT_TOASTS_KEY = "__recent_toasts__"
 
 
 def _already_toasted(msg: str) -> bool:
-    shown: set[str] = st.session_state.setdefault(_RECENT_TOASTS_KEY, set())
+    shown: Set[str] = st.session_state.setdefault(_RECENT_TOASTS_KEY, set())
     if msg in shown:
         return True
     shown.add(msg)


### PR DESCRIPTION
## Summary
- replace built-in generic annotations with typing.List/Dict/Set/Tuple to ensure modules import under Python 3.8
- convert PEP 604 union syntax to typing.Optional/Union equivalents across auth, assignment, keychain, and related utilities
- update startup modules to import the typing helpers now used in their annotations

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cd8a63869c8321807dfdfa73db0bbd