### PR TITLE
Persist Topic Coach transcripts to Firestore

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -43,6 +43,11 @@ from src.discussion_board import (
     CLASS_DISCUSSION_REMINDER,
     go_class_thread,
 )
+from src.topic_coach_persistence import (
+    get_topic_coach_doc,
+    load_topic_coach_state,
+    persist_topic_coach_state,
+)
 
 from flask import Flask
 from auth import auth_bp
@@ -5424,12 +5429,101 @@ if tab == "Custom Chat & Speaking Tools":
     </style>
     """, unsafe_allow_html=True)
 
+    student_code_tc = (st.session_state.get("student_code") or "").strip()
+
+    def _resolve_topic_coach_db():
+        """Return a Firestore client for Topic Coach persistence if available."""
+
+        global db  # type: ignore  # Streamlit runtime assigns this at module scope
+        existing = globals().get("db")
+        if existing is None:
+            existing = getattr(_falowen_sessions, "db", None) or getattr(
+                _falowen_sessions, "_db_client", None
+            )
+        if existing is not None:
+            return existing
+
+        getter = getattr(_falowen_sessions, "get_db", None)
+        if callable(getter):
+            try:
+                existing = getter()
+            except Exception as exc:
+                logging.debug("Topic Coach Firestore unavailable: %s", exc)
+                return None
+            if existing is not None:
+                try:
+                    _falowen_sessions.db = existing
+                except Exception:
+                    pass
+                if hasattr(_falowen_sessions, "_db_client"):
+                    try:
+                        _falowen_sessions._db_client = existing
+                    except Exception:
+                        pass
+                db = existing
+                return existing
+        return None
+
+    topic_db = _resolve_topic_coach_db()
+    topic_doc_ref = None
+    topic_messages: List[Dict[str, Any]] = []
+    topic_meta: Dict[str, Any] = {}
+    if student_code_tc:
+        topic_doc_ref, topic_messages, topic_meta = load_topic_coach_state(
+            topic_db, student_code_tc
+        )
+
+    def _infer_topic_qcount(messages: List[Dict[str, Any]]) -> int:
+        count = 0
+        assistant_seen = False
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("role")
+            if role == "assistant":
+                assistant_seen = True
+            elif role == "user" and assistant_seen:
+                count = min(6, count + 1)
+        return count
+
+    loaded_qcount_raw = topic_meta.get("qcount") if isinstance(topic_meta, dict) else None
+    try:
+        loaded_qcount = int(loaded_qcount_raw) if loaded_qcount_raw is not None else None
+    except Exception:
+        loaded_qcount = None
+    if loaded_qcount is None:
+        loaded_qcount = _infer_topic_qcount(topic_messages)
+    loaded_qcount = max(0, loaded_qcount)
+
+    loaded_finalized = (
+        bool(topic_meta.get("finalized")) if isinstance(topic_meta, dict) else False
+    )
+
     # ---------- Persistent (data-only) session state ----------
-    if "cchat_data_chat" not in st.session_state:     st.session_state["cchat_data_chat"] = []
-    if "cchat_data_qcount" not in st.session_state:   st.session_state["cchat_data_qcount"] = 0
-    if "cchat_data_finalized" not in st.session_state: st.session_state["cchat_data_finalized"] = False
-    chat_data_key   = "cchat_data_chat"
+    if "cchat_data_chat" not in st.session_state:
+        st.session_state["cchat_data_chat"] = list(topic_messages)
+    elif not st.session_state["cchat_data_chat"] and topic_messages:
+        st.session_state["cchat_data_chat"] = list(topic_messages)
+    if "cchat_data_qcount" not in st.session_state:
+        st.session_state["cchat_data_qcount"] = loaded_qcount
+    if "cchat_data_finalized" not in st.session_state:
+        st.session_state["cchat_data_finalized"] = loaded_finalized
+
+    chat_data_key = "cchat_data_chat"
     qcount_data_key = "cchat_data_qcount"
+
+    def _save_topic_coach_transcript() -> None:
+        if not student_code_tc:
+            return
+        doc_ref = topic_doc_ref or get_topic_coach_doc(topic_db, student_code_tc)
+        if doc_ref is None:
+            return
+        persist_topic_coach_state(
+            doc_ref,
+            messages=list(st.session_state.get(chat_data_key, [])),
+            qcount=st.session_state.get(qcount_data_key, 0),
+            finalized=st.session_state.get("cchat_data_finalized", False),
+        )
 
     # ---------- Widget keys (make them UNIQUE across app) ----------
     KEY_LEVEL_SLIDER   = "cchat_w_level"
@@ -5513,6 +5607,7 @@ if tab == "Custom Chat & Speaking Tools":
                     "content": reply_raw,
                     "ts": datetime.now(UTC).isoformat()
                 })
+                _save_topic_coach_transcript()
                 st.rerun()
 
         st.divider()
@@ -5583,6 +5678,7 @@ if tab == "Custom Chat & Speaking Tools":
                     st.session_state[chat_data_key] = []
                     st.session_state[qcount_data_key] = 0
                     st.session_state["cchat_data_finalized"] = False
+                    _save_topic_coach_transcript()
                     st.toast("Cleared")
                     st.rerun()
             with col_right:
@@ -5603,6 +5699,8 @@ if tab == "Custom Chat & Speaking Tools":
             has_assistant_turn = any(m["role"] == "assistant" for m in st.session_state[chat_data_key][:-1])
             if has_assistant_turn and not st.session_state["cchat_data_finalized"]:
                 st.session_state[qcount_data_key] = min(6, int(st.session_state[qcount_data_key] or 0) + 1)
+
+            _save_topic_coach_transcript()
 
             # Build conversation
             convo = [{"role": "system", "content": system_text}]
@@ -5726,6 +5824,7 @@ if tab == "Custom Chat & Speaking Tools":
                     </div>
                 """, height=170)
 
