### PR TITLE
Update coursebook status labels to new wording

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -498,13 +498,13 @@ def _build_coursebook_status_payload(
     passed = best_score is not None and best_score >= PASS_MARK
 
     if needs_resubmit:
-        label = "Resubmit needed"
+        label = "Resubmission needed"
     elif passed:
-        label = "Passed"
+        label = "Completed"
     elif has_submission:
         label = "In review"
     else:
-        label = "Draft"
+        label = "Not yet submitted"
 
     meta_lines: List[str] = []
 
@@ -525,9 +525,9 @@ def _build_coursebook_status_payload(
     if last_submission_str:
         meta_lines.insert(0, f"Last submitted: {last_submission_str}")
 
-    if label == "Draft" and not meta_lines:
+    if label == "Not yet submitted" and not meta_lines:
         meta_lines.append("No submission yet.")
-    elif label == "Resubmit needed" and not meta_lines:
+    elif label == "Resubmission needed" and not meta_lines:
         meta_lines.append("Tutor requested another attempt.")
 
     payload = {
@@ -553,19 +553,21 @@ def _render_coursebook_status_banner(payload: Dict[str, Any]) -> None:
     if not isinstance(payload, dict) or not payload:
         return
 
-    label = str(payload.get("label") or "Draft")
+    default_label = "Not yet submitted"
+    label = str(payload.get("label") or default_label)
     icon_map = {
-        "Passed": "✅",
+        "Completed": "✅",
         "In review": "⏳",
-        "Resubmit needed": "⚠️",
-        "Draft": "📝",
+        "Resubmission needed": "⚠️",
+        "Not yet submitted": "📝",
     }
     color_map = {
-        "Passed": "#dcfce7",
+        "Completed": "#dcfce7",
         "In review": "#fef9c3",
-        "Resubmit needed": "#fee2e2",
-        "Draft": "#e0f2fe",
+        "Resubmission needed": "#fee2e2",
+        "Not yet submitted": "#e0f2fe",
     }
+    default_color = color_map.get(default_label, "#e0f2fe")
 
     meta_lines = [str(line).strip() for line in payload.get("meta_lines", []) if str(line).strip()]
     meta_html = "".join(
@@ -579,11 +581,11 @@ def _render_coursebook_status_banner(payload: Dict[str, Any]) -> None:
             border-radius: 10px;
             padding: 0.75rem 1rem;
             margin-bottom: 0.75rem;
-            background: {color_map.get(label, '#e0f2fe')};
+            background: {color_map.get(label, default_color)};
             border: 1px solid rgba(15, 23, 42, 0.12);
         ">
             <div style="font-weight:600;color:#0f172a;">
-                {icon_map.get(label, '📝')} {html.escape(label)}
+                {icon_map.get(label, icon_map.get(default_label, '📝'))} {html.escape(label)}
             </div>
             {meta_html}
         </div>

--- a/tests/test_coursebook_status_helper.py
+++ b/tests/test_coursebook_status_helper.py
@@ -5,7 +5,7 @@ import textwrap
 import types
 from pathlib import Path
 from datetime import datetime, UTC
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import pandas as pd
 import pytest
@@ -44,6 +44,8 @@ def _load_status_helper():
     mod.MIN_RESUBMIT_WORD_COUNT = 20
     mod.Iterable = Iterable
     mod.List = List
+    mod.Tuple = Tuple
+    mod.Callable = Callable
     mod.Dict = Dict
     mod.Optional = Optional
     mod.Any = Any
@@ -72,8 +74,8 @@ def _make_summary(score_value):
 @pytest.mark.parametrize(
     "needs_resubmit,score_value,expected_label",
     [
-        (True, 50, "Resubmit needed"),
-        (False, 85, "Passed"),
+        (True, 50, "Resubmission needed"),
+        (False, 85, "Completed"),
         (False, None, "In review"),
     ],
 )
@@ -98,4 +100,16 @@ def test_coursebook_status_helper_labels(status_helper, needs_resubmit, score_va
         assert "85" in lines
     if expected_label == "In review":
         assert any("Last submitted" in line for line in payload.get("meta_lines", []))
+
+
+def test_coursebook_status_helper_not_yet_submitted(status_helper):
+    payload = status_helper(
+        latest_submission=None,
+        needs_resubmit=False,
+        attempts_summary=None,
+        assignment_identifiers=[1.0],
+    )
+
+    assert payload["label"] == "Not yet submitted"
+    assert "No submission yet." in " ".join(payload.get("meta_lines", []))
 


### PR DESCRIPTION
## Summary
- rename coursebook status labels to the new copy and update fallback banner messaging
- refresh the banner rendering defaults, icon map, and color map to use the new labels
- adjust coursebook status helper tests to expect the updated wording and cover the no-submission state

## Testing
- pytest tests/test_coursebook_status_helper.py


------
https://chatgpt.com/codex/tasks/task_e_68d1731d74c4832187c409fe59f2a5b8