### PR TITLE
Wrap day 0 onboarding guidance in expander

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2750,114 +2750,122 @@ def render_day_zero_onboarding(
 ) -> None:
     """Render a dedicated onboarding layout for the tutorial day."""
 
-    st.markdown(
-        """
-        <style>
-        .day0-card{background:#f8fafc;border:1px solid #e2e8f0;border-radius:16px;padding:18px 16px;
-                   box-shadow:0 8px 24px rgba(15,23,42,.08);min-height:260px;display:flex;flex-direction:column;gap:12px;}
-        .day0-card__title{font-size:1.1rem;font-weight:600;color:#0f172a;}
-        .day0-card__helper{color:#475569;font-size:.95rem;line-height:1.4;}
-        .day0-card ol{margin:0;padding-left:1.2rem;color:#1e293b;font-size:.95rem;line-height:1.45;}
-        .day0-card__cta{margin-top:auto;}
-        .day0-card__cta button{width:100%;border-radius:999px;}
-        @media (max-width:768px){.day0-card{min-height:auto;}}
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
+    seen_state_key = "day0_onboarding_seen"
+    expanded_default = not st.session_state.get(seen_state_key, False)
 
-    goal_text = _safe_str(info.get("goal"))
-    intro_text = _safe_str(info.get("instruction"))
-    if goal_text:
-        st.markdown(f"#### 🚀 {goal_text}")
-    else:
-        st.markdown("#### 🚀 Welcome to Falowen")
-    if intro_text:
-        st.caption(intro_text)
+    with st.expander("Day 0 onboarding overview", expanded=expanded_default):
+        st.markdown(
+            """
+            <style>
+            .day0-card{background:#f8fafc;border:1px solid #e2e8f0;border-radius:16px;padding:18px 16px;
+                       box-shadow:0 8px 24px rgba(15,23,42,.08);min-height:260px;display:flex;flex-direction:column;gap:12px;}
+            .day0-card__title{font-size:1.1rem;font-weight:600;color:#0f172a;}
+            .day0-card__helper{color:#475569;font-size:.95rem;line-height:1.4;}
+            .day0-card ol{margin:0;padding-left:1.2rem;color:#1e293b;font-size:.95rem;line-height:1.45;}
+            .day0-card__cta{margin-top:auto;}
+            .day0-card__cta button{width:100%;border-radius:999px;}
+            @media (max-width:768px){.day0-card{min-height:auto;}}
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
 
-    cards = info.get("onboarding_cards") or []
-    if not isinstance(cards, Sequence) or not cards:
-        return
+        goal_text = _safe_str(info.get("goal"))
+        intro_text = _safe_str(info.get("instruction"))
+        if goal_text:
+            st.markdown(f"#### 🚀 {goal_text}")
+        else:
+            st.markdown("#### 🚀 Welcome to Falowen")
+        if intro_text:
+            st.caption(intro_text)
 
-    target_day = _next_available_lesson_day(schedule, idx) or 1
+        cards = info.get("onboarding_cards") or []
+        if not isinstance(cards, Sequence) or not cards:
+            cards = []
 
-    def _set_coursebook_page(page: str) -> None:
-        st.session_state["coursebook_page"] = page
-        st.session_state["coursebook_prev_page"] = page
+        if cards:
+            target_day = _next_available_lesson_day(schedule, idx) or 1
 
-    def _jump_course(page: str) -> None:
-        _go_next_assignment(target_day)
-        _set_coursebook_page(page)
+            def _set_coursebook_page(page: str) -> None:
+                st.session_state["coursebook_page"] = page
+                st.session_state["coursebook_prev_page"] = page
 
-    def _jump_classroom() -> None:
-        st.session_state["nav_sel"] = "My Course"
-        st.session_state["main_tab_select"] = "My Course"
-        st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
-        st.session_state["cb_prev_subtab"] = "🧑‍🏫 Classroom"
-        _qp_set(tab="My Course")
-        st.session_state["need_rerun"] = True
+            def _jump_course(page: str) -> None:
+                _go_next_assignment(target_day)
+                _set_coursebook_page(page)
 
-    def _go_dashboard() -> None:
-        st.session_state["nav_sel"] = "Dashboard"
-        st.session_state["main_tab_select"] = "Dashboard"
-        _qp_set(tab="Dashboard")
-        st.session_state["need_rerun"] = True
+            def _jump_classroom() -> None:
+                st.session_state["nav_sel"] = "My Course"
+                st.session_state["main_tab_select"] = "My Course"
+                st.session_state["coursebook_subtab"] = "🧑‍🏫 Classroom"
+                st.session_state["cb_prev_subtab"] = "🧑‍🏫 Classroom"
+                _qp_set(tab="My Course")
+                st.session_state["need_rerun"] = True
 
-    action_map: Dict[str, Any] = {
-        "overview": lambda: _jump_course("Overview"),
-        "assignment": lambda: _jump_course("Assignment"),
-        "submit": lambda: _jump_course("Submit"),
-        "classroom": _jump_classroom,
-        "attendance": _go_attendance,
-        "dashboard": _go_dashboard,
-    }
+            def _go_dashboard() -> None:
+                st.session_state["nav_sel"] = "Dashboard"
+                st.session_state["main_tab_select"] = "Dashboard"
+                _qp_set(tab="Dashboard")
+                st.session_state["need_rerun"] = True
 
-    chunk = 3
-    for start in range(0, len(cards), chunk):
-        cols = st.columns(len(cards[start : start + chunk]))
-        for col, card in zip(cols, cards[start : start + chunk]):
-            with col:
-                title_raw = _safe_str(card.get("title"), "")
-                helper_raw = _safe_str(card.get("helper"), "")
-                title = html.escape(title_raw)
-                helper = html.escape(helper_raw)
-                steps = card.get("steps") or []
-                if not isinstance(steps, Sequence):
-                    steps = []
-                steps_html = "".join(
-                    f"<li>{html.escape(_safe_str(step, ''))}</li>" for step in steps if _safe_str(step, "")
-                )
+            action_map: Dict[str, Any] = {
+                "overview": lambda: _jump_course("Overview"),
+                "assignment": lambda: _jump_course("Assignment"),
+                "submit": lambda: _jump_course("Submit"),
+                "classroom": _jump_classroom,
+                "attendance": _go_attendance,
+                "dashboard": _go_dashboard,
+            }
 
-                st.markdown("<div class='day0-card'>", unsafe_allow_html=True)
-                if title:
-                    st.markdown(
-                        f"<div class='day0-card__title'>{title}</div>",
-                        unsafe_allow_html=True,
-                    )
-                if helper:
-                    st.markdown(
-                        f"<div class='day0-card__helper'>{helper}</div>",
-                        unsafe_allow_html=True,
-                    )
-                if steps_html:
-                    st.markdown(
-                        f"<ol>{steps_html}</ol>",
-                        unsafe_allow_html=True,
-                    )
+            chunk = 3
+            for start in range(0, len(cards), chunk):
+                cols = st.columns(len(cards[start : start + chunk]))
+                for col, card in zip(cols, cards[start : start + chunk]):
+                    with col:
+                        title_raw = _safe_str(card.get("title"), "")
+                        helper_raw = _safe_str(card.get("helper"), "")
+                        title = html.escape(title_raw)
+                        helper = html.escape(helper_raw)
+                        steps = card.get("steps") or []
+                        if not isinstance(steps, Sequence):
+                            steps = []
+                        steps_html = "".join(
+                            f"<li>{html.escape(_safe_str(step, ''))}</li>" for step in steps if _safe_str(step, "")
+                        )
 
-                cta_label = _safe_str(card.get("cta_label"))
-                action_key = _safe_lower(card.get("action"))
-                action_fn = action_map.get(action_key)
-                if cta_label and callable(action_fn):
-                    st.markdown("<div class='day0-card__cta'>", unsafe_allow_html=True)
-                    st.button(
-                        cta_label,
-                        key=f"day0_card_btn_{start}_{title_raw}",
-                        on_click=action_fn,
-                        use_container_width=True,
-                    )
-                    st.markdown("</div>", unsafe_allow_html=True)
-                st.markdown("</div>", unsafe_allow_html=True)
+                        st.markdown("<div class='day0-card'>", unsafe_allow_html=True)
+                        if title:
+                            st.markdown(
+                                f"<div class='day0-card__title'>{title}</div>",
+                                unsafe_allow_html=True,
+                            )
+                        if helper:
+                            st.markdown(
+                                f"<div class='day0-card__helper'>{helper}</div>",
+                                unsafe_allow_html=True,
+                            )
+                        if steps_html:
+                            st.markdown(
+                                f"<ol>{steps_html}</ol>",
+                                unsafe_allow_html=True,
+                            )
+
+                        cta_label = _safe_str(card.get("cta_label"))
+                        action_key = _safe_lower(card.get("action"))
+                        action_fn = action_map.get(action_key)
+                        if cta_label and callable(action_fn):
+                            st.markdown("<div class='day0-card__cta'>", unsafe_allow_html=True)
+                            st.button(
+                                cta_label,
+                                key=f"day0_card_btn_{start}_{title_raw}",
+                                on_click=action_fn,
+                                use_container_width=True,
+                            )
+                            st.markdown("</div>", unsafe_allow_html=True)
+                        st.markdown("</div>", unsafe_allow_html=True)
+
+    if expanded_default:
+        st.session_state[seen_state_key] = True
 
 
 # ---- Firestore Helpers ----


### PR DESCRIPTION
## Summary
- wrap the day zero onboarding content in a collapsible "Day 0 onboarding overview" expander
- track session state so the expander only opens by default on the first visit
- keep the existing onboarding navigation buttons intact inside the new expander

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69e9668108321928dcb0f203cfd11