### PR TITLE
Adjust save_now toast behavior

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -8111,7 +8111,7 @@ if tab == "Schreiben Trainer":
 
             if st.session_state.pop(ns("clear_chat"), False):
                 st.session_state[draft_key] = ""
-                save_now(draft_key, student_code)
+                save_now(draft_key, student_code, show_toast=False)
 
             st.text_area(
                 "Chat input",
@@ -8153,7 +8153,6 @@ if tab == "Schreiben Trainer":
             if send:
                 user_input = st.session_state[draft_key].strip()
                 save_now(draft_key, student_code)
-                toast_ok("Saved!")
 
             else:
                 user_input = ""

--- a/src/draft_management.py
+++ b/src/draft_management.py
@@ -36,7 +36,7 @@ def _draft_state_keys(draft_key: str) -> Tuple[str, str, str, str]:
     )
 
 
-def save_now(draft_key: str, code: str) -> None:
+def save_now(draft_key: str, code: str, show_toast: bool = True) -> None:
     """Immediately persist the draft associated with ``draft_key``."""
     text = st.session_state.get(draft_key, "") or ""
     if st.session_state.get("falowen_chat_draft_key") == draft_key:
@@ -52,7 +52,8 @@ def save_now(draft_key: str, code: str) -> None:
     st.session_state[last_ts_key] = time.time()
     st.session_state[saved_flag_key] = True
     st.session_state[saved_at_key] = datetime.now(_timezone.utc)
-    toast_ok("Saved!")
+    if show_toast:
+        toast_ok("Saved!")
 
 
 def autosave_maybe(


### PR DESCRIPTION
## Summary
- allow `save_now` to optionally skip raising a success toast
- avoid triggering a second toast when clearing the Schreiben Coach chat after sending a turn

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d66a32ca3c832198872c0fd0f8c38b