### PR TITLE
Ensure textual pass clears fallback resubmit flag

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -484,6 +484,7 @@ def _build_coursebook_status_payload(
     attempts_count = 0
     last_scored = ""
     textual_outcome: Optional[str] = None
+    explicit_fail = False
 
     if best_row is not None:
         score_display = str(best_row.get("score_display") or "").strip()
@@ -502,13 +503,23 @@ def _build_coursebook_status_payload(
             status_text,
         )
 
-    passed = best_score is not None and best_score >= PASS_MARK
-
-    if best_score is None:
-        if textual_outcome == "pass":
+    passed = False
+    if best_score is not None:
+        if best_score >= PASS_MARK:
             passed = True
-        elif textual_outcome == "fail":
-            needs_resubmit_flag = True
+        else:
+            explicit_fail = True
+
+    if textual_outcome == "fail":
+        explicit_fail = True
+        passed = False
+    elif textual_outcome == "pass" and best_score is None:
+        passed = True
+
+    if explicit_fail:
+        needs_resubmit_flag = True
+    elif passed:
+        needs_resubmit_flag = False
 
     if needs_resubmit_flag:
         label = "Resubmission needed"

--- a/tests/test_coursebook_status_helper.py
+++ b/tests/test_coursebook_status_helper.py
@@ -172,3 +172,17 @@ def test_coursebook_status_helper_textual_fallback(
     assert payload["label"] == expected_label
     assert payload["needs_resubmit"] is expected_resubmit
 
+
+def test_coursebook_status_helper_soft_resubmit_clears_on_textual_pass(status_helper):
+    summary_df = _make_summary(None, status_value="Completed")
+
+    payload = status_helper(
+        latest_submission={"answer": "Hallo"},
+        needs_resubmit=True,
+        attempts_summary=summary_df,
+        assignment_identifiers=[1.0],
+    )
+
+    assert payload["label"] == "Completed"
+    assert payload["needs_resubmit"] is False
+


### PR DESCRIPTION
## Summary
- update the coursebook status payload helper to treat textual pass outcomes as clearing soft resubmit flags while preserving explicit failure overrides
- add a regression test covering a textual pass with a non-numeric score so the status banner displays "Completed"

## Testing
- pytest tests/test_coursebook_status_helper.py

------
https://chatgpt.com/codex/tasks/task_e_68d1863ecc508321b52f94d1d95f8889