### PR TITLE
Add helper for exam practice link buttons

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6047,6 +6047,22 @@ if tab == "Chat • Grammar • Exams":
 
         sub_speak, sub_lesen, sub_hoeren = st.tabs(["🗣️ Speaking", "📖 Lesen", "🎧 Hören"])
 
+        def _link_buttons(links: Iterable[Tuple[str, str]]) -> None:
+            """Render a set of practice links as buttons in the Exams tab."""
+
+            items = list(links or [])
+            if not items:
+                st.caption("No practice links available for this level yet.")
+                return
+
+            for idx, (label, url) in enumerate(items):
+                if not label or not url:
+                    continue
+
+                key_seed = f"{label}|{url}|{idx}"
+                btn_key = f"exam_link_{hashlib.md5(key_seed.encode()).hexdigest()[:8]}"
+                st.link_button(label, url, use_container_width=True, key=btn_key)
+
 
     with sub_speak:
         st.markdown(


### PR DESCRIPTION
## Summary
- add a `_link_buttons` helper within the Exams tab to render level-specific practice links
- use the helper for Lesen and Hören so missing link sets are handled gracefully

## Testing
- python -m compileall a1sprechen.py

------
https://chatgpt.com/codex/tasks/task_e_68d14b9329f883218fb868a2cd5cb1dc