### PR TITLE
Handle Firestore FieldFilter fallback

### DIFF
--- a/src/schreiben.py
+++ b/src/schreiben.py
@@ -15,7 +15,12 @@ import pandas as pd
 
 import streamlit as st
 from google.api_core.exceptions import GoogleAPICallError
-from google.cloud.firestore_v1 import FieldFilter
+
+try:  # FieldFilter is optional in local/unit test environments
+    from google.cloud.firestore_v1 import FieldFilter
+except ImportError:  # pragma: no cover - fallback path covered in tests
+    FieldFilter = None  # type: ignore[assignment]
+
 from firebase_admin import firestore
 
 try:  # Firestore may be unavailable in tests
@@ -29,6 +34,14 @@ db = None  # type: ignore
 
 def _get_db():
     return db if db is not None else get_db()
+
+
+def _firestore_where(query, field: str, op: str, value):
+    """Apply a Firestore ``where`` clause regardless of FieldFilter availability."""
+
+    if FieldFilter is None:
+        return query.where(field, op, value)
+    return query.where(filter=FieldFilter(field, op, value))
 
 
 # ---------------------------------------------------------------------------
@@ -202,9 +215,10 @@ def update_schreiben_stats(student_code: str) -> None:
         st.warning("Firestore not initialized; skipping stats update.")
         return
 
-    submissions = db.collection("schreiben_submissions").where(
-        filter=FieldFilter("student_code", "==", student_code)
-    ).stream()
+    submissions_query = _firestore_where(
+        db.collection("schreiben_submissions"), "student_code", "==", student_code
+    )
+    submissions = submissions_query.stream()
 
     total = 0
     passed = 0

--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -14,7 +14,11 @@ import html  # noqa: F401
 
 import bcrypt
 import streamlit as st
-from google.cloud.firestore_v1 import FieldFilter
+
+try:  # FieldFilter may be unavailable in local test environments
+    from google.cloud.firestore_v1 import FieldFilter
+except ImportError:  # pragma: no cover - fallback path covered via tests
+    FieldFilter = None  # type: ignore[assignment]
 from falowen.email_utils import send_reset_email, build_gas_reset_link
 from falowen.sessions import create_session_token, destroy_session_token
 from src.auth import persist_session_client
@@ -24,6 +28,14 @@ from src.session_management import determine_level
 from src.ui_helpers import qp_get, qp_clear
 from src.services.contracts import contract_active
 from src.utils.toasts import refresh_with_toast, toast_ok, toast_err
+
+
+def _firestore_where(query, field: str, op: str, value):
+    """Apply a Firestore ``where`` using ``FieldFilter`` when available."""
+
+    if FieldFilter is None:
+        return query.where(field, op, value)
+    return query.where(filter=FieldFilter(field, op, value))
 
 
 # Google OAuth configuration
@@ -387,13 +399,10 @@ def render_forgot_password_panel() -> None:
                     return db
 
             db = get_db()
-            user_query = db.collection("students").where(
-                filter=FieldFilter("email", "==", e)
-            ).get()
+            students = db.collection("students")
+            user_query = _firestore_where(students, "email", "==", e).get()
             if not user_query:
-                user_query = db.collection("students").where(
-                    filter=FieldFilter("Email", "==", e)
-                ).get()
+                user_query = _firestore_where(students, "Email", "==", e).get()
             if not user_query:
                 st.error("No account found with that email.")
             else:

--- a/tests/test_firestore_where_compat.py
+++ b/tests/test_firestore_where_compat.py
@@ -1,0 +1,53 @@
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+
+MODULES = [
+    "src.firestore_helpers",
+    "src.schreiben",
+    "src.ui.auth",
+]
+
+
+class _SentinelFieldFilter:
+    """Simple stand-in that stores the arguments it was initialised with."""
+
+    def __init__(self, *args):
+        self.args = args
+
+
+@pytest.mark.parametrize("module_name", MODULES)
+def test_firestore_where_prefers_filter(monkeypatch, module_name):
+    module = importlib.import_module(module_name)
+    query = MagicMock()
+    chained = MagicMock(name="filtered_query")
+    query.where.return_value = chained
+
+    monkeypatch.setattr(module, "FieldFilter", _SentinelFieldFilter, raising=False)
+
+    result = module._firestore_where(query, "field", "==", "value")
+
+    query.where.assert_called_once()
+    kwargs = query.where.call_args.kwargs
+    assert "filter" in kwargs
+    sentinel = kwargs["filter"]
+    assert isinstance(sentinel, _SentinelFieldFilter)
+    assert sentinel.args == ("field", "==", "value")
+    assert result is chained
+
+
+@pytest.mark.parametrize("module_name", MODULES)
+def test_firestore_where_fallback(monkeypatch, module_name):
+    module = importlib.import_module(module_name)
+    query = MagicMock()
+    chained = MagicMock(name="filtered_query")
+    query.where.return_value = chained
+
+    monkeypatch.setattr(module, "FieldFilter", None, raising=False)
+
+    result = module._firestore_where(query, "field", "==", "value")
+
+    query.where.assert_called_once_with("field", "==", "value")
+    assert result is chained


### PR DESCRIPTION
## Summary
- wrap Firestore FieldFilter imports in try/except and add helper to use legacy where() when the class is unavailable
- update Firestore queries across the app to go through the compatibility helper
- add tests covering both FieldFilter-present and fallback code paths for key modules

## Testing
- pytest tests/test_firestore_where_compat.py tests/test_schreiben_helpers.py


------
https://chatgpt.com/codex/tasks/task_e_68d1a040715c8321ac2b3e1f7976d112