### PR TITLE
Add grammar CTA to workbook assignments

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2164,7 +2164,7 @@ def render_section(day_info: dict, key: str, title: str, icon: str) -> None:
             )
         if part.get('workbook_link'):
             render_link("📒 Workbook (Assignment)", part['workbook_link'])
-            render_assignment_reminder()
+            render_assignment_reminder(show_grammar_cta=True)
         extras = part.get('extra_resources')
         if extras:
             for ex in (extras if isinstance(extras, list) else [extras]):
@@ -2761,7 +2761,7 @@ if tab == "My Course":
                                 f"{key}-{idx_part}",
                                 f"Day {day_info.get('day')} Chapter {chapter}",
                             )
-                        render_assignment_reminder()
+                        render_assignment_reminder(show_grammar_cta=True)
                     if extras:
                         for ex in _as_list(extras):
                             st.markdown(f"- [🔗 Extra]({ex})")
@@ -2793,7 +2793,7 @@ if tab == "My Course":
                             f"fallback-{info.get('day', '')}",
                             f"Day {info.get('day')} Chapter {info.get('chapter', '')}",
                         )
-                    render_assignment_reminder()
+                    render_assignment_reminder(show_grammar_cta=True)
                     showed = True
                 for ex in _as_list(info.get("extra_resources")):
                     st.markdown(f"- [🔗 Extra]({ex})")

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -39,8 +39,8 @@ def _load_vocab_sheet(sheet_id: str = VOCAB_SHEET_ID) -> Optional[pd.DataFrame]:
         return None
 
 
-def render_assignment_reminder() -> None:
-    """Show a yellow assignment reminder box."""
+def render_assignment_reminder(*, show_grammar_cta: bool = False) -> None:
+    """Show a yellow assignment reminder box and optional grammar CTA."""
 
     st.markdown(
         '''
@@ -63,9 +63,16 @@ def render_assignment_reminder() -> None:
             ⬆️ <strong>Your Assignment:</strong><br>
             Complete the exercises in your <em>workbook</em> for this chapter.
         </div>
-        ''',
+        '''
+        ,
         unsafe_allow_html=True,
     )
+
+    if show_grammar_cta:
+        if st.button("Ask a grammar question", use_container_width=True):
+            st.session_state["nav_sel"] = "Chat • Grammar • Exams"
+            st.session_state["main_tab_select"] = "Chat • Grammar • Exams"
+            st.session_state["need_rerun"] = True
 
 
 def render_link(label: str, url: str) -> None:

--- a/tests/test_assignment_reminder.py
+++ b/tests/test_assignment_reminder.py
@@ -1,0 +1,42 @@
+import src.ui_components as ui
+
+
+class DummyStreamlit:
+    def __init__(self):
+        self.markdowns = []
+        self.button_calls = []
+        self.session_state = {}
+        self.next_button_result = False
+
+    def markdown(self, text, **kwargs):  # pragma: no cover - trivial
+        self.markdowns.append((text, kwargs))
+
+    def button(self, label, **kwargs):  # pragma: no cover - trivial
+        self.button_calls.append((label, kwargs))
+        return self.next_button_result
+
+
+def test_assignment_reminder_no_cta_by_default(monkeypatch):
+    st = DummyStreamlit()
+    monkeypatch.setattr(ui, "st", st)
+
+    ui.render_assignment_reminder()
+
+    assert st.button_calls == []
+
+
+def test_assignment_reminder_cta_sets_session_state(monkeypatch):
+    st = DummyStreamlit()
+    st.next_button_result = True
+    monkeypatch.setattr(ui, "st", st)
+
+    ui.render_assignment_reminder(show_grammar_cta=True)
+
+    assert st.button_calls == [
+        ("Ask a grammar question", {"use_container_width": True})
+    ]
+    assert st.session_state == {
+        "nav_sel": "Chat • Grammar • Exams",
+        "main_tab_select": "Chat • Grammar • Exams",
+        "need_rerun": True,
+    }

--- a/tests/test_render_section_any.py
+++ b/tests/test_render_section_any.py
@@ -5,7 +5,7 @@ import types
 from pathlib import Path
 
 
-def _load_render_section_any(render_vocab_stub=None):
+def _load_render_section_any(render_vocab_stub=None, assignment_stub=None):
     """Load the ``render_section_any`` helper from ``a1sprechen.py``.
 
     Parameters
@@ -53,7 +53,7 @@ def _load_render_section_any(render_vocab_stub=None):
 
     mod.st = ST()
     mod.render_vocab_lookup = render_vocab_stub or (lambda *a, **k: None)
-    mod.render_assignment_reminder = lambda *a, **k: None
+    mod.render_assignment_reminder = assignment_stub or (lambda *a, **k: None)
     mod.logging = logging
 
     exec(snippet, mod.__dict__)
@@ -98,4 +98,19 @@ def test_dictionary_label_passed():
     render_section_any(day_info, "lesen", "Lesen", "📖", set())
 
     assert captured == {"key": "lesen-0", "label": "Day 7 Chapter 2"}
+
+
+def test_assignment_reminder_receives_cta_flag():
+    calls = []
+
+    def assignment_stub(*args, **kwargs):  # pragma: no cover - trivial
+        calls.append((args, kwargs))
+
+    render_section_any, st = _load_render_section_any(assignment_stub=assignment_stub)
+    day_info = {"lesen": {"chapter": "2", "workbook_link": "x"}, "day": 7}
+    render_section_any(day_info, "lesen", "Lesen", "📖", set())
+
+    assert len(calls) == 1
+    assert calls[0][0] == ()
+    assert calls[0][1] == {"show_grammar_cta": True}
 


### PR DESCRIPTION
## Summary
- allow the assignment reminder component to optionally show a grammar chat CTA that redirects to the chat tab
- pass the CTA flag for each workbook link in the course book views so the button is visible alongside assignments
- add regression tests that exercise the CTA flag and verify session-state navigation updates

## Testing
- pytest tests/test_render_section_any.py tests/test_assignment_reminder.py

------
https://chatgpt.com/codex/tasks/task_e_68d0305392048321ae523f44c5497e80