### PR TITLE
Keep custom chat active after turn limit

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -33,6 +33,7 @@ def reset_falowen_chat_flow(*, clear_messages: bool = True, clear_intro: bool = 
         st.session_state["custom_topic_intro_done"] = False
     st.session_state["falowen_turn_count"] = 0
     st.session_state["falowen_chat_closed"] = False
+    st.session_state.pop("falowen_summary_emitted", None)
 
 
 def back_step() -> None:
@@ -50,6 +51,7 @@ def back_step() -> None:
         "custom_topic_intro_done",
         "falowen_turn_count",
         "falowen_chat_closed",
+        "falowen_summary_emitted",
     ]:
         st.session_state.pop(key, None)
     if draft_key:


### PR DESCRIPTION
## Summary
- avoid closing custom chats at the turn cap while still emitting a single summary via a new session flag
- keep the custom input controls enabled regardless of turn count
- expand turn-count tests to cover the unlocked flow and summary emission tracking

## Testing
- pytest tests/test_turn_count.py

------
https://chatgpt.com/codex/tasks/task_e_68cdaae0e57c83218ab1789fb7d9cac4