### PR TITLE
Remove unsupported key argument from exam link buttons

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6059,9 +6059,7 @@ if tab == "Chat • Grammar • Exams":
                 if not label or not url:
                     continue
 
-                key_seed = f"{label}|{url}|{idx}"
-                btn_key = f"exam_link_{hashlib.md5(key_seed.encode()).hexdigest()[:8]}"
-                st.link_button(label, url, use_container_width=True, key=btn_key)
+                st.link_button(label, url, use_container_width=True)
 
 
     with sub_speak:


### PR DESCRIPTION
## Summary
- remove the custom key generation from the exam practice link buttons to avoid passing the unsupported `key` argument to `st.link_button`

## Testing
- pytest *(fails: existing test suite expects class discussion button wiring and data_loading.request mock signatures)*

------
https://chatgpt.com/codex/tasks/task_e_68d14e18fa3c83219426168addb19e01