### PR TITLE
Play UI sounds when toasts appear

### DIFF
--- a/src/utils/toasts.py
+++ b/src/utils/toasts.py
@@ -2,6 +2,8 @@ from typing import Set
 
 import streamlit as st
 
+from src.ui.sound import play_ui_sound
+
 
 _RECENT_TOASTS_KEY = "__recent_toasts__"
 
@@ -29,6 +31,7 @@ def toast_once(msg: str, icon: str) -> None:
     """
     if not _already_toasted(msg):
         st.toast(msg, icon=icon)
+        play_ui_sound(force=True)
 
 
 def toast_ok(msg: str) -> None:
@@ -40,6 +43,7 @@ def toast_ok(msg: str) -> None:
         The message to display.
     """
     st.toast(msg, icon="✅")
+    play_ui_sound(force=True)
 
 
 def toast_err(msg: str) -> None:
@@ -51,6 +55,7 @@ def toast_err(msg: str) -> None:
         The message to display.
     """
     st.toast(msg, icon="❌")
+    play_ui_sound(force=True)
 
 
 def toast_warn(msg: str) -> None:
@@ -62,6 +67,7 @@ def toast_warn(msg: str) -> None:
         The message to display.
     """
     st.toast(msg, icon="⚠️")
+    play_ui_sound(force=True)
 
 
 def toast_info(msg: str) -> None:
@@ -73,6 +79,7 @@ def toast_info(msg: str) -> None:
         The message to display.
     """
     st.toast(msg, icon="ℹ️")
+    play_ui_sound(force=True)
 
 
 def rerun_without_toast() -> None:

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -4,37 +4,47 @@ import types
 from src.utils import toasts
 
 
-def test_toast_ok(monkeypatch):
-    mock_st = types.SimpleNamespace(toast=MagicMock())
+def _patch_toast_and_sound(monkeypatch):
+    mock_toast = MagicMock()
+    mock_sound = MagicMock()
+    mock_st = types.SimpleNamespace(toast=mock_toast, session_state={})
     monkeypatch.setattr(toasts, "st", mock_st)
+    monkeypatch.setattr(toasts, "play_ui_sound", mock_sound)
+    return mock_st, mock_sound
+
+
+def test_toast_ok(monkeypatch):
+    mock_st, mock_sound = _patch_toast_and_sound(monkeypatch)
     toasts.toast_ok("hello")
     mock_st.toast.assert_called_once_with("hello", icon="✅")
+    mock_sound.assert_called_once_with(force=True)
 
 
 def test_toast_err(monkeypatch):
-    mock_st = types.SimpleNamespace(toast=MagicMock())
-    monkeypatch.setattr(toasts, "st", mock_st)
+    mock_st, mock_sound = _patch_toast_and_sound(monkeypatch)
     toasts.toast_err("oops")
     mock_st.toast.assert_called_once_with("oops", icon="❌")
+    mock_sound.assert_called_once_with(force=True)
 
 
 def test_toast_warn(monkeypatch):
-    mock_st = types.SimpleNamespace(toast=MagicMock())
-    monkeypatch.setattr(toasts, "st", mock_st)
+    mock_st, mock_sound = _patch_toast_and_sound(monkeypatch)
     toasts.toast_warn("careful")
     mock_st.toast.assert_called_once_with("careful", icon="⚠️")
+    mock_sound.assert_called_once_with(force=True)
 
 
 def test_toast_info(monkeypatch):
-    mock_st = types.SimpleNamespace(toast=MagicMock())
-    monkeypatch.setattr(toasts, "st", mock_st)
+    mock_st, mock_sound = _patch_toast_and_sound(monkeypatch)
     toasts.toast_info("note")
     mock_st.toast.assert_called_once_with("note", icon="ℹ️")
+    mock_sound.assert_called_once_with(force=True)
 
 
 def test_rerun_without_toast(monkeypatch):
     mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
     monkeypatch.setattr(toasts, "st", mock_st)
+    monkeypatch.setattr(toasts, "play_ui_sound", MagicMock())
     toasts.rerun_without_toast()
     mock_st.toast.assert_not_called()
     assert mock_st.session_state["__refresh"] == 1
@@ -42,30 +52,30 @@ def test_rerun_without_toast(monkeypatch):
 
 
 def test_refresh_with_toast(monkeypatch):
-    mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
-    monkeypatch.setattr(toasts, "st", mock_st)
+    mock_st, mock_sound = _patch_toast_and_sound(monkeypatch)
     toasts.refresh_with_toast()
     mock_st.toast.assert_called_once_with("Saved!", icon="✅")
+    mock_sound.assert_called_once_with(force=True)
     assert mock_st.session_state["__refresh"] == 1
     assert mock_st.session_state["need_rerun"] is True
 
 
 def test_refresh_with_toast_custom_msg(monkeypatch):
-    mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
-    monkeypatch.setattr(toasts, "st", mock_st)
+    mock_st, mock_sound = _patch_toast_and_sound(monkeypatch)
     toasts.refresh_with_toast("Updated!")
     mock_st.toast.assert_called_once_with("Updated!", icon="✅")
+    mock_sound.assert_called_once_with(force=True)
     assert mock_st.session_state["__refresh"] == 1
     assert mock_st.session_state["need_rerun"] is True
 
 
 def test_toast_once_suppresses_duplicates(monkeypatch):
-    mock_st = types.SimpleNamespace(toast=MagicMock(), session_state={})
-    monkeypatch.setattr(toasts, "st", mock_st)
+    mock_st, mock_sound = _patch_toast_and_sound(monkeypatch)
 
     toasts.toast_once("hi", "✅")
     toasts.toast_once("hi", "✅")
     toasts.toast_once("bye", "✅")
 
     assert mock_st.toast.call_count == 2
+    assert mock_sound.call_count == 2
     assert mock_st.session_state["__recent_toasts__"] == {"hi", "bye"}


### PR DESCRIPTION
## Summary
- import and invoke the UI sound helper whenever toast utilities display a message
- extend toast tests to verify the sound helper is triggered alongside Streamlit toasts

## Testing
- pytest tests/test_toasts.py

------
https://chatgpt.com/codex/tasks/task_e_68d4392e35c88321b1cb3a3f3f13273b