### PR TITLE
Remove key parameter from chat history expander

### DIFF
--- a/src/falowen/chat_core.py
+++ b/src/falowen/chat_core.py
@@ -484,8 +484,7 @@ def render_chat_stage(
     )
     relevant_conversations = {key: chats_by_student[key] for key in relevant_keys}
 
-    expander_key = key_fn("chat_history_expander")
-    with st.expander("📚 Previous conversations", expanded=False, key=expander_key):
+    with st.expander("📚 Previous conversations", expanded=False):
         if not relevant_conversations:
             st.caption("No saved conversations yet for this mode.")
         else:


### PR DESCRIPTION
## Summary
- remove the key argument from the previous conversations Streamlit expander to avoid widget key type errors

## Testing
- streamlit run a1sprechen.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68cea1825d5c8321ab3c141ea06ec792