### PR TITLE
Adjust blog cards iframe height dynamically

### DIFF
--- a/src/blog_cards_widget.py
+++ b/src/blog_cards_widget.py
@@ -163,5 +163,40 @@ def render_blog_cards(
         .falowen-blog-wrap {{ grid-template-columns: 1fr; }}
       }}
     </style>
+    <script>
+      (() => {{
+        let lastHeight = 0;
+        const updateHeight = () => {{
+          const outer = document.querySelector('.falowen-blog-outer');
+          if (!outer) return;
+          const height = Math.ceil(outer.getBoundingClientRect().height);
+          if (!height || height === lastHeight) return;
+          lastHeight = height;
+          document.body.style.minHeight = height + 'px';
+          document.documentElement.style.minHeight = height + 'px';
+          if (window.parent && window.parent !== window) {{
+            window.parent.postMessage({{ type: 'streamlit:setFrameHeight', height }}, '*');
+          }}
+        }};
+
+        const init = () => {{
+          const outer = document.querySelector('.falowen-blog-outer');
+          if (!outer) {{
+            window.requestAnimationFrame(init);
+            return;
+          }}
+          updateHeight();
+          const observer = new ResizeObserver(() => window.requestAnimationFrame(updateHeight));
+          observer.observe(outer);
+          window.addEventListener('load', updateHeight, {{ once: true }});
+        }};
+
+        if ('ResizeObserver' in window) {{
+          init();
+        }} else {{
+          window.addEventListener('load', updateHeight);
+        }}
+      }})();
+    </script>
     """
-    components.html(html_block, height=height, scrolling=True)
+    components.html(html_block, height=height, scrolling=False)


### PR DESCRIPTION
## Summary
- inject an inline script in the blog cards widget to measure the rendered height and notify Streamlit so the iframe shrinks to fit the content
- apply the measured height to the document and disable iframe scrolling to reduce the fallback gap and remove stray scrollbars

## Testing
- pytest tests/test_login_page_blog_announcements.py
- Manual verification attempted via `streamlit run`; blocked by missing OpenAI API key in the local environment


------
https://chatgpt.com/codex/tasks/task_e_68d0444c1e58832196653af5a1835d71