+            _save_topic_coach_transcript()
             st.rerun()
 
     # ===================== Grammar (simple, one-box) =====================

--- a/src/topic_coach_persistence.py
+++ b/src/topic_coach_persistence.py
@@ -1,0 +1,113 @@
+"""Helpers for persisting Topic Coach transcripts to Firestore.
+
+This module contains small utilities that mirror the lightweight
+Topic Coach chat experience implemented directly inside
+``a1sprechen.py``.  They are deliberately side-effect free so that tests
+can exercise the Firestore integration logic without importing the
+Streamlit app entrypoint.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Tuple
+
+import logging
+
+TOPIC_COACH_CHAT_KEY = "topic_coach"
+TOPIC_COACH_META_FIELD = "topic_coach_meta"
+
+
+def _coerce_messages(value: Any) -> List[Dict[str, Any]]:
+    """Return ``value`` as a list of message dictionaries."""
+
+    if isinstance(value, list):
+        # Defensive copy so callers can mutate without affecting the
+        # cached Firestore data returned by :meth:`~google.cloud.firestore.DocumentSnapshot.to_dict`.
+        return [dict(item) if isinstance(item, dict) else item for item in value]
+    return []
+
+
+def get_topic_coach_doc(db: Any, student_code: str):
+    """Return the Firestore document reference for Topic Coach chats."""
+
+    if db is None or not student_code:
+        return None
+    try:
+        return db.collection("falowen_chats").document(student_code)
+    except Exception as exc:  # pragma: no cover - safety net for unexpected SDK failures
+        logging.warning("Failed to resolve Topic Coach doc for %s: %s", student_code, exc)
+        return None
+
+
+def load_topic_coach_state(db: Any, student_code: str) -> Tuple[Any, List[Dict[str, Any]], Dict[str, Any]]:
+    """Return ``(doc_ref, messages, meta)`` for the student's Topic Coach chat."""
+
+    doc_ref = get_topic_coach_doc(db, student_code)
+    if doc_ref is None:
+        return None, [], {}
+
+    try:
+        snapshot = doc_ref.get()
+    except Exception as exc:  # pragma: no cover - safety net for unexpected SDK failures
+        logging.warning("Failed to load Topic Coach transcript for %s: %s", student_code, exc)
+        return doc_ref, [], {}
+
+    data: Dict[str, Any] = {}
+    if getattr(snapshot, "exists", False):
+        try:
+            data = snapshot.to_dict() or {}
+        except Exception as exc:  # pragma: no cover - defensive guard for bad snapshots
+            logging.warning("Topic Coach snapshot conversion failed for %s: %s", student_code, exc)
+            data = {}
+
+    chats = data.get("chats") or {}
+    raw_messages = chats.get(TOPIC_COACH_CHAT_KEY) if isinstance(chats, dict) else []
+    messages = _coerce_messages(raw_messages)
+
+    raw_meta = data.get(TOPIC_COACH_META_FIELD)
+    meta = raw_meta if isinstance(raw_meta, dict) else {}
+
+    return doc_ref, messages, meta
+
+
+def _normalise_meta(qcount: Any, finalised: Any) -> Dict[str, Any]:
+    """Return a Firestore-friendly metadata payload."""
+
+    try:
+        qcount_value = int(qcount or 0)
+    except Exception:
+        qcount_value = 0
+    return {
+        "qcount": max(0, qcount_value),
+        "finalized": bool(finalised),
+    }
+
+
+def persist_topic_coach_state(
+    doc_ref: Any,
+    *,
+    messages: Iterable[Dict[str, Any]],
+    qcount: Any,
+    finalized: Any,
+) -> bool:
+    """Persist the latest Topic Coach state to Firestore.
+
+    Returns ``True`` when the write is attempted successfully and ``False``
+    when no document reference is available or the SDK raises an error.
+    """
+
+    if doc_ref is None:
+        return False
+
+    payload = {
+        "chats": {TOPIC_COACH_CHAT_KEY: list(messages or [])},
+        TOPIC_COACH_META_FIELD: _normalise_meta(qcount, finalized),
+    }
+
+    try:
+        doc_ref.set(payload, merge=True)
+        return True
+    except Exception as exc:  # pragma: no cover - depends on Firestore availability
+        doc_id = getattr(doc_ref, "id", "<unknown>")
+        logging.warning("Failed to persist Topic Coach transcript for %s: %s", doc_id, exc)
+        return False

