### PR TITLE
Restore Day 0 orientation fallback for schedules without onboarding cards

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2776,7 +2776,14 @@ def render_day_zero_onboarding(
         st.caption(intro_text)
 
     cards = info.get("onboarding_cards") or []
-    if not isinstance(cards, Sequence) or not cards:
+    if not isinstance(cards, Sequence) or isinstance(cards, (str, bytes)) or not cards:
+        info_lines: List[str] = []
+        if goal_text:
+            info_lines.append(f"🎯 **Goal:** {goal_text}")
+        if intro_text:
+            info_lines.append(f"📝 **Instruction:** {intro_text}")
+        if info_lines:
+            st.info("\n\n".join(info_lines))
         return
 
     target_day = _next_available_lesson_day(schedule, idx) or 1


### PR DESCRIPTION
## Summary
- restore the legacy goal/instruction info block when no onboarding cards are configured for Day 0
- guard the onboarding card renderer so only list-like card data trigger the card layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69e94f1f08321aec87d4dbcd21ace