### PR TITLE
Fix day zero onboarding indentation

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -2823,52 +2823,52 @@ def render_day_zero_onboarding(
         "dashboard": _go_dashboard,
     }
 
-        chunk = 3
-        for start in range(0, len(cards), chunk):
-            cols = st.columns(len(cards[start : start + chunk]))
-            for col, card in zip(cols, cards[start : start + chunk]):
-                with col:
-                    title_raw = _safe_str(card.get("title"), "")
-                    helper_raw = _safe_str(card.get("helper"), "")
-                    title = html.escape(title_raw)
-                    helper = html.escape(helper_raw)
-                    steps = card.get("steps") or []
-                    if not isinstance(steps, Sequence):
-                        steps = []
-                    steps_html = "".join(
-                        f"<li>{html.escape(_safe_str(step, ''))}</li>" for step in steps if _safe_str(step, "")
+    chunk = 3
+    for start in range(0, len(cards), chunk):
+        cols = st.columns(len(cards[start : start + chunk]))
+        for col, card in zip(cols, cards[start : start + chunk]):
+            with col:
+                title_raw = _safe_str(card.get("title"), "")
+                helper_raw = _safe_str(card.get("helper"), "")
+                title = html.escape(title_raw)
+                helper = html.escape(helper_raw)
+                steps = card.get("steps") or []
+                if not isinstance(steps, Sequence):
+                    steps = []
+                steps_html = "".join(
+                    f"<li>{html.escape(_safe_str(step, ''))}</li>" for step in steps if _safe_str(step, "")
+                )
+
+                st.markdown("<div class='day0-card'>", unsafe_allow_html=True)
+                if title:
+                    st.markdown(
+                        f"<div class='day0-card__title'>{title}</div>",
+                        unsafe_allow_html=True,
+                    )
+                if helper:
+                    st.markdown(
+                        f"<div class='day0-card__helper'>{helper}</div>",
+                        unsafe_allow_html=True,
+                    )
+                if steps_html:
+                    st.markdown(
+                        f"<ol>{steps_html}</ol>",
+                        unsafe_allow_html=True,
                     )
 
-                    st.markdown("<div class='day0-card'>", unsafe_allow_html=True)
-                    if title:
-                        st.markdown(
-                            f"<div class='day0-card__title'>{title}</div>",
-                            unsafe_allow_html=True,
-                        )
-                    if helper:
-                        st.markdown(
-                            f"<div class='day0-card__helper'>{helper}</div>",
-                            unsafe_allow_html=True,
-                        )
-                    if steps_html:
-                        st.markdown(
-                            f"<ol>{steps_html}</ol>",
-                            unsafe_allow_html=True,
-                        )
-
-                    cta_label = _safe_str(card.get("cta_label"))
-                    action_key = _safe_lower(card.get("action"))
-                    action_fn = action_map.get(action_key)
-                    if cta_label and callable(action_fn):
-                        st.markdown("<div class='day0-card__cta'>", unsafe_allow_html=True)
-                        st.button(
-                            cta_label,
-                            key=f"day0_card_btn_{start}_{title_raw}",
-                            on_click=action_fn,
-                            use_container_width=True,
-                        )
-                        st.markdown("</div>", unsafe_allow_html=True)
+                cta_label = _safe_str(card.get("cta_label"))
+                action_key = _safe_lower(card.get("action"))
+                action_fn = action_map.get(action_key)
+                if cta_label and callable(action_fn):
+                    st.markdown("<div class='day0-card__cta'>", unsafe_allow_html=True)
+                    st.button(
+                        cta_label,
+                        key=f"day0_card_btn_{start}_{title_raw}",
+                        on_click=action_fn,
+                        use_container_width=True,
+                    )
                     st.markdown("</div>", unsafe_allow_html=True)
+                st.markdown("</div>", unsafe_allow_html=True)
 
 
 # ---- Firestore Helpers ----


### PR DESCRIPTION
## Summary
- fix the indentation of the day zero onboarding card rendering loop so it executes at the proper scope

## Testing
- python -m compileall a1sprechen.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a5304c508321b5ad0c69f28fe7bc