### PR TITLE
Adjust Schreiben Trainer passing threshold to 18

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -7609,7 +7609,7 @@ if tab == "Schreiben Trainer":
                 # --- Save to Firestore ---
                 score_match = re.search(r"Score[: ]+(\d+)", feedback)
                 score = int(score_match.group(1)) if score_match else 0
-                passed = score >= 17
+                passed = score >= 18
                 save_submission(
                     student_code=student_code,
                     score=score,


### PR DESCRIPTION
## Summary
- update the Schreiben Trainer flow to require a score of 18 before marking a submission as passed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66665aeb08321b14da47cf583af14