### PR TITLE
Remove custom chat autorefresh

### DIFF
--- a/src/falowen/custom_chat.py
+++ b/src/falowen/custom_chat.py
@@ -159,12 +159,6 @@ def render_custom_chat_input(
                 min_delta=12,
                 locked=chat_locked,
             )
-        try:  # pragma: no cover - optional dependency
-            from streamlit_autorefresh import st_autorefresh
-
-            st_autorefresh(interval=2000, key=widget_key("chat_autosave"))
-        except Exception:
-            pass
         with col_btn:
             send_clicked = st.button(
                 "Send",


### PR DESCRIPTION
## Summary
- remove the unconditional `st_autorefresh` call from the Falowen custom chat input so typing no longer triggers reruns

## Testing
- `pytest` *(fails: existing class discussion/data loading tests unrelated to chat input require additional data mocking)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb303c3fc8321879d07f7796b95a8