### PR TITLE
Clear Falowen draft via flag before textarea

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6138,8 +6138,8 @@ if tab == "Exams Mode & Custom Chat":
         if user_input:
             # 1) Show student's message immediately
             st.session_state["falowen_messages"].append({"role": "user", "content": user_input})
-            # 2) Clear textarea
-            st.session_state[draft_key] = ""
+            # 2) Clear textarea on next render
+            st.session_state["falowen_clear_draft"] = True
             # 3) OpenAI reply
             with st.spinner("🧑‍🏫 Herr Felix is typing..."):
                 messages = [{"role": "system", "content": system_prompt}] + st.session_state["falowen_messages"]


### PR DESCRIPTION
## Summary
- set a session flag when sending so the draft field clears before the textarea renders
- rely on the pre-render clearing block instead of mutating the textarea value after creation

## Testing
- not run (explain why)

------
https://chatgpt.com/codex/tasks/task_e_68cd93f2f4d08321aaaa21249ed6da4d