### PR TITLE
Add Firestore score integration for coursebook submissions

### DIFF
--- a/src/firestore_helpers.py
+++ b/src/firestore_helpers.py
@@ -4,8 +4,12 @@ These helpers were previously embedded in ``a1sprechen.py`` but moving them
 here keeps the entrypoint slimmer and improves reusability.
 """
 
+from __future__ import annotations
+
+import math
 import re
-from typing import Any, Dict, Optional
+from datetime import datetime
+from typing import Any, Dict, Iterable, Optional
 
 from firebase_admin import firestore
 from google.cloud.firestore_v1 import FieldFilter
@@ -166,6 +170,190 @@ def fetch_latest(level: str, code: str, lesson_key: str) -> Optional[Dict[str, A
     return None
 
 
+def _coerce_score_value(value: Any) -> Optional[float]:
+    """Best-effort conversion of a score value to ``float``."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)):
+        try:
+            if math.isnan(value):  # type: ignore[arg-type]
+                return None
+        except Exception:
+            pass
+        try:
+            return float(value)
+        except Exception:
+            return None
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        text = text.replace("%", "")
+        match = re.search(r"-?\d+(?:\.\d+)?", text)
+        if match:
+            try:
+                return float(match.group())
+            except Exception:
+                return None
+    return None
+
+
+def _score_timestamp(value: Any) -> float:
+    """Return a comparable timestamp for ordering score documents."""
+
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        try:
+            return float(value)
+        except Exception:
+            return 0.0
+    if isinstance(value, datetime):
+        try:
+            return float(value.timestamp())
+        except Exception:
+            return 0.0
+    try:
+        if hasattr(value, "timestamp"):
+            return float(value.timestamp())  # type: ignore[call-arg]
+    except Exception:
+        pass
+    return 0.0
+
+
+def _score_matches_lesson(doc: Dict[str, Any], lesson_key: str) -> bool:
+    key_norm = (lesson_key or "").strip().lower()
+    if not key_norm:
+        return False
+    for field in ("lesson_key", "lessonKey", "lesson", "chapter"):
+        value = doc.get(field)
+        if value is None:
+            continue
+        text = str(value).strip().lower()
+        if text == key_norm:
+            return True
+    return False
+
+
+def _score_candidates(ref, filters: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    try:
+        query = ref
+        for field, value in filters.items():
+            query = query.where(filter=FieldFilter(field, "==", value))
+        docs = [doc.to_dict() for doc in query.stream()]
+    except Exception:
+        return []
+
+    docs.sort(
+        key=lambda item: _score_timestamp(
+            item.get("updated_at")
+            or item.get("graded_at")
+            or item.get("created_at")
+        ),
+        reverse=True,
+    )
+    return docs
+
+
+def fetch_latest_score(
+    student_code: str,
+    lesson_key: str,
+    submission: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return the most recent score document for this lesson.
+
+    The helper first tries to match on explicit submission identifiers before
+    falling back to ``student_code``/``lesson_key`` pairs. The returned
+    dictionary contains the original document data plus a ``numeric_score`` key
+    when a numeric value could be inferred.
+    """
+
+    db = _get_db()
+    if db is None:
+        return None
+
+    try:
+        scores_ref = db.collection("scores")
+    except Exception:
+        return None
+
+    candidates: list[Dict[str, Any]] = []
+
+    def _extend_from(filters: Dict[str, Any]) -> None:
+        for doc in _score_candidates(scores_ref, filters):
+            candidates.append(doc)
+
+    submission_ids: list[str] = []
+    if submission:
+        for key in (
+            "submission_id",
+            "submissionId",
+            "submission_doc_id",
+            "submission",
+            "id",
+            "doc_id",
+        ):
+            value = submission.get(key)
+            if value:
+                text = str(value).strip()
+                if text:
+                    submission_ids.append(text)
+
+    for sid in submission_ids:
+        for field in ("submission_id", "submissionId", "submission_doc_id"):
+            _extend_from({field: sid})
+        if candidates:
+            break
+
+    student_code = (student_code or "").strip()
+    lesson_key = (lesson_key or "").strip()
+
+    if not candidates and student_code and lesson_key:
+        for code_field in ("student_code", "studentCode", "studentcode"):
+            for lesson_field in ("lesson_key", "lessonKey"):
+                _extend_from({code_field: student_code, lesson_field: lesson_key})
+            if candidates:
+                break
+
+    if not candidates and student_code:
+        for code_field in ("student_code", "studentCode", "studentcode"):
+            for doc in _score_candidates(scores_ref, {code_field: student_code}):
+                if lesson_key and _score_matches_lesson(doc, lesson_key):
+                    candidates.append(doc)
+            if candidates:
+                break
+
+    if not candidates:
+        return None
+
+    best = candidates[0]
+    payload = dict(best)
+
+    numeric_score: Optional[float] = None
+    for key in (
+        "numeric_score",
+        "score",
+        "percentage",
+        "percent",
+        "points",
+        "marks",
+    ):
+        numeric_score = _coerce_score_value(payload.get(key))
+        if numeric_score is not None:
+            break
+    if numeric_score is not None:
+        payload["numeric_score"] = numeric_score
+
+    status_value = payload.get("status") or payload.get("status_text")
+    if isinstance(status_value, str):
+        payload["status_text"] = status_value.strip()
+
+    return payload
+
+
 __all__ = [
     "lesson_key_build",
     "lock_id",
@@ -174,4 +362,5 @@ __all__ = [
     "is_locked",
     "resolve_current_content",
     "fetch_latest",
+    "fetch_latest_score",
 ]

--- a/tests/test_submit_status_from_scores.py
+++ b/tests/test_submit_status_from_scores.py
@@ -1,0 +1,105 @@
+import ast
+import math
+import re
+import textwrap
+import types
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+import pytest
+
+
+def _load_submit_status_helper():
+    src_path = Path("a1sprechen.py")
+    source = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename="a1sprechen.py")
+
+    class Finder(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.positions: Dict[str, tuple[int, int]] = {}
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # pragma: no cover - AST helper
+            self.positions[node.name] = (node.lineno, node.end_lineno)
+            self.generic_visit(node)
+
+    finder = Finder()
+    finder.visit(tree)
+
+    start, end = finder.positions["_derive_coursebook_submit_status"]
+    snippet = textwrap.dedent("\n".join(source.splitlines()[start - 1 : end]))
+
+    module = types.ModuleType("submit_status_helper")
+    module.math = math
+    module.re = re
+    module.Any = Any
+    module.Dict = Dict
+    module.Optional = Optional
+    module.Callable = Callable
+
+    exec(snippet, module.__dict__)
+    return module
+
+
+@pytest.fixture()
+def submit_status_helper():
+    module = _load_submit_status_helper()
+    helper = module._derive_coursebook_submit_status
+    return helper, module
+
+
+def test_submit_status_in_review(submit_status_helper, monkeypatch):
+    helper, module = submit_status_helper
+    monkeypatch.setattr(module, "fetch_latest_score", lambda *_: None, raising=False)
+
+    state = helper(
+        locked=True,
+        needs_resubmit=None,
+        latest_submission={"answer": "Hallo"},
+        student_code="S1",
+        lesson_key="A1_day1_ch1",
+        pass_mark=60.0,
+    )
+
+    assert state["status_label"] == "In review"
+    assert state["locked"] is True
+    assert state["needs_resubmit"] is False
+    assert state["from_scores"] is True
+    assert state["clear_lock"] is False
+
+
+def test_submit_status_completed(submit_status_helper, monkeypatch):
+    helper, module = submit_status_helper
+    monkeypatch.setattr(module, "fetch_latest_score", lambda *_: {"score": 85}, raising=False)
+
+    state = helper(
+        locked=True,
+        needs_resubmit=True,
+        latest_submission={"answer": "Hallo"},
+        student_code="S1",
+        lesson_key="A1_day1_ch1",
+        pass_mark=60.0,
+    )
+
+    assert state["status_label"] == "Passed/Completed"
+    assert state["needs_resubmit"] is False
+    assert state["locked"] is True
+    assert state["clear_lock"] is False
+
+
+def test_submit_status_triggers_resubmit(submit_status_helper, monkeypatch):
+    helper, module = submit_status_helper
+    monkeypatch.setattr(module, "fetch_latest_score", lambda *_: {"score": 40}, raising=False)
+
+    state = helper(
+        locked=True,
+        needs_resubmit=None,
+        latest_submission={"answer": "Hallo"},
+        student_code="S1",
+        lesson_key="A1_day1_ch1",
+        pass_mark=60.0,
+    )
+
+    assert state["status_label"] == "Resubmission needed"
+    assert state["needs_resubmit"] is True
+    assert state["locked"] is False
+    assert state["clear_lock"] is True


### PR DESCRIPTION
## Summary
- add a Firestore helper to retrieve the latest score/status for a lesson
- surface score-derived status in the Course Book submit workflow and unlock on failed scores
- cover score status paths with a focused unit test harness

## Testing
- pytest (fails: existing coursebook helpers missing `_extract_assignment_numbers_for_resubmit` and data loading tests expect different request signature)
- pytest tests/test_submit_status_from_scores.py


------
https://chatgpt.com/codex/tasks/task_e_68d191d413ac832192e9f4524c46258a