### PR TITLE
Add student note to coursebook submissions

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2120,6 +2120,7 @@ if tab == "Dashboard":
                             "[Register online here](https://www.goethe.de/ins/gh/en/spr/prf.html)",
                         ]
                     )
+
                 )
             elif days_to_exam == 0:
                 st.success("🚀 Exam is today! Good luck!")
@@ -2984,6 +2985,8 @@ if tab == "My Course":
 
                 draft_key = f"draft_{lesson_key}"
                 st.session_state["coursebook_draft_key"] = draft_key
+                note_key = f"{lesson_key}__student_note"
+                st.session_state.setdefault(note_key, "")
                 db_locked = is_locked(student_level, code, lesson_key)
                 locked_key = f"{lesson_key}_locked"
                 if db_locked:
@@ -3044,6 +3047,10 @@ if tab == "My Course":
                         st.session_state[saved_at_key]   = (sub_ts or datetime.now(_timezone.utc))
                         st.session_state[locked_key]     = True
                         st.session_state[hydrated_key]   = True
+                        note_val = latest.get("student_note")
+                        if note_val is None:
+                            note_val = latest.get("note")
+                        st.session_state[note_key] = _safe_str(note_val, "")
                         locked = True  # enforce read-only
 
                         when = f"{sub_ts.strftime('%Y-%m-%d %H:%M')} UTC" if sub_ts else ""
@@ -3225,6 +3232,8 @@ if tab == "My Course":
                         _You’ll get an **email** when it’s marked. See **Results & Resources** for scores & feedback._
                     """)
 
+                submit_in_progress = st.session_state.get(submit_in_progress_key, False)
+
                 col1, col2, col3 = st.columns(3)
                 with col1:
                     st.markdown("#### 🧾 Finalize")
@@ -3240,133 +3249,150 @@ if tab == "My Course":
                     )
                     can_submit = (confirm_final and confirm_lock and (not locked))
 
-                    submit_in_progress = st.session_state.get(submit_in_progress_key, False)
-
-                    if st.button(
+                    submit_clicked = st.button(
                         "✅ Confirm & Submit",
                         type="primary",
                         disabled=(not can_submit) or submit_in_progress,
-                    ):
-                        st.session_state[submit_in_progress_key] = True
-                        
+                    )
+
+                with col2:
+                    st.text_area(
+                        "Add a note for your tutor (optional)",
+                        key=note_key,
+                        disabled=locked,
+                        placeholder="Share context, questions, or anything you'd like your tutor to know.",
+                        height=150,
+                    )
+
+                if submit_clicked:
+                    st.session_state[submit_in_progress_key] = True
+
+                    try:
+
+                        # 1) Try to acquire the lock first
+                        got_lock = acquire_lock(student_level, code, lesson_key)
+
+                        # If lock exists already, check whether a submission exists; if yes, reflect lock and rerun.
+                        if not got_lock:
+                            if has_existing_submission(student_level, code, lesson_key):
+                                st.session_state[locked_key] = True
+                                st.warning("You have already submitted this assignment. It is locked.")
+                                refresh_with_toast()
+                            else:
+                                st.info("Found an old lock without a submission — recovering and submitting now…")
+
+                        posts_ref = db.collection("submissions").document(student_level).collection("posts")
+
+                        # 2) Pre-create doc (avoids add() tuple-order mismatch)
+                        doc_ref = posts_ref.document()  # auto-ID now available
+                        short_ref = f"{doc_ref.id[:8].upper()}-{info['day']}"
+
+                        payload = {
+                            "student_code": code,
+                            "student_name": name or "Student",
+                            "student_email": email,
+                            "level": student_level,
+                            "day": info["day"],
+                            "chapter": chapter_name,
+                            "lesson_key": lesson_key,
+                            "answer": (st.session_state.get(draft_key, "") or "").strip(),
+                            "status": "submitted",
+                            "receipt": short_ref,  # persist receipt immediately
+                            "created_at": firestore.SERVER_TIMESTAMP,
+                            "updated_at": firestore.SERVER_TIMESTAMP,
+                            "version": 1,
+                            "student_note": (st.session_state.get(note_key, "") or "").strip(),
+                        }
+
+                        saved_ok = False
+
+                        # Archive the draft so it won't rehydrate again (drafts_v2)
                         try:
 
-                            # 1) Try to acquire the lock first
-                            got_lock = acquire_lock(student_level, code, lesson_key)
+                            doc_ref.set(payload)  # write the submission
+                            saved_ok = True
+                            st.caption(f"Saved to: `{doc_ref.path}`")  # optional debug
+                        except Exception as e:
+                            st.error(f"Could not save submission: {e}")
 
-                            # If lock exists already, check whether a submission exists; if yes, reflect lock and rerun.
-                            if not got_lock:
-                                if has_existing_submission(student_level, code, lesson_key):
-                                    st.session_state[locked_key] = True
-                                    st.warning("You have already submitted this assignment. It is locked.")
-                                    refresh_with_toast()
-                                else:
-                                    st.info("Found an old lock without a submission — recovering and submitting now…")
+                        if saved_ok:
+                            # 3) Success: lock UI, remember receipt, archive draft, notify, rerun
+                            st.session_state[locked_key] = True
+                            st.session_state[f"{lesson_key}__receipt"] = short_ref
 
-                            posts_ref = db.collection("submissions").document(student_level).collection("posts")
+                            st.success("Submitted! Your work has been sent to your tutor.")
+                            st.caption(
+                                f"Receipt: `{short_ref}` • You’ll be emailed when it’s marked. "
+                                "See **Results & Resources** for scores & feedback."
+                            )
+                            row = st.session_state.get("student_row") or {}
+                            tg_subscribed = bool(
+                                row.get("TelegramChatID")
+                                or row.get("telegram_chat_id")
+                                or row.get("Telegram")
+                                or row.get("telegram")
+                            )
+                            if not tg_subscribed:
+                                try:
+                                    tg_subscribed = has_telegram_subscription(code)
+                                except Exception:
+                                    tg_subscribed = False
+                            if tg_subscribed:
+                                st.info("You'll also receive a Telegram notification when your score is posted.")
+                            else:
+                                with st.expander("🔔 Subscribe to Telegram notifications", expanded=False):
+                                    st.markdown(
+                                        f"""1. [Open the Falowen bot](https://t.me/falowenbot) and tap **Start**\n2. Register: `/register {code}`\n3. To deactivate: send `/stop`"""
+                                    )
+                            answer_text = st.session_state.get(draft_key, "").strip()
+                            MIN_WORDS = 20
 
