### PR TITLE
Update Chat • Grammar • Exams naming across app

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -837,7 +837,7 @@ def render_sidebar_published():
         st.sidebar.button("🏠 Dashboard",                use_container_width=True, on_click=_go, args=("Dashboard",))
         st.sidebar.button("📈 My Course",                use_container_width=True, on_click=_go, args=("My Course",))
         st.sidebar.button("📊 Results & Resources",      use_container_width=True, on_click=_go, args=("My Results and Resources",))
-        st.sidebar.button("🗣️ Custom Chat & Speaking Tools", use_container_width=True, on_click=_go, args=("Custom Chat & Speaking Tools",))
+        st.sidebar.button("🗣️ Chat • Grammar • Exams", use_container_width=True, on_click=_go, args=("Chat • Grammar • Exams",))
         st.sidebar.button("📚 Vocab Trainer",            use_container_width=True, on_click=_go, args=("Vocab Trainer",))
         st.sidebar.button("📗 Dictionary",              use_container_width=True, on_click=_go_dictionary)
         st.sidebar.button("✍️ Schreiben Trainer",        use_container_width=True, on_click=_go, args=("Schreiben Trainer",))
@@ -874,7 +874,7 @@ def render_sidebar_published():
 - **Dashboard:** Overview (streak, next lesson, missed, leaderboard, new posts).
 - **My Course:** Lessons, materials, and submission flow.
 - **Results & Resources:** Marks, feedback, downloadable resources.
-- **Custom Chat & Speaking Tools:** Guided conversation practice plus instant pronunciation feedback.
+- **Chat • Grammar • Exams:** Guided conversation practice plus instant pronunciation feedback.
 - **Vocab Trainer:** Daily picks, spaced review, stats.
 - **Schreiben Trainer:** Structured writing with iterative feedback.
                 """
@@ -1379,7 +1379,7 @@ def render_dropdown_nav():
         "Dashboard",
         "My Course",
         "My Results and Resources",
-        "Custom Chat & Speaking Tools",
+        "Chat • Grammar • Exams",
         "Vocab Trainer",
         "Schreiben Trainer",
     ]
@@ -1387,7 +1387,7 @@ def render_dropdown_nav():
         "Dashboard": "🏠",
         "My Course": "📈",
         "My Results and Resources": "📊",
-        "Custom Chat & Speaking Tools": "🗣️",
+        "Chat • Grammar • Exams": "🗣️",
         "Vocab Trainer": "📚",
         "Schreiben Trainer": "✍️",
     }
@@ -5375,8 +5375,8 @@ if tab == "My Course":
 if tab == "My Results and Resources":
     render_results_and_resources_tab()
 
-if tab == "Custom Chat & Speaking Tools":
-    st.markdown("## 🗣️ Custom Chat & Speaking Tools")
+if tab == "Chat • Grammar • Exams":
+    st.markdown("## 🗣️ Chat • Grammar • Exams")
     st.caption("Simple & clear: last 3 messages shown; input stays below. 3 keywords • 6 questions.")
 
     # ---- Links
@@ -6280,7 +6280,7 @@ if tab == "Schreiben Trainer":
         Practice German letters, emails, and essays for A1–C1 exams—now with automatic level detection.
 
         Want to practice presentations or focus on Speaking, Reading, or Listening?
-        👉 Switch to **Exam Mode & Custom Chat** (tab above)!
+        👉 Switch to **Exam Mode & Chat • Grammar • Exams** (tab above)!
 
         Your writing will be assessed and scored out of 25 marks, just like in the real exam.
         """,

