### PR TITLE
Reposition recorder button above chat log

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -313,6 +313,7 @@ def render_chat_stage(
         doc_data=session.doc_data,
     )
 
+    recorder_display = st.container()
     chat_display = st.container()
 
     def _render_chat_messages(container):
@@ -333,9 +334,10 @@ def render_chat_stage(
                             unsafe_allow_html=True,
                         )
 
-    _render_chat_messages(chat_display)
+    with recorder_display:
+        _render_recorder_button(key_fn, student_code)
 
-    _render_recorder_button(key_fn, student_code)
+    _render_chat_messages(chat_display)
 
     if is_exam:
         input_result = _render_exam_input_area(


### PR DESCRIPTION
## Summary
- render the recorder call-to-action before the chat message container so it stays at the top of the chat UI
- reuse the existing recorder helper only in the new location to avoid duplicate buttons

## Testing
- streamlit run a1sprechen.py --server.port=8501 --server.address=0.0.0.0 *(fails: missing OpenAI API key in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb4b761dc8321a4af887019d206bf