### PR TITLE
Fix coach transcript export join syntax

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5576,8 +5576,7 @@ def page_custom_chat():
     # Export transcript (coach tab history)
     if st.button("📥 Download coach transcript (.txt)"):
         fname = f"chat_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.txt"
-        txt = "
-".join([f"[{m['ts']}] {m['role'].upper()}: {m['content']}" for m in st.session_state.chat])
+        txt = "\n".join([f"[{m['ts']}] {m['role'].upper()}: {m['content']}" for m in st.session_state.chat])
         st.download_button("Save now", data=txt.encode("utf-8"), file_name=fname, mime="text/plain")
 
 


### PR DESCRIPTION
## Summary
- fix the transcript export join expression so the newline delimiter and join call share one line

## Testing
- streamlit run a1sprechen.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68d008e3ab148321a6eae4d2295ef1b7