### PR TITLE
Handle Firestore ordering failures when fetching latest submissions

### DIFF
--- a/tests/test_firestore_helpers_fallback.py
+++ b/tests/test_firestore_helpers_fallback.py
@@ -1,0 +1,45 @@
+from google.api_core.exceptions import FailedPrecondition
+
+from src.firestore_helpers import stream_latest_snapshots
+
+
+class StubSnapshot:
+    def __init__(self, created_at, payload):
+        self._data = {"created_at": created_at, "payload": payload}
+        self.reference = f"ref-{payload}"
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class StubQuery:
+    def __init__(self, snapshots):
+        self._snapshots = list(snapshots)
+
+    def where(self, *args, **kwargs):  # pragma: no cover - chaining support
+        return self
+
+    def order_by(self, *args, **kwargs):
+        raise FailedPrecondition("missing index for order")
+
+    def limit(self, *args, **kwargs):  # pragma: no cover - not used in fallback
+        return self
+
+    def stream(self):
+        return list(self._snapshots)
+
+
+def test_stream_latest_snapshots_handles_failed_precondition():
+    docs = [
+        StubSnapshot(2, "middle"),
+        StubSnapshot(5, "latest"),
+        StubSnapshot(1, "earliest"),
+    ]
+    query = StubQuery(docs)
+
+    results = stream_latest_snapshots(query, "created_at", limit=1)
+
+    assert len(results) == 1
+    snapshot, data = results[0]
+    assert snapshot is docs[1]
+    assert data["payload"] == "latest"


### PR DESCRIPTION
## Summary
- add a shared Firestore helper that retries order_by queries and sorts client-side when Firestore rejects the ordering
- use the helper from both `get_latest_submission_doc` and `fetch_latest` so missing indexes still return the newest document
- cover the fallback path with a regression test that stubs a query raising `FailedPrecondition`

## Testing
- pytest tests/test_firestore_helpers_fallback.py


------
https://chatgpt.com/codex/tasks/task_e_68d29183601083218764a847ce1dd5e3