### PR TITLE
Handle falowen.db import race

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -465,10 +465,7 @@ from falowen.sessions import (
     destroy_session_token,
     api_post,
 )
-from falowen.db import (
-    SCHREIBEN_DAILY_LIMIT,
-    inc_sprechen_usage,
-)
+from src.utils.falowen_imports import load_falowen_db
 from src.contracts import (
     is_contract_expired,
 )
@@ -517,6 +514,10 @@ from src.ui_components import (
     render_link,
     render_vocab_lookup,
 )
+
+_falowen_db = load_falowen_db()
+SCHREIBEN_DAILY_LIMIT = _falowen_db.SCHREIBEN_DAILY_LIMIT
+inc_sprechen_usage = _falowen_db.inc_sprechen_usage
 
 prepare_audio_url = getattr(_ui_components, "prepare_audio_url", lambda url: url)
 render_audio_player = getattr(_ui_components, "render_audio_player", lambda *a, **k: None)

--- a/src/utils/falowen_imports.py
+++ b/src/utils/falowen_imports.py
@@ -1,0 +1,28 @@
+"""Helpers for loading optional :mod:`falowen` submodules safely."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from types import ModuleType
+
+LOGGER = logging.getLogger(__name__)
+
+
+def load_falowen_db() -> ModuleType:
+    """Return the ``falowen.db`` module, retrying once if the import half-loads.
+
+    Streamlit's script reloader can sometimes leave ``falowen.db`` in a broken
+    state inside :data:`sys.modules`. The next import attempt then bubbles up a
+    ``KeyError`` from :mod:`importlib`. To make the application resilient we
+    clear the partial entry and try again before giving up.
+    """
+
+    module_name = "falowen.db"
+    try:
+        return importlib.import_module(module_name)
+    except KeyError:
+        LOGGER.warning("Retrying import for partially-loaded module %s", module_name)
+        sys.modules.pop(module_name, None)
+        return importlib.import_module(module_name)

--- a/tests/test_falowen_imports.py
+++ b/tests/test_falowen_imports.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+
+from src.utils.falowen_imports import load_falowen_db
+
+
+def test_load_falowen_db_retries_after_keyerror(monkeypatch):
+    """The helper should clear broken cache entries and retry once."""
+
+    real_import_module = importlib.import_module
+    sentinel = object()
+    attempts = {"count": 0}
+
+    def fake_import_module(name, package=None):
+        if name == "falowen.db":
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                sys.modules[name] = sentinel
+                raise KeyError(name)
+            assert sys.modules.get(name) is not sentinel
+        return real_import_module(name, package=package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    module = load_falowen_db()
+
+    assert module.__name__ == "falowen.db"
+    assert attempts["count"] == 2


### PR DESCRIPTION
## Summary
- add a utility that retries loading `falowen.db` when the first import returns a KeyError
- switch the main Streamlit app to obtain `SCHREIBEN_DAILY_LIMIT` and `inc_sprechen_usage` through the new helper
- cover the retry logic with a dedicated unit test

## Testing
- pytest tests/test_falowen_imports.py
- ruff check src/utils/falowen_imports.py tests/test_falowen_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e73d3bb8832194facb355bdf0b39