### PR TITLE
Restore Falowen chat helpers and turn counting

### DIFF
--- a/src/falowen/custom_chat.py
+++ b/src/falowen/custom_chat.py
@@ -134,11 +134,10 @@ def increment_turn_count_and_maybe_close(
 
     st.session_state["falowen_chat_closed"] = False
 
-    # Derive count from messages to avoid drift
-    answers = _count_user_answers()
-    st.session_state["falowen_turn_count"] = answers
+    current = int(st.session_state.get("falowen_turn_count", 0)) + 1
+    st.session_state["falowen_turn_count"] = current
 
-    if answers < TURN_LIMIT:
+    if current < TURN_LIMIT:
         st.session_state["falowen_summary_emitted"] = False
         return False
 


### PR DESCRIPTION
## Summary
- ensure the Falowen chat helper API exposed by `chat_core` continues to work by deferring to the `custom_chat` helpers
- update `increment_turn_count_and_maybe_close` so the stored turn counter advances before summary checks, preserving the expected chat flow

## Testing
- pytest tests/test_render_chat_stage.py tests/test_turn_count.py
- streamlit run a1sprechen.py --server.headless true --server.port 9999 --browser.gatherUsageStats false

------
https://chatgpt.com/codex/tasks/task_e_68cff4a85b188321aeab370891bc4958