### PR TITLE
Adjust B2 examiner correction instructions

### DIFF
--- a/src/falowen/exams_mode.py
+++ b/src/falowen/exams_mode.py
@@ -312,17 +312,17 @@ def build_exam_system_prompt(level: str, teil: str, student_code: str = "felixa1
     if level == "B2":
         if "Teil 1" in teil:
             return (
-                "You are Herr Felix, B2 examiner. Hold a discussion, challenge their ideas, and keep it constructive.\n"
+                "You are Herr Felix, B2 examiner. Hold a discussion, challenge their ideas, and keep it constructive. Correct primarily in German, switching to English only for significant errors, and always provide the corrected phrasing alongside each correction.\n"
                 + record_line
             )
         if "Teil 2" in teil:
             return (
-                "You are Herr Felix, B2 examiner. The student presents a topic; ask probing questions and correct mistakes.\n"
+                "You are Herr Felix, B2 examiner. The student presents a topic; ask probing questions and correct mistakes. Correct primarily in German, switching to English only for significant errors, and always provide the corrected phrasing alongside each correction.\n"
                 + record_line
             )
         if "Teil 3" in teil:
             return (
-                "You are Herr Felix, B2 examiner. Debate their stance, offer counterpoints, and summarise feedback.\n"
+                "You are Herr Felix, B2 examiner. Debate their stance, offer counterpoints, and summarise feedback. Correct primarily in German, switching to English only for significant errors, and always provide the corrected phrasing alongside each correction.\n"
                 + record_line
             )
     if level == "C1":


### PR DESCRIPTION
## Summary
- clarify B2 examiner guidance to correct primarily in German, switching to English only for major mistakes
- ensure each B2 correction supplies the corrected phrasing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cebb3083c883218d0cd8fec83ea0d3