### PR TITLE
Update submit confirmation messaging

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -3850,10 +3850,13 @@ if tab == "My Course":
                                 st.session_state[locked_key] = True
                                 st.session_state[f"{lesson_key}__receipt"] = short_ref
 
-                                st.success("Submitted! Your work has been sent to your tutor.")
+                                st.success(
+                                    f"Well done, {name or 'Student'}! Remember the pass mark is 60, "
+                                    "and if you score below that you must revisit this Submit page to try again."
+                                )
                                 st.caption(
-                                    f"Receipt: `{short_ref}` • You’ll be emailed when it’s marked. "
-                                    "See **Results & Resources** for scores & feedback."
+                                    f"Receipt: `{short_ref}` • Marks will arrive by email and via "
+                                    "Telegram from @falowenbot. See **Results & Resources** for scores & feedback."
                                 )
                                 row = st.session_state.get("student_row") or {}
                                 tg_subscribed = bool(
@@ -3872,7 +3875,13 @@ if tab == "My Course":
                                 else:
                                     with st.expander("🔔 Subscribe to Telegram notifications", expanded=False):
                                         st.markdown(
-                                            f"""1. [Open the Falowen bot](https://t.me/falowenbot) and tap **Start**\n2. Register: `/register {code}`\n3. To deactivate: send `/stop`"""
+                                            "\n".join(
+                                                [
+                                                    "1. Search for **@falowenbot** on Telegram and open the chat.",
+                                                    "2. Tap **Start**, then follow the prompts to connect your account so you can receive your marks.",
+                                                    "3. To deactivate: send `/stop`",
+                                                ]
+                                            )
                                         )
                                 answer_text = st.session_state.get(draft_key, "").strip()
                                 MIN_WORDS = 20


### PR DESCRIPTION
## Summary
- personalize the coursebook submit success message and remind learners about the 60 pass mark and resubmission process
- clarify that marks will arrive by email and from @falowenbot on Telegram
- update Telegram subscription guidance so unsubscribed learners know how to find the bot and connect for results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d59ce657988321af60d8379ea63727