### PR TITLE
Reset custom chat draft immediately after send

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -374,7 +374,22 @@ def render_chat_stage(
             {"role": "user", "content": input_result.user_input}
         )
         if not use_chat_input:
-            st.session_state["falowen_clear_draft"] = True
+            st.session_state[session.draft_key] = ""
+            autosave_maybe(
+                student_code,
+                session.draft_key,
+                st.session_state[session.draft_key],
+                min_secs=0.0,
+                min_delta=0,
+                locked=chat_locked,
+            )
+            last_val_key, last_ts_key, saved_flag_key, saved_at_key = _draft_state_keys(
+                session.draft_key
+            )
+            st.session_state[last_val_key] = ""
+            st.session_state[last_ts_key] = time.time()
+            st.session_state[saved_flag_key] = True
+            st.session_state[saved_at_key] = datetime.now(_timezone.utc)
 
         with status_placeholder:
             with st.spinner("🧑‍🏫 Herr Felix is typing…"):


### PR DESCRIPTION
## Summary
- clear the custom chat draft immediately after a message is submitted when the text area is in use
- reuse autosave helpers to persist the cleared draft without triggering extra saved toasts

## Testing
- pytest *(fails: known baseline test failures in class discussion and roster loading suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbd12e5e48321adcd66067a95a7bc