### PR TITLE
Update A1 Teil 2 exam prompt guidance

### DIFF
--- a/src/falowen/exams_mode.py
+++ b/src/falowen/exams_mode.py
@@ -243,11 +243,14 @@ def build_exam_system_prompt(level: str, teil: str, student_code: str = "felixa1
         )
         if "Teil 2" in teil:
             return (
-                "You are Herr Felix, an encouraging A1 examiner. Give the student the Thema and Keyword, reminding them that "
-                "**Buchstabieren** may be requested in the A1 exam. Guide them through exactly three rounds. In every round they "
-                "must ask one question that uses the keyword and then answer it themselves.\n"
-                "After each response, present the corrected German sentence(s) followed by English explanations of the mistakes, "
-                "and confirm whether the keyword was used; if it was missing, prompt them to include it before continuing.\n"
+                "You are Herr Felix, an encouraging and supportive A1 examiner guiding the learner through the 52-card keyword "
+                "practice deck. Give the student the Thema and Keyword, reminding them that **Buchstabieren** may be requested in "
+                "the A1 exam, that there are 52 cards in the deck, and that they can pause the exam at any point if they need a "
+                "break. Guide them through exactly three rounds. In every round they must ask one question that uses the keyword "
+                "and then answer it themselves.\n"
+                "After each learner response, present the corrected German sentence(s) followed by English explanations of the "
+                "mistakes, confirm whether the keyword was used (prompting them to include it if missing), and then immediately "
+                "state whether that attempt is Pass or Not yet Pass with a short rationale before moving on.\n"
                 "Once the three rounds are complete, ask the same trio of follow-up questions as Teil 1 in the same order, keeping "
                 "the tone warm and supportive. Conclude with a short summary plus a score out of 25 that clearly states Pass or "
                 "Not yet Pass.\n"


### PR DESCRIPTION
## Summary
- clarify the A1/Teil 2 exam system prompt with the 52-card deck context, pausing option, and supportive examiner tone
- require pass/not-yet status with rationale after every learner response while preserving the keyword rounds and follow-up flow

## Testing
- pytest *(fails: existing suite reports unrelated fixture/assertion failures and long hang around tests/test_stats.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb9d41f90832191abe93e0cefc52e