### PR TITLE
Handle non-assignment lessons in resubmit detection

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -464,6 +464,26 @@ def _extract_assignment_numbers_for_resubmit(lesson: Optional[Dict[str, Any]]) -
     return sorted(numbers)
 
 
+def _lesson_contains_assignment_flag(node: Any) -> bool:
+    """Return ``True`` when ``node`` contains a truthy ``assignment`` flag."""
+
+    if isinstance(node, dict):
+        if node.get("assignment"):
+            return True
+        for value in node.values():
+            if _lesson_contains_assignment_flag(value):
+                return True
+        return False
+
+    if isinstance(node, (list, tuple, set)):
+        for item in node:
+            if _lesson_contains_assignment_flag(item):
+                return True
+        return False
+
+    return False
+
+
 def determine_needs_resubmit(
     summary: Optional[Dict[str, Any]],
     lesson: Optional[Dict[str, Any]],
@@ -505,8 +525,12 @@ def determine_needs_resubmit(
                     continue
 
     lesson_numbers = set(_extract_assignment_numbers_for_resubmit(lesson))
+    has_assignment_flag = _lesson_contains_assignment_flag(lesson)
     if failed_numbers and lesson_numbers & failed_numbers:
         return True
+
+    if not lesson_numbers and not has_assignment_flag:
+        return False
 
     words = (answer_text or "").split()
     try:

--- a/tests/test_coursebook_resubmit_logic.py
+++ b/tests/test_coursebook_resubmit_logic.py
@@ -73,3 +73,11 @@ def test_determine_needs_resubmit_detects_nested_assignment():
     long_answer = "word " * 25
 
     assert determine(summary, lesson, answer_text=long_answer) is True
+
+
+def test_determine_needs_resubmit_skips_word_count_for_non_assignment():
+    determine = _load_determine_needs_resubmit()
+    summary = {"failed_identifiers": []}
+    lesson = {"assignment": False, "chapter": "intro"}
+
+    assert determine(summary, lesson, answer_text="", min_words=5) is False


### PR DESCRIPTION
## Summary
- avoid triggering the resubmit word-count fallback when the lesson metadata has no assignment flag
- add coverage proving that non-assignment lessons do not require a resubmission

## Testing
- pytest tests/test_coursebook_resubmit_logic.py

------
https://chatgpt.com/codex/tasks/task_e_68d2488fe35483219b1f16faafa33c5f