### PR TITLE
Add umlaut helper to chat tab input

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5686,6 +5686,7 @@ if tab == "Chat • Grammar • Exams":
                     "Hallo! 👋 What would you like to talk about? Give me details of what you want so I can understand.",
                     key=KEY_CHAT_INPUT
                 )
+                render_umlaut_pad(KEY_CHAT_INPUT, context="chat_tab", disabled=True)
             st.markdown("</div>", unsafe_allow_html=True)
 
         # ---- SEND ----


### PR DESCRIPTION
## Summary
- render the shared umlaut pad helper below the chat tab input so users can copy characters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0340e4ab48321b9df6c50c0bbbe11