### PR TITLE
Restore Falowen chat navigation helpers

### DIFF
--- a/src/falowen/custom_chat.py
+++ b/src/falowen/custom_chat.py
@@ -141,9 +141,7 @@ def generate_summary(messages: List[str]) -> str:
             model="gpt-4o-mini",
             messages=[
                 {"role": "system", "content": prompt},
-                {"role": "user", "content": "
-
-".join(messages)},
+                {"role": "user", "content": "\n\n".join(messages)},
             ],
             temperature=0.7,
         )


### PR DESCRIPTION
## Summary
- reintroduce the Falowen chat navigation helpers in `chat_core.py`, delegating chat functionality to `custom_chat`
- ensure the public API exports the expected symbols and state helpers for conversation management
- fix the newline join bug in `custom_chat.generate_summary`

## Testing
- pytest tests/test_prepare_chat_session.py
- pytest tests/test_back_step.py tests/test_render_chat_stage.py tests/test_turn_count.py


------
https://chatgpt.com/codex/tasks/task_e_68cfed5d8e7c8321ac6014e4b47ff543