### PR TITLE
Add streamlit cookies controller to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ rapidfuzz==3.13.0
 flake8==7.1.1
 extra-streamlit-components>=0.1.63
 rich==14.1.0
+streamlit-cookies-controller==0.0.4


### PR DESCRIPTION
## Summary
- add the `streamlit-cookies-controller` package to the Python requirements so deployments install the cookie manager used by the app

## Testing
- pytest *(fails: `tests/test_class_discussion_link.py::test_lesson_includes_class_discussion_button`, `tests/test_class_discussion_missing_classname.py::test_class_discussion_skips_without_classname`, `tests/test_get_score_for_assignment.py::test_get_score_for_assignment_matches_numeric_chapter`; existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eb7f46a48321a13807693111febe