### PR TITLE
Add umlaut helper for improved letter textarea

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6501,6 +6501,10 @@ if tab == "Schreiben Trainer":
                 height=400,
                 placeholder="Paste your improved letter here..."
             )
+            render_umlaut_pad(
+                f"{student_code}_improved_letter",
+                context=f"schreiben_improve_{student_code}",
+            )
             compare_clicked = st.button("Compare My Improvement", key=f"compare_btn_{student_code}")
 
             if compare_clicked and improved_letter.strip():


### PR DESCRIPTION
## Summary
- add the umlaut helper to the Schreiben Trainer improvement textarea so the shortcut reminder is available while revising letters

## Testing
- ruff check a1sprechen.py *(fails: pre-existing lint errors elsewhere in file)*

------
https://chatgpt.com/codex/tasks/task_e_68ceaeab052c8321b70d347e44b55014