### PR TITLE
Replace deprecated Streamlit use_container_width

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -887,7 +887,7 @@ def render_logged_in_topbar():
                 "Log out",
                 key="logout_global",
                 type="primary",
-                use_container_width=True,
+                width="stretch",
                 on_click=do_logout,
             )
 
@@ -982,15 +982,15 @@ def render_sidebar_published():
         st.session_state["need_rerun"] = True
     if st.session_state.get("logged_in", False):
         st.sidebar.markdown("## Quick access")
-        st.sidebar.button("🏠 Dashboard",                use_container_width=True, on_click=_go, args=("Dashboard",))
-        st.sidebar.button("📈 My Course",                use_container_width=True, on_click=_go, args=("My Course",))
-        st.sidebar.button("📊 Results & Resources",      use_container_width=True, on_click=_go, args=("My Results and Resources",))
-        st.sidebar.button("🗣️ Chat • Grammar • Exams", use_container_width=True, on_click=_go, args=("Chat • Grammar • Exams",))
-        st.sidebar.button("📚 Vocab Trainer",            use_container_width=True, on_click=_go, args=("Vocab Trainer",))
-        st.sidebar.button("📗 Dictionary",              use_container_width=True, on_click=_go_dictionary)
-        st.sidebar.button("✍️ Schreiben Trainer",        use_container_width=True, on_click=_go, args=("Schreiben Trainer",))
-        st.sidebar.button("🎥 Join on Zoom",             use_container_width=True, on_click=_go_zoom_class)
-        st.sidebar.button("❓ Class Notes & Q&A",         use_container_width=True, on_click=_go_post_qna)
+        st.sidebar.button("🏠 Dashboard",                width="stretch", on_click=_go, args=("Dashboard",))
+        st.sidebar.button("📈 My Course",                width="stretch", on_click=_go, args=("My Course",))
+        st.sidebar.button("📊 Results & Resources",      width="stretch", on_click=_go, args=("My Results and Resources",))
+        st.sidebar.button("🗣️ Chat • Grammar • Exams", width="stretch", on_click=_go, args=("Chat • Grammar • Exams",))
+        st.sidebar.button("📚 Vocab Trainer",            width="stretch", on_click=_go, args=("Vocab Trainer",))
+        st.sidebar.button("📗 Dictionary",              width="stretch", on_click=_go_dictionary)
+        st.sidebar.button("✍️ Schreiben Trainer",        width="stretch", on_click=_go, args=("Schreiben Trainer",))
+        st.sidebar.button("🎥 Join on Zoom",             width="stretch", on_click=_go_zoom_class)
+        st.sidebar.button("❓ Class Notes & Q&A",         width="stretch", on_click=_go_post_qna)
         st.sidebar.divider()
 
         st.sidebar.markdown("## Our Socials")
@@ -1942,7 +1942,7 @@ if tab == "Dashboard":
         st.button(
             button_label,
             type="primary",
-            use_container_width=True,
+            width="stretch",
             key="btn_dash_next_assignment",
             on_click=_go_next_assignment,
             args=(_next_lesson.get("day"),),
@@ -4327,7 +4327,7 @@ if tab == "My Course":
                     df_att.rename(columns={"session": "Session"}, inplace=True)
                     st.dataframe(
                         df_att,
-                        use_container_width=True,
+                        width="stretch",
                         hide_index=True,
                     )
                 else:
@@ -5256,7 +5256,7 @@ if tab == "My Course":
                             "Send Reply",
                             key=f"q_send_comment_{q_id}",
                             type="primary",
-                            use_container_width=True,
+                            width="stretch",
                         ):
                             if not current_text.strip():
                                 st.warning("Type a reply first.")
@@ -5280,7 +5280,7 @@ if tab == "My Course":
                             "✨ Correct with AI",
                             key=f"q_ai_btn_{q_id}",
                             disabled=st.session_state.get(ai_flag, False),
-                            use_container_width=True,
+                            width="stretch",
                         ):
                             st.session_state[ai_flag] = True
                             st.session_state["need_rerun"] = True
@@ -6048,7 +6048,7 @@ if tab == "Chat • Grammar • Exams":
             )
             col_left, col_right = st.columns([1, 10])
             with col_left:
-                if st.button("🧹 New chat", key=KEY_NEWCHAT_BTN, use_container_width=True):
+                if st.button("🧹 New chat", key=KEY_NEWCHAT_BTN, width="stretch"):
                     st.session_state[chat_data_key] = []
                     st.session_state[qcount_data_key] = 0
                     st.session_state[finalized_data_key] = False
