### PR TITLE
Simplify post-chat actions

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -420,7 +420,7 @@ def render_chat_stage(
         mime="application/pdf",
         key=key_fn("dl_chat_pdf"),
     )
-    col1, col2, col3 = st.columns(3)
+    col1, col2 = st.columns(2)
     with col1:
         if st.button("🗑️ Delete All Chat History", key=key_fn("btn_delete_history")):
             if db is not None:
@@ -445,10 +445,6 @@ def render_chat_stage(
                     st.session_state["falowen_stage"] = 1
                     rerun_without_toast()
     with col2:
-        if st.button("🔁 Reset Chat", key=key_fn("reset_chat")):
-            reset_falowen_chat_flow()
-            rerun_without_toast()
-    with col3:
         if st.button("⬅️ Back", key=key_fn("btn_back_stage4")):
             save_now(session.draft_key, student_code)
             back_step()


### PR DESCRIPTION
## Summary
- update the chat actions layout to display only delete history and back buttons
- remove the reset chat button from the post-chat controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdbc24e5f0832187c1da74c7c0eaf7