### PR TITLE
Reuse stored Falowen chats when available

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -94,12 +94,22 @@ def prepare_chat_session(
 
     conv_key = st.session_state.get("falowen_conv_key")
     fresh_chat = False
-    if not conv_key or not str(conv_key).startswith(f"{mode_level_teil}_"):
+    prefix = f"{mode_level_teil}_"
+
+    def _matches_prefix(value: Any) -> bool:
+        return bool(value) and str(value).startswith(prefix)
+
+    if not _matches_prefix(conv_key):
         conv_key = (doc_data.get("current_conv", {}) or {}).get(mode_level_teil)
-        if not conv_key or not str(conv_key).startswith(f"{mode_level_teil}_"):
+        if not _matches_prefix(conv_key):
             drafts = (doc_data.get("drafts", {}) or {})
-            conv_key = next((k for k in drafts if str(k).startswith(f"{mode_level_teil}_")), None)
-        if not conv_key:
+            conv_key = next((k for k in drafts if _matches_prefix(k)), None)
+        if not _matches_prefix(conv_key):
+            chats = (doc_data.get("chats", {}) or {})
+            matching_chats = [k for k in chats if _matches_prefix(k)]
+            if matching_chats:
+                conv_key = matching_chats[-1]
+        if not _matches_prefix(conv_key):
             conv_key = f"{mode_level_teil}_{uuid4().hex[:8]}"
             fresh_chat = True
         if doc_ref is not None:

--- a/tests/test_prepare_chat_session.py
+++ b/tests/test_prepare_chat_session.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+
+from src.falowen import chat_core
+
+
+class FakeSnapshot:
+    def __init__(self, data):
+        self._data = data
+        self.exists = True
+
+    def to_dict(self):
+        return self._data
+
+
+class FakeDocRef:
+    def __init__(self, data):
+        self._data = data
+        self.set_calls = []
+
+    def get(self):
+        return FakeSnapshot(self._data)
+
+    def set(self, payload, merge=False):
+        self.set_calls.append((payload, merge))
+
+
+class FakeDB:
+    def __init__(self, data):
+        self._data = data
+        self.doc_ref = FakeDocRef(data)
+
+    def collection(self, name):
+        assert name == "falowen_chats"
+        return self
+
+    def document(self, student_code):
+        self.doc_ref.student_code = student_code
+        return self.doc_ref
+
+
+def test_prepare_chat_session_reuses_existing_chat(monkeypatch):
+    st = SimpleNamespace(session_state={})
+    st.session_state["student_code"] = "stu1"
+    monkeypatch.setattr(chat_core, "st", st)
+    monkeypatch.setattr(chat_core, "load_chat_draft_from_db", lambda *args, **kwargs: "")
+
+    existing_key = "Chat Mode_A1_custom_deadbeef"
+    stored_messages = [{"role": "assistant", "content": "Hallo"}]
+    doc_data = {"chats": {existing_key: stored_messages}}
+    fake_db = FakeDB(doc_data)
+
+    session = chat_core.prepare_chat_session(
+        db=fake_db,
+        student_code="stu1",
+        mode="Chat Mode",
+        level="A1",
+        teil=None,
+    )
+
+    assert session.conv_key == existing_key
+    assert st.session_state["falowen_messages"] == stored_messages
+    assert set(doc_data["chats"].keys()) == {existing_key}
+    assert fake_db.doc_ref.set_calls
+    payload, merge = fake_db.doc_ref.set_calls[-1]
+    assert payload == {"current_conv": {"Chat Mode_A1_custom": existing_key}}
+    assert merge is True


### PR DESCRIPTION
## Summary
- reuse existing Falowen conversation keys by checking stored chat transcripts before minting new ids
- load stored messages into the chat session state when resuming a saved conversation
- add a regression test covering chat history reuse

## Testing
- pytest tests/test_prepare_chat_session.py

------
https://chatgpt.com/codex/tasks/task_e_68cdd8c056508321acb878b43b4db46e