@@ -6247,7 +6247,7 @@ if tab == "Chat • Grammar • Exams":
             if cur_level_g not in level_options:
                 cur_level_g = default_gram
             gram_level = st.select_slider("Level", level_options, value=cur_level_g, key=KEY_GRAM_LEVEL)
-            ask = st.button("Ask", type="primary", use_container_width=True, key=KEY_GRAM_ASK_BTN)
+            ask = st.button("Ask", type="primary", width="stretch", key=KEY_GRAM_ASK_BTN)
 
         if ask and (gram_q or "").strip():
             sys = (
@@ -6357,7 +6357,7 @@ if tab == "Chat • Grammar • Exams":
                 if not label or not url:
                     continue
 
-                st.link_button(label, url, use_container_width=True)
+                st.link_button(label, url, width="stretch")
 
 
     with sub_speak:
@@ -6456,7 +6456,7 @@ if tab == "Chat • Grammar • Exams":
                         .sort_values(["part"])
                     )
                     st.markdown("#### Breakdown by Part")
-                    st.dataframe(by_part.assign(avg_score=by_part["avg_score"].round(1)), use_container_width=True)
+                    st.dataframe(by_part.assign(avg_score=by_part["avg_score"].round(1)), width="stretch")
 
                 # Recent attempts table
                 show_cols = [c for c in [
@@ -6484,7 +6484,7 @@ if tab == "Chat • Grammar • Exams":
                             )
 
                 st.markdown("#### Recent attempts")
-                st.dataframe(df_recent, use_container_width=True)
+                st.dataframe(df_recent, width="stretch")
 
                 # Inline audio for newest attempt — column could be 'audio_file_id' or similar
                 audio_col = next((c for c in ["audio_file_id", "audio_id", "audio"] if c in df_me.columns), None)
@@ -7011,7 +7011,7 @@ if tab == "Vocab Trainer":
             f"Browse all words for levels: {levels_label}", expanded=False
         ):
             df_show = df_view[["German", "English"]].copy()
-            st.dataframe(df_show, use_container_width=True, height=420)
+            st.dataframe(df_show, width="stretch", height=420)
 
 
 

--- a/src/falowen/custom_chat.py
+++ b/src/falowen/custom_chat.py
@@ -321,7 +321,7 @@ def render_custom_chat_input(
             "Save draft",
             key=widget_key("chat_save_draft"),
             disabled=chat_locked,
-            use_container_width=True,
+            width="stretch",
         )
         user_input_btn = (
             st.session_state.get(draft_key, "").strip()

--- a/src/ui/auth.py
+++ b/src/ui/auth.py
@@ -362,11 +362,11 @@ def render_forgot_password_panel() -> None:
     c3, c4 = st.columns([0.55, 0.45])
     with c3:
         send_btn = st.button(
-            "Send reset link", key="send_reset_btn", use_container_width=True
+            "Send reset link", key="send_reset_btn", width="stretch"
         )
     with c4:
         back_btn = st.button(
-            "Back to login", key="hide_reset_btn", use_container_width=True
+            "Back to login", key="hide_reset_btn", width="stretch"
         )
 
     if back_btn:

--- a/src/ui_widgets.py
+++ b/src/ui_widgets.py
@@ -100,7 +100,11 @@ def render_google_signin_once(auth_url: str, full_width: bool = True) -> None:
     try:
         components.html(btn_html, height=72, scrolling=False)
     except Exception:
-        st.link_button("Continue with Google", auth_url, use_container_width=full_width)
+        st.link_button(
+            "Continue with Google",
+            auth_url,
+            width="stretch" if full_width else "content",
+        )
     st.session_state["_google_btn_rendered"] = True
 
 

--- a/src/vocab/dictionary.py
+++ b/src/vocab/dictionary.py
@@ -273,4 +273,4 @@ def render_vocab_dictionary(student_level_locked: str) -> None:
         f"Browse all words for levels: {levels_label}", expanded=False
     ):
         df_show = df_view[["German", "English"]].copy()
-        st.dataframe(df_show, use_container_width=True, height=420)
+        st.dataframe(df_show, width="stretch", height=420)


### PR DESCRIPTION
## Summary
- replace deprecated `use_container_width` arguments with the new `width` API across dashboard buttons and tables
- update custom chat, auth, and dictionary widgets to keep full-width layouts with the new parameter
- ensure the Google fallback link button respects the desired width when the component render fails

## Testing
- pytest *(fails: class discussion button/tests expect missing helpers; existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e29d675883218101dc071ec14634