### PR TITLE
Show YouTube video guidance in Video of the Day

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -3230,6 +3230,12 @@ if tab == "My Course":
             fetch_videos = fetch_youtube_playlist_videos
             playlist_id = random.choice(playlist_ids) if playlist_ids else None
 
+            reflection_prompts = [
+                "📝 After watching, jot down two new words or phrases you heard.",
+                "🗣️ Pause the video and repeat a key sentence aloud to practice pronunciation.",
+                "💬 Summarize the main idea of the video in one or two simple sentences.",
+            ]
+
             if playlist_id:
                 if st.button("🔄 Refresh videos", key=f"refresh_vod_{level_key}"):
                     st.cache_data.clear()
@@ -3246,6 +3252,11 @@ if tab == "My Course":
                     video = video_list[today_idx]
                     st.markdown(f"**{video['title']}**")
                     st.video(video['url'])
+                    description = video.get("description")
+                    if description:
+                        st.caption(description)
+                    else:
+                        st.caption(random.choice(reflection_prompts))
                 else:
                     st.info("No videos found for your level’s playlist. Check back soon!")
             else:

--- a/tests/test_youtube_utils.py
+++ b/tests/test_youtube_utils.py
@@ -1,0 +1,62 @@
+import pytest
+
+from src import youtube
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    youtube.fetch_youtube_playlist_videos.clear()
+    yield
+    youtube.fetch_youtube_playlist_videos.clear()
+
+
+def test_fetch_youtube_playlist_videos_includes_trimmed_description(monkeypatch):
+    long_description = " ".join(["Wort"] * 80)
+    payload = {
+        "items": [
+            {
+                "snippet": {
+                    "title": "Erstes Video",
+                    "description": long_description,
+                    "resourceId": {"videoId": "abc123"},
+                }
+            },
+            {
+                "snippet": {
+                    "title": "Zweites Video",
+                    "description": " ",
+                    "resourceId": {"videoId": "def456"},
+                }
+            },
+        ]
+    }
+
+    def fake_get(url, params=None, timeout=None):
+        assert "playlistItems" in url
+        return DummyResponse(payload)
+
+    monkeypatch.setattr(youtube.requests, "get", fake_get)
+
+    videos = youtube.fetch_youtube_playlist_videos("playlist123", api_key="fake")
+
+    assert len(videos) == 2
+    first_video = videos[0]
+    assert first_video["title"] == "Erstes Video"
+    assert first_video["url"].endswith("abc123")
+    assert first_video["description"]
+    assert len(first_video["description"]) <= 200
+    assert first_video["description"].endswith("…")
+
+    second_video = videos[1]
+    assert second_video["description"] is None


### PR DESCRIPTION
## Summary
- capture and trim YouTube playlist video descriptions when fetching playlist items
- extend the Video of the Day section to surface the video description or a fallback reflection prompt
- add a focused unit test covering the trimmed-description logic

## Testing
- pytest tests/test_youtube_utils.py


------
https://chatgpt.com/codex/tasks/task_e_68d5954e79bc83218562f7a9953bc6d4