### PR TITLE
Fix Ideas Generator chat payload duplication

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -8165,7 +8165,7 @@ if tab == "Schreiben Trainer":
                 with st.spinner("👨‍🏫 Herr Felix is typing..."):
                     resp = client.chat.completions.create(
                         model="gpt-4o",
-                        messages=[{"role": "system", "content": system_prompt}] + chat_history[1:] + [{"role": "user", "content": user_input}],
+                        messages=[{"role": "system", "content": system_prompt}] + chat_history[1:],
                         temperature=0.22,
                         max_tokens=380
                     )


### PR DESCRIPTION
## Summary
- ensure the Ideas Generator letter coach send handler only includes the latest user message once in the OpenAI payload

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6699268c08321903b696e37c51dcb