### PR TITLE
Reorder chat display before input controls

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -314,6 +314,28 @@ def render_chat_stage(
         doc_data=session.doc_data,
     )
 
+    chat_display = st.container()
+
+    def _render_chat_messages(container):
+        with container:
+            for msg in st.session_state.get("falowen_messages", []):
+                if msg.get("role") == "assistant":
+                    with st.chat_message("assistant", avatar="🧑‍🏫"):
+                        st.markdown(
+                            "<span style='color:#cddc39;font-weight:bold'>🧑‍🏫 Herr Felix:</span><br>"
+                            f"<div style='{bubble_assistant}'>{highlight_keywords(msg.get('content', ''), highlight_words)}</div>",
+                            unsafe_allow_html=True,
+                        )
+                else:
+                    with st.chat_message("user"):
+                        st.markdown(
+                            "<div style='display:flex;justify-content:flex-end;'>"
+                            f"<div style='{bubble_user}'>🗣️ {msg.get('content', '')}</div></div>",
+                            unsafe_allow_html=True,
+                        )
+
+    _render_chat_messages(chat_display)
+
     _render_recorder_button(key_fn, student_code)
 
     if is_exam:
@@ -379,23 +401,8 @@ def render_chat_stage(
             doc_data=session.doc_data,
         )
 
-    chat_display = st.container()
-    with chat_display:
-        for msg in st.session_state.get("falowen_messages", []):
-            if msg.get("role") == "assistant":
-                with st.chat_message("assistant", avatar="🧑‍🏫"):
-                    st.markdown(
-                        "<span style='color:#cddc39;font-weight:bold'>🧑‍🏫 Herr Felix:</span><br>"
-                        f"<div style='{bubble_assistant}'>{highlight_keywords(msg.get('content', ''), highlight_words)}</div>",
-                        unsafe_allow_html=True,
-                    )
-            else:
-                with st.chat_message("user"):
-                    st.markdown(
-                        "<div style='display:flex;justify-content:flex-end;'>"
-                        f"<div style='{bubble_user}'>🗣️ {msg.get('content', '')}</div></div>",
-                        unsafe_allow_html=True,
-                    )
+        refreshed_chat_display = chat_display.empty()
+        _render_chat_messages(refreshed_chat_display)
 
     teil_str = str(teil) if teil else "chat"
     pdf_bytes = generate_chat_pdf(st.session_state.get("falowen_messages", []))


### PR DESCRIPTION
## Summary
- render the chat message container before the recorder and input areas so history shows above the controls
- reuse a helper to refresh the chat container after new messages are persisted

## Testing
- timeout 5 streamlit run a1sprechen.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68cda8af2fac8321b4d013f16a6b0114