### PR TITLE
Adjust blog link spacing below announcements slider

### DIFF
--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import textwrap
 import streamlit as st
 import streamlit.components.v1 as components
 
@@ -250,7 +251,16 @@ def render_announcements(announcements: list) -> None:
             if a.get("body"):
                 text += f" — {a.get('body','')}"
             st.markdown(text)
-    st.markdown("Visit [blog.falowen.app](https://blog.falowen.app) for more.")
+    st.markdown(
+        textwrap.dedent(
+            """
+            <div style="margin-top:6px;">
+              Visit <a href="https://blog.falowen.app" target="_blank" rel="noopener">blog.falowen.app</a> for more.
+            </div>
+            """
+        ).strip(),
+        unsafe_allow_html=True,
+    )
 
 
 def render_announcements_once(data: list, dashboard_active: bool) -> None:


### PR DESCRIPTION
## Summary
- wrap the post-slider blog link in an HTML block with a small top margin and render it via `st.markdown(..., unsafe_allow_html=True)`
- update announcement widget tests to expect the HTML footer and verify the unsafe flag is set

## Testing
- pytest tests/test_ui_widgets_announcements.py

------
https://chatgpt.com/codex/tasks/task_e_68d0473371208321bf5ec00cd1ba265f