### PR TITLE
Sync chat and grammar level sliders with roster updates

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -48,6 +48,7 @@ from src.topic_coach_persistence import (
     load_topic_coach_state,
     persist_topic_coach_state,
 )
+from src.level_sync import sync_level_state
 
 from flask import Flask
 from auth import auth_bp
@@ -5561,6 +5562,15 @@ if tab == "Chat • Grammar • Exams":
         match = re.search("|".join(level_options), roster_level) if roster_level else None
         default_level = match.group(0) if match else "A2"
 
+        sync_level_state(
+            st,
+            student_code=student_code_tc,
+            default_level=default_level,
+            level_options=level_options,
+            slider_key=KEY_LEVEL_SLIDER,
+            grammar_key=KEY_GRAM_LEVEL,
+        )
+
         colA, colB, colC = st.columns([1,1,1.2])
         with colA:
             cur_level = st.session_state.get(KEY_LEVEL_SLIDER, default_level)
@@ -5840,9 +5850,12 @@ if tab == "Chat • Grammar • Exams":
             )
         with gcol2:
             level_options = ["A1", "A2", "B1", "B2"]
-            cur_level_g = st.session_state.get(KEY_LEVEL_SLIDER, "A2")
+            default_gram = st.session_state.get("_cchat_last_profile_level") or level_options[0]
+            if default_gram not in level_options:
+                default_gram = level_options[0]
+            cur_level_g = st.session_state.get(KEY_GRAM_LEVEL, default_gram)
             if cur_level_g not in level_options:
-                cur_level_g = "A2"
+                cur_level_g = default_gram
             gram_level = st.select_slider("Level", level_options, value=cur_level_g, key=KEY_GRAM_LEVEL)
             ask = st.button("Ask", type="primary", use_container_width=True, key=KEY_GRAM_ASK_BTN)
 

--- a/src/level_sync.py
+++ b/src/level_sync.py
@@ -1,0 +1,80 @@
+"""Helpers for synchronising Streamlit level sliders with roster data."""
+
+from __future__ import annotations
+
+from typing import Sequence, Any
+
+
+def _coerce_level_options(level_options: Sequence[str]) -> list[str]:
+    coerced: list[str] = []
+    for opt in level_options:
+        text = str(opt)
+        if text:
+            coerced.append(text)
+    return coerced or [""]
+
+
+def sync_level_state(
+    st: Any,
+    *,
+    student_code: str,
+    default_level: str,
+    level_options: Sequence[str],
+    slider_key: str,
+    grammar_key: str,
+    last_student_key: str = "_cchat_last_student_code",
+    last_level_key: str = "_cchat_last_profile_level",
+) -> str:
+    """Synchronise Topic Coach and Grammar level widgets with roster updates.
+
+    Parameters
+    ----------
+    st:
+        Streamlit module (or compatible object) exposing ``session_state``.
+    student_code:
+        Currently active student identifier.
+    default_level:
+        Auto-detected level from the roster/profile.
+    level_options:
+        Permitted CEFR level options for the sliders.
+    slider_key / grammar_key:
+        Session-state keys for the Topic Coach and Grammar sliders.
+    last_student_key / last_level_key:
+        Internal bookkeeping keys used to detect when to reset state.
+
+    Returns
+    -------
+    str
+        The final value stored for the Topic Coach slider.
+    """
+
+    if not hasattr(st, "session_state"):
+        raise AttributeError("Streamlit module must expose session_state")
+
+    session = st.session_state
+    options = _coerce_level_options(level_options)
+    auto_level = str(default_level or "")
+    if auto_level not in options:
+        auto_level = options[0]
+
+    student_code = student_code or ""
+
+    previous_code = session.get(last_student_key, "")
+    previous_level = session.get(last_level_key, "")
+    current_slider = session.get(slider_key)
+    current_grammar = session.get(grammar_key)
+
+    roster_changed = (student_code != previous_code) or (auto_level != previous_level)
+
+    if roster_changed or current_slider not in options:
+        session[slider_key] = auto_level
+    if roster_changed or current_grammar not in options:
+        session[grammar_key] = auto_level
+
+    session[last_student_key] = student_code
+    session[last_level_key] = auto_level
+
+    return session[slider_key]
+
+
+__all__ = ["sync_level_state"]

--- a/tests/test_level_sync.py
+++ b/tests/test_level_sync.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.level_sync import sync_level_state
+
+
+@pytest.fixture
+def level_options():
+    return ["A1", "A2", "B1", "B2"]
+
+
+def test_sync_level_state_resets_on_profile_change(level_options):
+    st = SimpleNamespace(session_state={})
+
+    # Initial roster load seeds both sliders
+    sync_level_state(
+        st,
+        student_code="stu1",
+        default_level="A2",
+        level_options=level_options,
+        slider_key="slider",
+        grammar_key="grammar",
+    )
+    assert st.session_state["slider"] == "A2"
+    assert st.session_state["grammar"] == "A2"
+
+    # Learner customises their sliders during the session
+    st.session_state["slider"] = "B2"
+    st.session_state["grammar"] = "B2"
+
+    # When the roster updates to a new level for the same student,
+    # both widgets should snap back to the fresh profile value.
+    sync_level_state(
+        st,
+        student_code="stu1",
+        default_level="B1",
+        level_options=level_options,
+        slider_key="slider",
+        grammar_key="grammar",
+    )
+    assert st.session_state["slider"] == "B1"
+    assert st.session_state["grammar"] == "B1"
+
+    system_prompt = f"CEFR level: {st.session_state['slider']}."
+    assert system_prompt.endswith("B1.")
+
+
+def test_sync_level_state_preserves_manual_choice(level_options):
+    st = SimpleNamespace(session_state={})
+
+    sync_level_state(
+        st,
+        student_code="stu1",
+        default_level="A2",
+        level_options=level_options,
+        slider_key="slider",
+        grammar_key="grammar",
+    )
+
+    # User adjusts level but roster remains unchanged.
+    st.session_state["slider"] = "B2"
+    st.session_state["grammar"] = "B2"
+
+    sync_level_state(
+        st,
+        student_code="stu1",
+        default_level="A2",
+        level_options=level_options,
+        slider_key="slider",
+        grammar_key="grammar",
+    )
+
+    assert st.session_state["slider"] == "B2"
+    assert st.session_state["grammar"] == "B2"


### PR DESCRIPTION
## Summary
- ensure the Topic Coach level slider resets to the roster level whenever a new student or profile level is detected
- apply the same roster-driven default to the Grammar tab slider to keep both widgets in sync
- factor the reset logic into a reusable helper and cover it with regression tests

## Testing
- pytest tests/test_level_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d033f0417c8321a62fcbba739d152a