--- a/tests/test_topic_coach_persistence.py
+++ b/tests/test_topic_coach_persistence.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+
+from src.topic_coach_persistence import (
+    TOPIC_COACH_CHAT_KEY,
+    TOPIC_COACH_META_FIELD,
+    get_topic_coach_doc,
+    load_topic_coach_state,
+    persist_topic_coach_state,
+)
+
+
+class FakeSnapshot:
+    def __init__(self, data, exists=True):
+        self._data = data
+        self.exists = exists
+
+    def to_dict(self):
+        return self._data
+
+
+def _deep_merge(target, payload):
+    for key, value in payload.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _deep_merge(target[key], value)
+        else:
+            target[key] = value
+    return target
+
+
+class FakeDocRef:
+    def __init__(self, data=None, doc_id="doc1"):
+        self._data = data or {}
+        self.id = doc_id
+        self.set_calls = []
+
+    def get(self):
+        return FakeSnapshot(self._data, exists=True)
+
+    def set(self, payload, merge=True):
+        self.set_calls.append((payload, merge))
+        if merge:
+            _deep_merge(self._data, payload)
+        else:
+            self._data = payload
+
+
+class FakeDB:
+    def __init__(self, doc):
+        self._doc = doc
+
+    def collection(self, name):
+        assert name == "falowen_chats"
+        return self
+
+    def document(self, student_code):
+        doc = getattr(self, "_doc", None)
+        if isinstance(doc, dict):
+            return FakeDocRef(doc, doc_id=student_code)
+        return doc
+
+
+def test_load_topic_coach_state_returns_messages_and_meta():
+    stored = {
+        "chats": {TOPIC_COACH_CHAT_KEY: [{"role": "assistant", "content": "Hallo"}]},
+        TOPIC_COACH_META_FIELD: {"qcount": 3, "finalized": True},
+    }
+    db = FakeDB(stored)
+
+    doc_ref, messages, meta = load_topic_coach_state(db, "stu1")
+
+    assert doc_ref is not None
+    assert messages == stored["chats"][TOPIC_COACH_CHAT_KEY]
+    assert meta == stored[TOPIC_COACH_META_FIELD]
+
+
+def test_persist_topic_coach_state_writes_payload():
+    base = {
+        "chats": {},
+        TOPIC_COACH_META_FIELD: {"qcount": 0, "finalized": False},
+    }
+    doc_ref = FakeDocRef(base, doc_id="stu2")
+
+    saved = persist_topic_coach_state(
+        doc_ref,
+        messages=[{"role": "user", "content": "Hi"}],
+        qcount=2,
+        finalized=True,
+    )
+
+    assert saved is True
+    payload, merge_flag = doc_ref.set_calls[-1]
+    assert merge_flag is True
+    assert payload["chats"][TOPIC_COACH_CHAT_KEY] == [{"role": "user", "content": "Hi"}]
+    assert payload[TOPIC_COACH_META_FIELD] == {"qcount": 2, "finalized": True}
+    assert doc_ref._data["chats"][TOPIC_COACH_CHAT_KEY]
+    assert doc_ref._data[TOPIC_COACH_META_FIELD]["finalized"] is True
+
+
+def test_topic_coach_state_round_trip():
+    storage = {
+        "chats": {},
+        TOPIC_COACH_META_FIELD: {"qcount": 0, "finalized": False},
+    }
+    doc_ref = FakeDocRef(storage, doc_id="stu3")
+    db = SimpleNamespace(collection=lambda name: SimpleNamespace(document=lambda code: doc_ref))
+
+    persisted = persist_topic_coach_state(
+        doc_ref,
+        messages=[{"role": "assistant", "content": "Start"}],
+        qcount=1,
+        finalized=False,
+    )
+    assert persisted is True
+
+    loaded_doc, messages, meta = load_topic_coach_state(db, "stu3")
+    assert loaded_doc is doc_ref
+    assert messages == [{"role": "assistant", "content": "Start"}]
+    assert meta == {"qcount": 1, "finalized": False}
+
+
+def test_persist_topic_coach_state_requires_document():
+    assert persist_topic_coach_state(None, messages=[], qcount=0, finalized=False) is False
+
+
+def test_get_topic_coach_doc_handles_missing_db():
+    assert get_topic_coach_doc(None, "stu4") is None
+    assert get_topic_coach_doc(SimpleNamespace(collection=lambda name: None), "") is None


### PR DESCRIPTION
## Summary
- load Topic Coach transcripts from Firestore when available and sync updates after each Topic Coach turn
- extract reusable Firestore helpers for Topic Coach transcripts and seed Streamlit state from stored metadata
- clear server-side transcripts when starting a new chat to avoid stale history resurfacing

## Testing
- pytest tests/test_topic_coach_persistence.py
- pytest tests/test_prepare_chat_session.py

------
https://chatgpt.com/codex/tasks/task_e_68d0259258848321b9872b6175ea25fc