### PR TITLE
Show user bubble immediately in Falowen chat

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -315,6 +315,7 @@ def render_chat_stage(
 
     recorder_display = st.container()
     chat_display = st.container()
+    chat_placeholder = chat_display.empty()
     status_display = st.container()
     status_placeholder = status_display.empty()
 
@@ -339,7 +340,7 @@ def render_chat_stage(
     with recorder_display:
         _render_recorder_button(key_fn, student_code)
 
-    _render_chat_messages(chat_display)
+    _render_chat_messages(chat_placeholder)
 
     if is_exam:
         input_result = _render_exam_input_area(
@@ -376,6 +377,9 @@ def render_chat_stage(
         if not use_chat_input:
             st.session_state["falowen_clear_draft"] = True
 
+        chat_placeholder.empty()
+        _render_chat_messages(chat_placeholder)
+
         with status_placeholder:
             with st.spinner("🧑‍🏫 Herr Felix is typing…"):
                 payload = [{"role": "system", "content": system_prompt}] + st.session_state["falowen_messages"]
@@ -393,6 +397,8 @@ def render_chat_stage(
         status_placeholder.empty()
 
         st.session_state["falowen_messages"].append({"role": "assistant", "content": ai_reply})
+        chat_placeholder.empty()
+        _render_chat_messages(chat_placeholder)
         if not is_exam:
             custom_chat.increment_turn_count_and_maybe_close(False)
         else:
@@ -407,9 +413,9 @@ def render_chat_stage(
             doc_data=session.doc_data,
         )
 
-        refreshed_chat_display = chat_display.empty()
+        chat_placeholder = chat_display.empty()
         status_placeholder = status_display.empty()
-        _render_chat_messages(refreshed_chat_display)
+        _render_chat_messages(chat_placeholder)
 
     teil_str = str(teil) if teil else "chat"
     pdf_bytes = generate_chat_pdf(st.session_state.get("falowen_messages", []))


### PR DESCRIPTION
## Summary
- render chat messages through a persistent placeholder so the feed can refresh in place
- rerender immediately after adding the user prompt and again when the assistant reply arrives

## Testing
- pytest *(fails: existing failures in tests/test_class_discussion_link.py::test_lesson_includes_class_discussion_button, tests/test_class_discussion_missing_classname.py::test_class_discussion_skips_without_classname, tests/test_load_student_classname.py::test_class_column_variants[Class], tests/test_load_student_classname.py::test_class_column_variants[classname], tests/test_load_student_classname.py::test_class_column_variants[Classroom], tests/test_load_student_classname.py::test_class_column_variants[class_name], tests/test_load_student_classname.py::test_class_column_variants[Group], tests/test_load_student_classname.py::test_class_column_variants[Course], tests/test_load_student_classname.py::test_missing_class_column_raises, tests/test_load_student_data_refresh.py::test_force_refresh_clears_cache)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbd425640832198e9ae0338095a99