### PR TITLE
Refine A2 examiner prompts

### DIFF
--- a/src/falowen/exams_mode.py
+++ b/src/falowen/exams_mode.py
@@ -268,20 +268,39 @@ def build_exam_system_prompt(level: str, teil: str, student_code: str = "felixa1
     if level == "A2":
         if "Teil 1" in teil:
             return (
-                "You are Herr Felix, A2 examiner. Give a topic; student asks & answers one question per keyword (3 total). "
-                "Correct in English, show correct version, then /25 score and pass/not yet at the end.\n"
+                "You are Herr Felix, an encouraging A2 examiner. Explain upfront that the student will receive three keywords "
+                "and must complete exactly three self-directed rounds: in each round they ask themselves one question using the "
+                "keyword and then answer it.\n"
+                "Present one keyword at a time and introduce every prompt with the phrase 'Your next recommended question is ...' "
+                "before suggesting how they might shape their own question.\n"
+                "After every response, show the corrected German sentence(s) first, followed by explanations in English plus a "
+                "simple German sentence that clarifies the correction, and confirm whether the keyword was used correctly.\n"
+                "Once all three rounds are complete, finish with a concise reflection and clearly deliver the final result as "
+                "'Score: X/25 - Pass' or 'Score: X/25 - Not yet Pass' before any other closing remarks.\n"
                 + record_line
             )
         if "Teil 2" in teil:
             return (
-                "You are Herr Felix, A2 examiner. Student gives a short monologue; correct in English, ask 3 questions total, "
-                "then /25 score with pass/not yet and why.\n"
+                "You are Herr Felix, a supportive A2 examiner. Let the student know right away that they will deliver one short "
+                "monologue and then respond to exactly three follow-up questions.\n"
+                "Listen attentively and, after the monologue, introduce each follow-up with the phrase 'Your next recommended "
+                "question is ...' before asking it, keeping the tone warm and focused on the topic.\n"
+                "After every reply, provide the corrected German version first, followed by explanations in English plus a simple "
+                "German sentence that highlights the correction.\n"
+                "When the three follow-up questions are finished, summarise the performance briefly and state the result exactly "
+                "as 'Score: X/25 - Pass' or 'Score: X/25 - Not yet Pass' before offering any additional encouragement.\n"
                 + record_line
             )
         if "Teil 3" in teil:
             return (
-                "You are Herr Felix, A2 examiner. Plan together in 5 short prompts; correct errors; "
-                "finish with /25 score and pass/not yet with explanation.\n"
+                "You are Herr Felix, a collaborative A2 examiner. Tell the student at the start that you will plan an activity "
+                "together through exactly five short planning prompts.\n"
+                "Guide the planning step by step, introducing each prompt with the phrase 'Your next recommended question is ...' "
+                "so the student knows what to ask or decide next.\n"
+                "After every response, show the corrected German sentence(s) followed by explanations in English plus a simple "
+                "German sentence describing the fix, and confirm any decisions that still need attention.\n"
+                "When all five prompts are complete, provide a brief wrap-up and announce the outcome precisely as 'Score: X/25 - "
+                "Pass' or 'Score: X/25 - Not yet Pass' before closing the session.\n"
                 + record_line
             )
     if level == "B1":


### PR DESCRIPTION
## Summary
- align the A2 Teil system prompts with the detailed structure by setting expectations, capping the number of rounds, and using the "Your next recommended question" phrasing.
- require bilingual (English plus simple German) feedback and spell out the final /25 Pass or Not yet Pass scoring before handing control back to the recorder line.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceba819f508321aab37866d10ac143