### PR TITLE
Log grammar tab questions to Firestore

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5947,6 +5947,20 @@ if tab == "Chat • Grammar • Exams":
             placeholder = st.empty()
             placeholder.markdown("<div class='bubble-a'><div class='typing'><span></span><span></span><span></span></div></div>", unsafe_allow_html=True)
             time.sleep(random.uniform(0.8, 1.2))
+            if topic_db is None:
+                logging.debug("Grammar Firestore logging skipped: no client available")
+            else:
+                try:
+                    topic_db.collection("falowen_grammar_questions").add(
+                        {
+                            "student_code": st.session_state.get("student_code"),
+                            "level": gram_level,
+                            "question": gram_q,
+                            "created_at": firestore.SERVER_TIMESTAMP,
+                        }
+                    )
+                except Exception:
+                    logging.warning("Failed to log grammar question", exc_info=True)
             try:
                 resp = client.chat.completions.create(
                     model="gpt-4o-mini",


### PR DESCRIPTION
## Summary
- log grammar tab submissions to a new `falowen_grammar_questions` collection using the existing Firestore client
- capture student code, CEFR level, raw question text, and a server timestamp while tolerating missing Firestore clients
- keep the UI responsive by swallowing Firestore write failures with debug logging

## Testing
- `pytest` *(fails: pre-existing discussion button/classname expectations and data loading mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68d0423a97288321980afe2a54c3bb52