### PR TITLE
Fix welcome video HTML style string

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1385,10 +1385,8 @@ def render_level_welcome_video(level: str | None):
     if not vid:
         st.info(f"No welcome video added yet for {level}. Check back soon!")
         return
-    components.html(
-        f"""
-        <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:12px;
-                    box-shadow:0 4px 12px rgba(0,0,0,.08);">
+    html = f"""
+        <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:12px;box-shadow:0 4px 12px rgba(0,0,0,.08);">
           <iframe
             src="https://www.youtube.com/embed/{vid}"
             title="Welcome • {level}"
@@ -1398,8 +1396,8 @@ def render_level_welcome_video(level: str | None):
             style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;border-radius:12px;">
           </iframe>
         </div>
-        """, height=320, scrolling=False
-    )
+    """
+    components.html(html, height=320, scrolling=False)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- refactor the HTML snippet for the welcome video to keep the style attribute on a single line
- pass the formatted HTML string through a temporary variable when rendering the component

## Testing
- python -m py_compile a1sprechen.py
- streamlit run a1sprechen.py

------
https://chatgpt.com/codex/tasks/task_e_68d2419dea708321890b07f3f4c46551