### PR TITLE
Use roster student name in Topic Coach chat bubbles

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5605,6 +5605,13 @@ if tab == "Chat • Grammar • Exams":
     """, unsafe_allow_html=True)
 
     student_code_tc = (st.session_state.get("student_code") or "").strip()
+    student_row_chat = st.session_state.get("student_row") or {}
+    student_display_name = (
+        _safe_str(student_row_chat.get("Name"))
+        or _safe_str(st.session_state.get("student_name"))
+        or "Student"
+    )
+    student_label_html = html.escape(student_display_name)
 
     def _resolve_topic_coach_db():
         """Return a Firestore client for Topic Coach persistence if available."""
@@ -5815,7 +5822,10 @@ if tab == "Chat • Grammar • Exams":
             with st.expander(f"Show earlier ({len(older)})"):
                 for m in older:
                     if m["role"] == "user":
-                        st.markdown(f"<div class='bubble-wrap'><div class='lbl-u'>Student</div></div>", unsafe_allow_html=True)
+                        st.markdown(
+                            f"<div class='bubble-wrap'><div class='lbl-u'>{student_label_html}</div></div>",
+                            unsafe_allow_html=True,
+                        )
                         st.markdown(f"<div class='bubble-u'>{m['content']}</div>", unsafe_allow_html=True)
                     else:
                         st.markdown(f"<div class='bubble-wrap'><div class='lbl-a'>Herr Felix</div></div>", unsafe_allow_html=True)
@@ -5823,7 +5833,10 @@ if tab == "Chat • Grammar • Exams":
 
         for m in latest:
             if m["role"] == "user":
-                st.markdown(f"<div class='bubble-wrap'><div class='lbl-u'>Student</div></div>", unsafe_allow_html=True)
+                st.markdown(
+                    f"<div class='bubble-wrap'><div class='lbl-u'>{student_label_html}</div></div>",
+                    unsafe_allow_html=True,
+                )
                 st.markdown(f"<div class='bubble-u'>{m['content']}</div>", unsafe_allow_html=True)
             else:
                 st.markdown(f"<div class='bubble-wrap'><div class='lbl-a'>Herr Felix</div></div>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- pull the student's display name from the roster/session state for the Chat • Grammar • Exams tab
- reuse the resolved name in chat history bubbles so past answers show the actual student instead of the generic "Student" label

## Testing
- pytest *(fails: ImportError: cannot import name 'stream_latest_snapshots' from 'src.firestore_helpers')*

------
https://chatgpt.com/codex/tasks/task_e_68d3ccbecb2c8321a2fd16caf6aae72c