### PR TITLE
Preserve level when backing out of chat

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -40,7 +40,6 @@ def back_step() -> None:
     draft_key = st.session_state.get("falowen_chat_draft_key")
     for key in [
         "falowen_mode",
-        "falowen_level",
         "falowen_teil",
         "falowen_exam_topic",
         "falowen_exam_keyword",

--- a/tests/test_back_step.py
+++ b/tests/test_back_step.py
@@ -43,10 +43,11 @@ def test_back_step_clears_chat_state():
     assert ss['_falowen_loaded'] is False
     assert ss['__refresh'] == 1
     assert ss['need_rerun'] is True
+    assert ss['falowen_level'] == 'A1'
     st.toast.assert_not_called()
 
     for key in [
-        'falowen_mode', 'falowen_level', 'falowen_teil',
+        'falowen_mode', 'falowen_teil',
         'falowen_exam_topic', 'falowen_exam_keyword',
         'falowen_messages',
         'falowen_loaded_key', 'falowen_conv_key',


### PR DESCRIPTION
## Summary
- keep the saved Falowen level when leaving the chat so re-entry skips the selector
- update back step test to assert the level persists after resetting other chat state

## Testing
- pytest tests/test_back_step.py

------
https://chatgpt.com/codex/tasks/task_e_68ce4da08454832180c5228f7009f23b