### PR TITLE
Open quick guide expander automatically for first-time users

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1128,7 +1128,10 @@ def render_sidebar_published():
         st.sidebar.divider()
 
         st.sidebar.markdown("## How-to & tips")
-        with st.sidebar.expander("📚 Quick guide", expanded=False):
+        first_time_quick_guide = not st.session_state.get("_seen_quick_guide", False)
+        if first_time_quick_guide:
+            st.toast("👋 New here? Peek at the Quick guide in the sidebar to get started!")
+        with st.sidebar.expander("📚 Quick guide", expanded=first_time_quick_guide):
             st.markdown(
                 """
 - **Submit work:** My Course → Submit → **Confirm & Submit** (locks after submission).
@@ -1138,6 +1141,8 @@ def render_sidebar_published():
 - **Track progress:** **Dashboard** shows streaks, next lesson, and missed items.
                 """
             )
+        if first_time_quick_guide:
+            st.session_state["_seen_quick_guide"] = True
 
         with st.sidebar.expander("🧭 Dashboard tabs, explained", expanded=False):
             st.markdown(


### PR DESCRIPTION
## Summary
- open the Quick guide sidebar expander by default on a user's first logged-in render
- set a session flag once the Quick guide has been shown to avoid reopening it repeatedly
- surface a one-time toast to draw attention to the guide for first-time visitors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6986745988321836c8625b29b8afb