### PR TITLE
Remove grammar CTA from assignment reminder

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2166,7 +2166,7 @@ def render_section(day_info: dict, key: str, title: str, icon: str) -> None:
             )
         if part.get('workbook_link'):
             render_link("📒 Workbook (Assignment)", part['workbook_link'])
-            render_assignment_reminder(show_grammar_cta=True)
+            render_assignment_reminder()
         extras = part.get('extra_resources')
         if extras:
             for ex in (extras if isinstance(extras, list) else [extras]):
@@ -2763,7 +2763,7 @@ if tab == "My Course":
                                 f"{key}-{idx_part}",
                                 f"Day {day_info.get('day')} Chapter {chapter}",
                             )
-                        render_assignment_reminder(show_grammar_cta=True)
+                        render_assignment_reminder()
                     if extras:
                         for ex in _as_list(extras):
                             st.markdown(f"- [🔗 Extra]({ex})")
@@ -2795,7 +2795,7 @@ if tab == "My Course":
                             f"fallback-{info.get('day', '')}",
                             f"Day {info.get('day')} Chapter {info.get('chapter', '')}",
                         )
-                    render_assignment_reminder(show_grammar_cta=True)
+                    render_assignment_reminder()
                     showed = True
                 for ex in _as_list(info.get("extra_resources")):
                     st.markdown(f"- [🔗 Extra]({ex})")

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -39,8 +39,8 @@ def _load_vocab_sheet(sheet_id: str = VOCAB_SHEET_ID) -> Optional[pd.DataFrame]:
         return None
 
 
-def render_assignment_reminder(*, show_grammar_cta: bool = False) -> None:
-    """Show a yellow assignment reminder box and optional grammar CTA."""
+def render_assignment_reminder() -> None:
+    """Show a yellow assignment reminder box."""
 
     st.markdown(
         '''
@@ -67,12 +67,6 @@ def render_assignment_reminder(*, show_grammar_cta: bool = False) -> None:
         ,
         unsafe_allow_html=True,
     )
-
-    if show_grammar_cta:
-        if st.button("Ask a grammar question", use_container_width=True):
-            st.session_state["nav_sel"] = "Chat • Grammar • Exams"
-            st.session_state["main_tab_select"] = "Chat • Grammar • Exams"
-            st.session_state["need_rerun"] = True
 
 
 def render_link(label: str, url: str) -> None:

--- a/tests/test_assignment_reminder.py
+++ b/tests/test_assignment_reminder.py
@@ -6,37 +6,28 @@ class DummyStreamlit:
         self.markdowns = []
         self.button_calls = []
         self.session_state = {}
-        self.next_button_result = False
 
     def markdown(self, text, **kwargs):  # pragma: no cover - trivial
         self.markdowns.append((text, kwargs))
 
-    def button(self, label, **kwargs):  # pragma: no cover - trivial
-        self.button_calls.append((label, kwargs))
-        return self.next_button_result
+
+def test_assignment_reminder_renders_notice(monkeypatch):
+    st = DummyStreamlit()
+    monkeypatch.setattr(ui, "st", st)
+
+    ui.render_assignment_reminder()
+
+    assert len(st.markdowns) == 1
+    text, kwargs = st.markdowns[0]
+    assert "Your Assignment" in text
+    assert kwargs.get("unsafe_allow_html") is True
 
 
-def test_assignment_reminder_no_cta_by_default(monkeypatch):
+def test_assignment_reminder_does_not_render_cta(monkeypatch):
     st = DummyStreamlit()
     monkeypatch.setattr(ui, "st", st)
 
     ui.render_assignment_reminder()
 
     assert st.button_calls == []
-
-
-def test_assignment_reminder_cta_sets_session_state(monkeypatch):
-    st = DummyStreamlit()
-    st.next_button_result = True
-    monkeypatch.setattr(ui, "st", st)
-
-    ui.render_assignment_reminder(show_grammar_cta=True)
-
-    assert st.button_calls == [
-        ("Ask a grammar question", {"use_container_width": True})
-    ]
-    assert st.session_state == {
-        "nav_sel": "Chat • Grammar • Exams",
-        "main_tab_select": "Chat • Grammar • Exams",
-        "need_rerun": True,
-    }
+    assert st.session_state == {}

--- a/tests/test_render_section_any.py
+++ b/tests/test_render_section_any.py
@@ -100,7 +100,7 @@ def test_dictionary_label_passed():
     assert captured == {"key": "lesen-0", "label": "Day 7 Chapter 2"}
 
 
-def test_assignment_reminder_receives_cta_flag():
+def test_assignment_reminder_called_without_kwargs():
     calls = []
 
     def assignment_stub(*args, **kwargs):  # pragma: no cover - trivial
@@ -112,5 +112,5 @@ def test_assignment_reminder_receives_cta_flag():
 
     assert len(calls) == 1
     assert calls[0][0] == ()
-    assert calls[0][1] == {"show_grammar_cta": True}
+    assert calls[0][1] == {}
 


### PR DESCRIPTION
## Summary
- remove the optional grammar CTA button from the assignment reminder component
- update workbook rendering paths to call the simplified reminder helper
- refresh the related tests to cover the remaining reminder behaviour

## Testing
- pytest tests/test_assignment_reminder.py tests/test_render_section_any.py

------
https://chatgpt.com/codex/tasks/task_e_68d039809730832193505d5fa1ff8186