### PR TITLE
Enable coursebook resubmission flow

### DIFF
--- a/src/firestore_helpers.py
+++ b/src/firestore_helpers.py
@@ -36,6 +36,16 @@ def lock_id(level: str, code: str, lesson_key: str) -> str:
     return f"{level}__{safe_code}__{lesson_key}"
 
 
+def clear_lock(level: str, code: str, lesson_key: str) -> None:
+    """Best-effort removal of an existing submission lock document."""
+    db = _get_db()
+    try:
+        db.collection("submission_locks").document(lock_id(level, code, lesson_key)).delete()
+    except Exception:
+        # Non-fatal: lock cleanup is best-effort only.
+        pass
+
+
 def has_existing_submission(level: str, code: str, lesson_key: str) -> bool:
     """True if a submission exists for this (level, code, lesson_key)."""
     db = _get_db()
@@ -150,7 +160,10 @@ def fetch_latest(level: str, code: str, lesson_key: str) -> Optional[Dict[str, A
             .stream()
         )
         for d in docs:
-            return d.to_dict()
+            payload = d.to_dict() or {}
+            payload.setdefault("__id", d.id)
+            payload.setdefault("__path", d.reference.path)
+            return payload
     except Exception:
         try:
             docs = (
@@ -158,7 +171,12 @@ def fetch_latest(level: str, code: str, lesson_key: str) -> Optional[Dict[str, A
                 .where(filter=FieldFilter("lesson_key", "==", lesson_key))
                 .stream()
             )
-            items = [d.to_dict() for d in docs]
+            items = []
+            for d in docs:
+                payload = d.to_dict() or {}
+                payload.setdefault("__id", d.id)
+                payload.setdefault("__path", getattr(d, "reference", None) and d.reference.path)
+                items.append(payload)
             items.sort(key=lambda x: x.get("updated_at"), reverse=True)
             return items[0] if items else None
         except Exception:
@@ -169,6 +187,7 @@ def fetch_latest(level: str, code: str, lesson_key: str) -> Optional[Dict[str, A
 __all__ = [
     "lesson_key_build",
     "lock_id",
+    "clear_lock",
     "has_existing_submission",
     "acquire_lock",
     "is_locked",

--- a/tests/test_submit_resubmit_flow.py
+++ b/tests/test_submit_resubmit_flow.py
@@ -1,0 +1,78 @@
+import ast
+import math
+import re
+import textwrap
+import types
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
+
+
+def _load_resubmit_helpers():
+    src_path = Path("a1sprechen.py")
+    source = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename="a1sprechen.py")
+
+    class Finder(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.positions: dict[str, tuple[int, int]] = {}
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # pragma: no cover - AST traversal helper
+            self.positions[node.name] = (node.lineno, node.end_lineno)
+            self.generic_visit(node)
+
+    finder = Finder()
+    finder.visit(tree)
+
+    start = finder.positions["_extract_assignment_numbers_for_resubmit"][0] - 1
+    end = finder.positions["_should_abort_submission_for_existing_attempt"][1]
+    snippet = textwrap.dedent("\n".join(source.splitlines()[start:end]))
+
+    module = types.ModuleType("resubmit_helpers")
+    module.re = re
+    module.math = math
+    module.Callable = Callable
+    module.Any = Any
+    module.Dict = Dict
+    module.Iterable = Iterable
+    module.List = List
+    module.Optional = Optional
+    module.Tuple = Tuple
+    module.Set = Set
+    module.MIN_RESUBMIT_WORD_COUNT = 20
+    module._ASSIGNMENT_NUMBER_PATTERN = re.compile(r"\d+(?:\.\d+)?")
+
+    exec(snippet, module.__dict__)
+    return module
+
+
+def test_resubmit_unlocks_editor_when_summary_flags():
+    helpers = _load_resubmit_helpers()
+    unlock = helpers._compute_resubmit_unlock_state
+
+    summary = {"failed_identifiers": [1.0]}
+    lesson = {"assignment": True, "chapter": "1.0"}
+    needs_resubmit, locked_after = unlock(
+        True,
+        summary=summary,
+        lesson=lesson,
+        answer_text="word " * 32,
+        min_words=helpers.MIN_RESUBMIT_WORD_COUNT,
+    )
+
+    assert needs_resubmit is True
+    assert locked_after is False
+
+
+def test_resubmit_skip_already_submitted_warning():
+    helpers = _load_resubmit_helpers()
+    guard = helpers._should_abort_submission_for_existing_attempt
+
+    abort, recovered = guard(
+        needs_resubmit=True,
+        got_lock=False,
+        has_existing_submission_fn=lambda: True,
+    )
+
+    assert abort is False
+    assert recovered is True
+


### PR DESCRIPTION
## Summary
- compute resubmit state before enforcing the coursebook lock, clear stale submission locks, and reuse existing submission docs so flagged lessons can be edited and resubmitted in-app
- extend Firestore helpers with a lock clearer and enrich `fetch_latest` responses with document metadata to support resubmission updates
- add regression coverage that exercises the resubmit unlock helper and verifies the submission guard bypasses the "already submitted" warning for flagged attempts

## Testing
- pytest tests/test_coursebook_resubmit_logic.py tests/test_submit_resubmit_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d16cf892a0832191d7a5dece2997da