--- a/src/falowen/custom_chat.py
+++ b/src/falowen/custom_chat.py
@@ -1,4 +1,4 @@
-"""Custom chat helpers used by the Falowen Streamlit experience."""
+"""Chat • Grammar • Exams helpers used by the Falowen Streamlit experience."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ _summary_client = None
 
 
 def set_summary_client(client) -> None:
-    """Configure the OpenAI client used for chat summaries."""
+    """Configure the OpenAI client used for Chat • Grammar • Exams summaries."""
     global _summary_client
     _summary_client = client
 
@@ -85,7 +85,7 @@ def build_custom_chat_prompt(level: str, student_code: Optional[str] = None) -> 
 
 
 def generate_summary(messages: List[str]) -> str:
-    """Use the configured OpenAI client to summarise custom chat answers."""
+    """Use the configured OpenAI client to summarise Chat • Grammar • Exams answers."""
     if not messages:
         return ""
     prompt = "Summarize the following student responses into about 60 words suitable for a presentation."

--- a/src/schedule.py
+++ b/src/schedule.py
@@ -338,7 +338,7 @@ Submitting Work
             "chapter": "4.7",
             "assignment": False,
             "goal": "Understand imperative statements and learn how to use them in your Sprechen exams, especially in Teil 3.",
-            "instruction": "After completing this chapter, open Custom Chat & Speaking Tools, pick A1 as your level, and ask for Teil 3-style prompts to practice.",
+            "instruction": "After completing this chapter, open Chat • Grammar • Exams, pick A1 as your level, and ask for Teil 3-style prompts to practice.",
             "grammar_topic": "Imperative",
             "schreiben_sprechen": {
                 "video": "https://youtu.be/IVtUc9T3o0Y",
@@ -530,7 +530,7 @@ Kindly communicate with us what you would like to do next by emailing **learnger
 You can prepare for the A1 exams or progress to A2. We wish you continued success in your journey. 
 
 Use:
-- **Custom Chat & Speaking Tools** for guided speaking practice and pronunciation feedback.  
+- **Chat • Grammar • Exams** for guided speaking practice and pronunciation feedback.
 - **Vocabulary Trainer**  
 - **Schreiben Trainer** (includes pre-filled questions on typical exam topics)  
 
@@ -568,7 +568,7 @@ Course Structure: Each day is divided into four Teile (parts).
         • Read this section one chapter ahead to prepare for class discussions.  
         • It includes a topic-of-the-day and tips to spark conversation.  
         • Participation here is essential; unprepared students may find it difficult to contribute.  
-        • For extra practice, open Custom Chat & Speaking Tools. Copy or type the daily question into Custom Chat; the AI will offer tips so you arrive “three times prepared.”  
+        • For extra practice, open Chat • Grammar • Exams. Copy or type the daily question into Chat • Grammar • Exams; the AI will offer tips so you arrive “three times prepared.”  
 
     Teil 2 – Schreiben (Writing Assignment)
         • Use the Schreibentrainer tools to draft and refine your writing.  
@@ -606,7 +606,7 @@ Summary
     • Teil 1: Prepare for group discussion (no submission).  
     • Teil 2–4: Complete writing, reading, and listening assignments daily.  
     • Stay Ahead: Always read Teil 1 one chapter in advance.  
-    • Be Prepared: Use Custom Chat & Speaking Tools to practice the question of the day.  
+    • Be Prepared: Use Chat • Grammar • Exams to practice the question of the day.  
     • Use Tools: Schreibentrainer for writing, recorded lectures for each topic, and grammar notes for quick reference.  
     • Submit Work: Teile 2–4 only, via the Submit tab.  
 
@@ -1013,7 +1013,7 @@ Kindly communicate with us what you would like to do next by emailing **learnger
 You can prepare for the A2 exams or progress to B1. We wish you continued success in your journey. 
 
 Use:
-- **Custom Chat & Speaking Tools** for guided speaking practice and pronunciation feedback.  
+- **Chat • Grammar • Exams** for guided speaking practice and pronunciation feedback.  
 - **Vocabulary Trainer**  
 - **Schreiben Trainer** (includes pre-filled questions on typical exam topics)  
 
@@ -1051,7 +1051,7 @@ Course Structure: Each day is divided into four Teile (parts).
         • Read this section one chapter ahead to prepare for class discussions.  
         • It includes a topic-of-the-day and tips to spark conversation.  
         • Participation here is essential; unprepared students may find it difficult to contribute.  
-        • For extra practice, open Custom Chat & Speaking Tools. Copy or type the daily question into Custom Chat; the AI will offer tips so you arrive “three times prepared.”  
+        • For extra practice, open Chat • Grammar • Exams. Copy or type the daily question into Chat • Grammar • Exams; the AI will offer tips so you arrive “three times prepared.”  
 
     Teil 2 – Schreiben (Writing Assignment)
         • Use the Schreibentrainer tools to draft and refine your writing.  
@@ -1089,7 +1089,7 @@ Summary
     • Teil 1: Prepare for group discussion (no submission).  
     • Teil 2–4: Complete writing, reading, and listening assignments daily.  
     • Stay Ahead: Always read Teil 1 one chapter in advance.  
-    • Be Prepared: Use Custom Chat & Speaking Tools to practice the question of the day.  
+    • Be Prepared: Use Chat • Grammar • Exams to practice the question of the day.  
     • Use Tools: Schreibentrainer for writing, recorded lectures for each topic, and grammar notes for quick reference.  
     • Submit Work: Teile 2–4 only, via the Submit tab.  
 
@@ -1495,7 +1495,7 @@ Nächste Schritte:
   • **Prüfungsmodus** (mit alten Goethe-Prüfungsfragen – für Hörverstehen bitte YouTube verwenden)  
   • **Vokabeltrainer**  
   • **Schreibtrainer** mit typischen Prüfungsthemen  
-  • **Custom Chat** für zusätzliche Übung  
+  • **Chat • Grammar • Exams** für zusätzliche Übung  
 
  Hinweis: Dein Zugang zu deinem Tutor bleibt bis zum Ende deines Vertrags aktiv.  
  Wenn dir der Kurs gefallen hat, hinterlasse uns bitte eine [positive Bewertung auf Google](https://g.page/r/Cdogveq3Hy69EBE/review).  
@@ -1534,7 +1534,7 @@ Course Structure: Each day is divided into four Teile (parts).
         • Read this section one chapter ahead to prepare for class discussions.
         • It includes a topic-of-the-day and tips to spark conversation.
         • Participation here is essential; unprepared students may find it difficult to contribute.
-        • For extra practice, open Custom Chat & Speaking Tools. Copy or type the daily question into Custom Chat; the AI will offer tips so you arrive “three times prepared.”
+        • For extra practice, open Chat • Grammar • Exams. Copy or type the daily question into Chat • Grammar • Exams; the AI will offer tips so you arrive “three times prepared.”
 
     Teil 2 – Schreiben (Writing Assignment)
         • Use the Schreibentrainer tools to draft and refine your writing.
@@ -1572,7 +1572,7 @@ Summary
     • Teil 1: Prepare for group discussion (no submission).
     • Teil 2–4: Complete writing, reading, and listening assignments daily.
     • Stay Ahead: Always read Teil 1 one chapter in advance.
-    • Be Prepared: Use Custom Chat & Speaking Tools to practice the question of the day.
+    • Be Prepared: Use Chat • Grammar • Exams to practice the question of the day.
     • Use Tools: Schreibentrainer for writing, recorded lectures for each topic, and grammar notes for quick reference.
     • Submit Work: Teile 2–4 only, via the Submit tab.
 


### PR DESCRIPTION
## Summary
- rename the Custom Chat navigation button, dropdown tab, and tab heading to “Chat • Grammar • Exams,” including the Schreiben helper callout
- update schedule guidance and documentation strings to reference the new Chat • Grammar • Exams name
- refresh the Chat • Grammar • Exams helper module docstrings to match the product rename

## Testing
- `pytest` *(fails: existing class discussion and student roster tests in the suite; unrelated to these string changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d0258ab8d0832183ee7271f24a129f