-                            # 2) Pre-create doc (avoids add() tuple-order mismatch)
-                            doc_ref = posts_ref.document()  # auto-ID now available
-                            short_ref = f"{doc_ref.id[:8].upper()}-{info['day']}"
+                            st.session_state[f"{lesson_key}__needs_resubmit"] = (
+                                len(answer_text.split()) < MIN_WORDS
+                            )
 
-                            payload = {
-                                "student_code": code,
-                                "student_name": name or "Student",
-                                "student_email": email,
-                                "level": student_level,
-                                "day": info["day"],
-                                "chapter": chapter_name,
-                                "lesson_key": lesson_key,
-                                "answer": (st.session_state.get(draft_key, "") or "").strip(),
-                                "status": "submitted",
-                                "receipt": short_ref,  # persist receipt immediately
-                                "created_at": firestore.SERVER_TIMESTAMP,
-                                "updated_at": firestore.SERVER_TIMESTAMP,
-                                "version": 1,
-                            }
-
-                            saved_ok = False
 
                             # Archive the draft so it won't rehydrate again (drafts_v2)
                             try:
-
-                                doc_ref.set(payload)  # write the submission
-                                saved_ok = True
-                                st.caption(f"Saved to: `{doc_ref.path}`")  # optional debug
-                            except Exception as e:
-                                st.error(f"Could not save submission: {e}")
-
-                            if saved_ok:
-                                # 3) Success: lock UI, remember receipt, archive draft, notify, rerun
-                                st.session_state[locked_key] = True
-                                st.session_state[f"{lesson_key}__receipt"] = short_ref
-
-                                st.success("Submitted! Your work has been sent to your tutor.")
-                                st.caption(
-                                    f"Receipt: `{short_ref}` • You’ll be emailed when it’s marked. "
-                                    "See **Results & Resources** for scores & feedback."
+                                _draft_doc_ref(student_level, lesson_key, code).set(
+                                    {"status": "submitted", "archived_at": firestore.SERVER_TIMESTAMP}, merge=True
                                 )
-                                row = st.session_state.get("student_row") or {}
-                                tg_subscribed = bool(
-                                    row.get("TelegramChatID")
-                                    or row.get("telegram_chat_id")
-                                    or row.get("Telegram")
-                                    or row.get("telegram")
-                                )
-                                if not tg_subscribed:
-                                    try:
-                                        tg_subscribed = has_telegram_subscription(code)
-                                    except Exception:
-                                        tg_subscribed = False
-                                if tg_subscribed:
-                                    st.info("You'll also receive a Telegram notification when your score is posted.")
-                                else:
-                                    with st.expander("🔔 Subscribe to Telegram notifications", expanded=False):
-                                        st.markdown(
-                                            f"""1. [Open the Falowen bot](https://t.me/falowenbot) and tap **Start**\n2. Register: `/register {code}`\n3. To deactivate: send `/stop`"""
-                                        )
-                                answer_text = st.session_state.get(draft_key, "").strip()
-                                MIN_WORDS = 20
+                            except Exception:
+                                pass
 
-                                st.session_state[f"{lesson_key}__needs_resubmit"] = (
-                                    len(answer_text.split()) < MIN_WORDS
+                            # Notify Slack (best-effort)
+                            webhook = get_slack_webhook()
+                            if webhook:
+                                preview_text = st.session_state.get(draft_key, "") or ""
+                                note_text = (st.session_state.get(note_key, "") or "").strip()
+                                if note_text:
+                                    if preview_text:
+                                        preview_text = f"{preview_text}\n\nStudent note: {note_text}"
+                                    else:
+                                        preview_text = f"Student note: {note_text}"
+                                notify_slack_submission(
+                                    webhook_url=webhook,
+                                    student_name=name or "Student",
+                                    student_code=code,
+                                    level=student_level,
+                                    day=info["day"],
+                                    chapter=chapter_name,
+                                    receipt=short_ref,
+                                    preview=preview_text,
                                 )
 
-
-                                # Archive the draft so it won't rehydrate again (drafts_v2)
-                                try:
-                                    _draft_doc_ref(student_level, lesson_key, code).set(
-                                        {"status": "submitted", "archived_at": firestore.SERVER_TIMESTAMP}, merge=True
-                                    )
-                                except Exception:
-                                    pass
-
-                                # Notify Slack (best-effort)
-                                webhook = get_slack_webhook()
-                                if webhook:
-                                    notify_slack_submission(
-                                        webhook_url=webhook,
-                                        student_name=name or "Student",
-                                        student_code=code,
-                                        level=student_level,
-                                        day=info["day"],
-                                        chapter=chapter_name,
-                                        receipt=short_ref,
-                                        preview=st.session_state.get(draft_key, "")
-                                    )
-
-                                # Rerun so hydration path immediately shows locked view
-                                refresh_with_toast()
-                            else:
-                                # 4) Failure: remove the lock doc so student can retry cleanly
-                                try:
-                                    db.collection("submission_locks").document(lock_id(student_level, code, lesson_key)).delete()
-                                except Exception:
-                                    pass
-                                st.warning("Submission not saved. Please fix the issue and try again.")
-                        finally:
-                            st.session_state[submit_in_progress_key] = False
-                            st.markdown("**The End**")
+                            # Rerun so hydration path immediately shows locked view
+                            refresh_with_toast()
+                        else:
+                            # 4) Failure: remove the lock doc so student can retry cleanly
+                            try:
+                                db.collection("submission_locks").document(lock_id(student_level, code, lesson_key)).delete()
+                            except Exception:
+                                pass
+                            st.warning("Submission not saved. Please fix the issue and try again.")
+                    finally:
+                        st.session_state[submit_in_progress_key] = False
+                        st.markdown("**The End**")
 
 
 


### PR DESCRIPTION
## Summary
- ensure coursebook submission state tracks a per-lesson student note and rehydrates it when locked
- add an optional "note for your tutor" textarea and persist the value to Firestore and Slack previews

## Testing
- pytest *(fails: known upstream discussion/slack and data loading tests fail in the base branch; run interrupted after failures surfaced)*

------
https://chatgpt.com/codex/tasks/task_e_68d03412ea0c83218f002e73aa8b99ef