### PR TITLE
Handle negated resubmission cues in textual score inference

### DIFF
--- a/tests/test_coursebook_status_helper.py
+++ b/tests/test_coursebook_status_helper.py
@@ -153,6 +153,8 @@ def test_textual_status_populates_failed_identifiers(monkeypatch, score_text, st
         (None, "Resubmission needed", "Resubmission needed", True),
         ("Pass", None, "Completed", False),
         (None, "Completed", "Completed", False),
+        ("Completed - no resubmission needed", None, "Completed", False),
+        (None, "Completed - resubmission not required", "Completed", False),
     ],
 )
 def test_coursebook_status_helper_textual_fallback(


### PR DESCRIPTION
## Summary
- recognize negated resubmission phrasing before classifying textual score states
- prevent resubmission keywords paired with clear pass cues from triggering failure when no resubmission is required
- add regression coverage for completed statuses that explicitly state no resubmission is needed

## Testing
- pytest tests/test_coursebook_status_helper.py

------
https://chatgpt.com/codex/tasks/task_e_68d1811d18848321bd8dc475888a41df