### PR TITLE
Add warning for Schreiben daily limit

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -7437,6 +7437,13 @@ if tab == "Schreiben Trainer":
             st.session_state[f"{student_code}_last_user_letter"] = existing_letter
 
         letter_disabled = daily_so_far >= SCHREIBEN_DAILY_LIMIT
+        if letter_disabled:
+            st.warning(
+                "You've reached today's limit for letter corrections. Please come back"
+                " tomorrow after the daily quota resets to submit a new letter. While"
+                " you wait, feel free to explore the other tabs for prompts, ideas, or"
+                " practice activities."
+            )
 
         user_letter = st.text_area(
             "Paste or type your German letter/essay here.",


### PR DESCRIPTION
## Summary
- show a warning when the Schreiben daily limit has been reached
- suggest exploring other tabs while waiting for the quota to reset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6673425908321ba5aaa1ff6c221d0