### PR TITLE
Add Firestore helper fallbacks and import regression test

### DIFF
--- a/tests/test_firestore_helpers_fallback.py
+++ b/tests/test_firestore_helpers_fallback.py
@@ -1,3 +1,7 @@
+import importlib
+import sys
+import types
+
 from google.api_core.exceptions import FailedPrecondition
 
 from src.firestore_helpers import stream_latest_snapshots
@@ -43,3 +47,31 @@ def test_stream_latest_snapshots_handles_failed_precondition():
     snapshot, data = results[0]
     assert snapshot is docs[1]
     assert data["payload"] == "latest"
+
+
+def test_stream_latest_snapshots_import_without_firestore(monkeypatch):
+    import src.firestore_helpers as helpers
+
+    with monkeypatch.context() as m:
+        stub_firebase = types.ModuleType("firebase_admin")
+        m.setitem(sys.modules, "firebase_admin", stub_firebase)
+
+        stub_google = types.ModuleType("google")
+        stub_google.__path__ = []  # type: ignore[attr-defined]
+        stub_cloud = types.ModuleType("google.cloud")
+        stub_cloud.__path__ = []  # type: ignore[attr-defined]
+        stub_firestore_v1 = types.ModuleType("google.cloud.firestore_v1")
+
+        stub_google.cloud = stub_cloud  # type: ignore[attr-defined]
+        stub_cloud.firestore_v1 = stub_firestore_v1  # type: ignore[attr-defined]
+
+        m.setitem(sys.modules, "google", stub_google)
+        m.setitem(sys.modules, "google.cloud", stub_cloud)
+        m.setitem(sys.modules, "google.cloud.firestore_v1", stub_firestore_v1)
+
+        reloaded = importlib.reload(helpers)
+
+        assert callable(reloaded.stream_latest_snapshots)
+        assert getattr(reloaded.firestore.Query, "DESCENDING", None) is not None
+
+    importlib.reload(helpers)


### PR DESCRIPTION
## Summary
- add firebase/firestore import fallbacks so `stream_latest_snapshots` remains importable without Firestore
- keep helper available at module scope and expose it via `__all__`
- cover the import-only scenario with a regression test that reloads the helpers module under stubbed Firestore packages

## Testing
- pytest tests/test_firestore_helpers_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a5ebc67c8321bafc9aeec4f1fb68