### PR TITLE
Improve prepare_chat_session fallback selection

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -106,9 +106,20 @@ def prepare_chat_session(
             conv_key = next((k for k in drafts if _matches_prefix(k)), None)
         if not _matches_prefix(conv_key):
             chats = (doc_data.get("chats", {}) or {})
-            matching_chats = [k for k in chats if _matches_prefix(k)]
-            if matching_chats:
-                conv_key = matching_chats[-1]
+
+            def _message_count(value: Any) -> int:
+                if isinstance(value, list):
+                    return len(value)
+                return 0
+
+            matching_chat_entries = [
+                (key, chats[key]) for key in chats if _matches_prefix(key)
+            ]
+            if matching_chat_entries:
+                conv_key = max(
+                    matching_chat_entries,
+                    key=lambda item: (_message_count(item[1]), item[0]),
+                )[0]
         if not _matches_prefix(conv_key):
             conv_key = f"{mode_level_teil}_{uuid4().hex[:8]}"
             fresh_chat = True

--- a/tests/test_prepare_chat_session.py
+++ b/tests/test_prepare_chat_session.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from src.falowen import chat_core
 
 
@@ -38,6 +40,29 @@ class FakeDB:
         return self.doc_ref
 
 
+@pytest.fixture
+def multiple_chat_doc_data():
+    populated_key = "Chat Mode_A1_custom_f00dbabe"
+    sparse_key = "Chat Mode_A1_custom_00c0ffee"
+    extra_key = "Chat Mode_B1_custom_deadbeef"
+    doc_data = {
+        "chats": {
+            sparse_key: [
+                {"role": "assistant", "content": "Hallo"},
+            ],
+            populated_key: [
+                {"role": "assistant", "content": "Hallo"},
+                {"role": "user", "content": "Guten Tag"},
+                {"role": "assistant", "content": "Wie geht's?"},
+            ],
+            extra_key: [
+                {"role": "assistant", "content": "Should not match"},
+            ],
+        }
+    }
+    return doc_data, populated_key, sparse_key
+
+
 def test_prepare_chat_session_reuses_existing_chat(monkeypatch):
     st = SimpleNamespace(session_state={})
     st.session_state["student_code"] = "stu1"
@@ -63,4 +88,86 @@ def test_prepare_chat_session_reuses_existing_chat(monkeypatch):
     assert fake_db.doc_ref.set_calls
     payload, merge = fake_db.doc_ref.set_calls[-1]
     assert payload == {"current_conv": {"Chat Mode_A1_custom": existing_key}}
+    assert merge is True
+
+
+def test_prepare_chat_session_prefers_most_populated_history(
+    monkeypatch, multiple_chat_doc_data
+):
+    doc_data, populated_key, _ = multiple_chat_doc_data
+    st = SimpleNamespace(session_state={})
+    st.session_state["student_code"] = "stu2"
+    monkeypatch.setattr(chat_core, "st", st)
+    monkeypatch.setattr(chat_core, "load_chat_draft_from_db", lambda *args, **kwargs: "")
+
+    fake_db = FakeDB(doc_data)
+
+    session = chat_core.prepare_chat_session(
+        db=fake_db,
+        student_code="stu2",
+        mode="Chat Mode",
+        level="A1",
+        teil=None,
+    )
+
+    assert session.conv_key == populated_key
+    assert st.session_state["falowen_messages"] == doc_data["chats"][populated_key]
+    payload, merge = fake_db.doc_ref.set_calls[-1]
+    assert payload == {"current_conv": {"Chat Mode_A1_custom": populated_key}}
+    assert merge is True
+
+
+def test_prepare_chat_session_respects_existing_pointers(
+    monkeypatch, multiple_chat_doc_data
+):
+    base_doc_data, _, sparse_key = multiple_chat_doc_data
+    monkeypatch.setattr(chat_core, "load_chat_draft_from_db", lambda *args, **kwargs: "")
+
+    doc_with_current = {
+        "current_conv": {"Chat Mode_A1_custom": sparse_key},
+        "drafts": {sparse_key: {"draft": ""}},
+        "chats": base_doc_data["chats"],
+    }
+    st_current = SimpleNamespace(session_state={})
+    st_current.session_state["student_code"] = "stu3"
+    monkeypatch.setattr(chat_core, "st", st_current)
+
+    fake_db_current = FakeDB(doc_with_current)
+
+    session_current = chat_core.prepare_chat_session(
+        db=fake_db_current,
+        student_code="stu3",
+        mode="Chat Mode",
+        level="A1",
+        teil=None,
+    )
+
+    assert session_current.conv_key == sparse_key
+    assert st_current.session_state["falowen_messages"] == base_doc_data["chats"][sparse_key]
+    payload, merge = fake_db_current.doc_ref.set_calls[-1]
+    assert payload == {"current_conv": {"Chat Mode_A1_custom": sparse_key}}
+    assert merge is True
+
+    doc_with_draft = {
+        "drafts": {sparse_key: {"draft": ""}},
+        "chats": base_doc_data["chats"],
+    }
+    st_draft = SimpleNamespace(session_state={})
+    st_draft.session_state["student_code"] = "stu4"
+    monkeypatch.setattr(chat_core, "st", st_draft)
+
+    fake_db_draft = FakeDB(doc_with_draft)
+
+    session_draft = chat_core.prepare_chat_session(
+        db=fake_db_draft,
+        student_code="stu4",
+        mode="Chat Mode",
+        level="A1",
+        teil=None,
+    )
+
+    assert session_draft.conv_key == sparse_key
+    assert st_draft.session_state["falowen_messages"] == base_doc_data["chats"][sparse_key]
+    payload, merge = fake_db_draft.doc_ref.set_calls[-1]
+    assert payload == {"current_conv": {"Chat Mode_A1_custom": sparse_key}}
     assert merge is True


### PR DESCRIPTION
## Summary
- ensure `prepare_chat_session` chooses the most substantive persisted chat when no pointer is provided
- cover multi-chat selection and pointer precedence in the regression tests

## Testing
- pytest tests/test_prepare_chat_session.py

------
https://chatgpt.com/codex/tasks/task_e_68cde314fca08321ae1cd83dbc1ffb68