### PR TITLE
Clear draft session state during logout

### DIFF
--- a/src/logout.py
+++ b/src/logout.py
@@ -26,6 +26,28 @@ def do_logout(
     except Exception:
         logger.exception("Token revoke failed on logout")
 
+    draft_keys = {
+        "coursebook_draft_key",
+        "__active_draft_key",
+        "falowen_chat_draft_key",
+    }
+    draft_prefixes = ("draft_", "falowen_chat_draft_")
+
+    for key in list(st_module.session_state.keys()):
+        should_clear = False
+        if key in draft_keys:
+            should_clear = True
+        elif any(key.startswith(prefix) for prefix in draft_prefixes):
+            should_clear = True
+        else:
+            for base_key in draft_keys:
+                if key.startswith(f"{base_key}__") or key.startswith(f"{base_key}_"):
+                    should_clear = True
+                    break
+
+        if should_clear:
+            st_module.session_state.pop(key, None)
+
     st_module.session_state.update(
         {
             "logged_in": False,

--- a/tests/test_logout_clears_drafts.py
+++ b/tests/test_logout_clears_drafts.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock
+import types
+
+from src.logout import do_logout
+
+
+def test_logout_clears_all_draft_state():
+    session_state = {
+        "draft_sample": "draft",
+        "draft_sample__last_val": "draft",
+        "draft_sample__pending_reload": True,
+        "coursebook_draft_key": "draft_sample",
+        "coursebook_draft_key__hydrated_v2": True,
+        "coursebook_draft_key_saved": True,
+        "__active_draft_key": "draft_sample",
+        "__active_draft_key__last_ts": 123,
+        "falowen_chat_draft_key": "falowen_chat_draft_1",
+        "falowen_chat_draft_key__reload_text": "hello",
+        "falowen_chat_draft_key__pending_reload": True,
+        "falowen_chat_draft_topic": "Hi",
+        "falowen_chat_draft_topic__last_val": "Hi",
+        "unrelated": "keep",
+        "another_key_saved": True,
+    }
+
+    success_calls = {}
+
+    def success(message: str) -> None:
+        success_calls["message"] = message
+        assert all(not k.startswith("draft_") for k in session_state)
+        assert "coursebook_draft_key" not in session_state
+        assert "__active_draft_key" not in session_state
+        assert "falowen_chat_draft_key" not in session_state
+        assert all(
+            not k.startswith("falowen_chat_draft_") for k in session_state
+        )
+
+    mock_st = types.SimpleNamespace(
+        session_state=session_state,
+        query_params={},
+        success=success,
+    )
+
+    do_logout(
+        st_module=mock_st,
+        destroy_token=MagicMock(),
+        logger=types.SimpleNamespace(exception=MagicMock()),
+    )
+
+    assert success_calls["message"] == "You’ve been logged out."
+    assert "draft_sample" not in session_state
+    assert "draft_sample__last_val" not in session_state
+    assert "draft_sample__pending_reload" not in session_state
+    assert "coursebook_draft_key" not in session_state
+    assert "coursebook_draft_key__hydrated_v2" not in session_state
+    assert "coursebook_draft_key_saved" not in session_state
+    assert "__active_draft_key" not in session_state
+    assert "__active_draft_key__last_ts" not in session_state
+    assert "falowen_chat_draft_key" not in session_state
+    assert "falowen_chat_draft_key__reload_text" not in session_state
+    assert "falowen_chat_draft_key__pending_reload" not in session_state
+    assert "falowen_chat_draft_topic" not in session_state
+    assert "falowen_chat_draft_topic__last_val" not in session_state
+
+    assert session_state["unrelated"] == "keep"
+    assert session_state["another_key_saved"] is True
+    assert session_state["logged_in"] is False
+    assert session_state["student_row"] == {}
+    assert session_state["student_code"] == ""
+    assert session_state["student_name"] == ""
+    assert session_state["session_token"] == ""
+    assert session_state["student_level"] == ""
+    assert session_state["need_rerun"] is True


### PR DESCRIPTION
## Summary
- clear all coursebook and chat draft session keys before resetting logout state
- remove associated draft metadata entries so the next login starts clean
- add a regression test confirming draft state is cleared and unrelated keys persist

## Testing
- pytest *(fails: existing class discussion, roster loading, and turn count tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d14fa6f34c83219dd47bf060c3439a