### PR TITLE
Reset Falowen state when switching students

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -80,6 +80,15 @@ def prepare_chat_session(
     level: str,
     teil: Optional[str],
 ) -> ChatSessionData:
+    previous_student_code = st.session_state.get("falowen_loaded_student_code")
+    student_switched = (
+        previous_student_code is not None and previous_student_code != student_code
+    )
+    if student_switched:
+        st.session_state.pop("falowen_conv_key", None)
+        st.session_state.pop("falowen_loaded_key", None)
+        st.session_state.pop("falowen_messages", None)
+
     mode_level_teil = f"{mode}_{level}_{teil or 'custom'}"
     doc_ref = None
     doc_data: Dict[str, Any] = {}
@@ -93,7 +102,7 @@ def prepare_chat_session(
             doc_data = {}
 
     conv_key = st.session_state.get("falowen_conv_key")
-    fresh_chat = False
+    fresh_chat = bool(student_switched)
     prefix = f"{mode_level_teil}_"
 
     def _matches_prefix(value: Any) -> bool:
@@ -160,6 +169,7 @@ def prepare_chat_session(
     st.session_state[saved_flag_key] = True
     st.session_state[saved_at_key] = datetime.now(_timezone.utc)
     st.session_state["falowen_loaded_key"] = conv_key
+    st.session_state["falowen_loaded_student_code"] = student_code
 
     return ChatSessionData(
         conv_key=conv_key,

--- a/src/logout.py
+++ b/src/logout.py
@@ -40,6 +40,10 @@ def do_logout(
     st_module.session_state.pop("_google_btn_rendered", None)
     st_module.session_state.pop("_google_cta_rendered", None)
     st_module.session_state.pop("_ann_hash", None)
+    st_module.session_state.pop("falowen_loaded_student_code", None)
+    st_module.session_state.pop("falowen_conv_key", None)
+    st_module.session_state.pop("falowen_loaded_key", None)
+    st_module.session_state.pop("falowen_messages", None)
     for k in list(st_module.session_state.keys()):
         if k.startswith("__google_btn_rendered::"):
             st_module.session_state.pop(k, None)


### PR DESCRIPTION
## Summary
- clear cached Falowen chat state when the loaded student code changes so each login reloads the appropriate history
- persist the active student code alongside the conversation key after session prep
- ensure logout removes all Falowen chat session keys, including the new student flag

## Testing
- pytest *(fails: known data_loading and class discussion expectations in main branch; interrupted after failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cdea163a1c8321a2ee3af09b206c1e