### PR TITLE
Add typing indicators for class board drafts

### DIFF
--- a/tests/test_comment_box_clears.py
+++ b/tests/test_comment_box_clears.py
@@ -23,6 +23,8 @@ def load_send_comment(stub_st):
         'uuid4': lambda: 'abcd1234',
         'time': time,
         'refresh_with_toast': lambda *a, **k: None,
+        '_clear_typing_state': lambda **kwargs: None,
+        'student_level': 'A1',
     }
     exec(compile(mod, 'a1sprechen.py', 'exec'), glb)
     return glb['send_comment']

--- a/tests/test_firestore_typing_helpers.py
+++ b/tests/test_firestore_typing_helpers.py
@@ -1,0 +1,142 @@
+from datetime import datetime, timedelta, timezone
+
+from src import firestore_utils
+
+
+class DummyDoc:
+    def __init__(self):
+        self.set_payloads = []
+        self.deleted = 0
+
+    def set(self, payload):
+        self.set_payloads.append(payload)
+
+    def delete(self):
+        self.deleted += 1
+
+
+class DummySnapshot:
+    def __init__(self, sid, data):
+        self.id = sid
+        self._data = data
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+def test_set_typing_indicator_updates_and_clears(monkeypatch):
+    doc = DummyDoc()
+    monkeypatch.setattr(
+        firestore_utils,
+        "_typing_doc_ref",
+        lambda *args, **kwargs: doc,
+    )
+
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert firestore_utils.set_typing_indicator(
+        "A1",
+        "Class-1",
+        "post1",
+        "stu",
+        "Student",
+        is_typing=True,
+        now=now,
+    )
+    assert doc.set_payloads[-1]["student_name"] == "Student"
+    assert doc.set_payloads[-1]["last_seen"].tzinfo is timezone.utc
+
+    assert firestore_utils.set_typing_indicator(
+        "A1",
+        "Class-1",
+        "post1",
+        "stu",
+        "Student",
+        is_typing=False,
+    )
+    assert doc.deleted == 1
+
+
+def test_set_typing_indicator_handles_failures(monkeypatch):
+    class FailingDoc:
+        def set(self, payload):
+            raise RuntimeError("boom")
+
+        def delete(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        firestore_utils,
+        "_typing_doc_ref",
+        lambda *args, **kwargs: FailingDoc(),
+    )
+
+    assert not firestore_utils.set_typing_indicator(
+        "A1",
+        "C",
+        "q",
+        "stu",
+        "Name",
+        is_typing=True,
+    )
+    assert not firestore_utils.set_typing_indicator(
+        "A1",
+        "C",
+        "q",
+        "stu",
+        "Name",
+        is_typing=False,
+    )
+
+
+def test_fetch_active_typists_filters_expired(monkeypatch):
+    now = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    recent = now - timedelta(seconds=5)
+    stale = now - timedelta(seconds=45)
+
+    class DummyCollection:
+        def stream(self):
+            return [
+                DummySnapshot("abc", {"student_name": "Alice", "last_seen": recent}),
+                DummySnapshot("xyz", {"student_name": "Bob", "last_seen": stale}),
+                DummySnapshot("raw", {"student_name": "Raw", "last_seen": 0}),
+            ]
+
+    monkeypatch.setattr(
+        firestore_utils,
+        "_typing_collection",
+        lambda *args, **kwargs: DummyCollection(),
+    )
+
+    active = firestore_utils.fetch_active_typists(
+        "A1",
+        "Class-1",
+        "post1",
+        now=now,
+        ttl_seconds=10,
+    )
+
+    assert [entry["student_code"] for entry in active] == ["abc"]
+    assert active[0]["last_seen"] == recent
+
+
+def test_fetch_active_typists_handles_stream_failure(monkeypatch):
+    class BrokenCollection:
+        def stream(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        firestore_utils,
+        "_typing_collection",
+        lambda *args, **kwargs: BrokenCollection(),
+    )
+
+    assert firestore_utils.fetch_active_typists("A1", "C", "post1") == []
+
+
+def test_fetch_active_typists_handles_missing_collection(monkeypatch):
+    monkeypatch.setattr(
+        firestore_utils,
+        "_typing_collection",
+        lambda *args, **kwargs: None,
+    )
+    assert firestore_utils.fetch_active_typists("A1", "C", "post1") == []

--- a/tests/test_typing_ui_helpers.py
+++ b/tests/test_typing_ui_helpers.py
@@ -1,0 +1,154 @@
+import ast
+import math
+from typing import Any, Dict, List
+
+
+class TimeStub:
+    def __init__(self, start: float = 1000.0):
+        self._now = start
+
+    def time(self) -> float:
+        return self._now
+
+    def advance(self, delta: float) -> None:
+        self._now += delta
+
+
+class StreamlitStub:
+    def __init__(self):
+        self.session_state: Dict[str, Any] = {}
+
+
+def load_typing_helpers(stub_st, indicator_func, time_stub):
+    with open("a1sprechen.py", "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename="a1sprechen.py")
+
+    wanted_funcs = {
+        "_safe_str",
+        "_typing_meta_key",
+        "_update_typing_state",
+        "_clear_typing_state",
+        "_format_typing_banner",
+    }
+    wanted_assigns = {"_TYPING_TRACKER_PREFIX", "_TYPING_PING_INTERVAL"}
+    selected = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id in wanted_assigns
+                for target in node.targets
+            ):
+                selected.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in wanted_funcs:
+            selected.append(node)
+
+    module = ast.Module(body=selected, type_ignores=[])
+    glb: Dict[str, Any] = {
+        "st": stub_st,
+        "time": time_stub,
+        "set_typing_indicator": indicator_func,
+        "math": math,
+        "Any": Any,
+        "Dict": Dict,
+        "List": List,
+    }
+    exec(compile(module, "a1sprechen.py", "exec"), glb)
+    return glb
+
+
+def test_update_typing_state_is_throttled():
+    indicator_calls: List[Dict[str, Any]] = []
+
+    def indicator(*args, **kwargs):
+        indicator_calls.append({"is_typing": kwargs.get("is_typing")})
+        return True
+
+    st = StreamlitStub()
+    time_stub = TimeStub()
+    helpers = load_typing_helpers(st, indicator, time_stub)
+    update = helpers["_update_typing_state"]
+    clear = helpers["_clear_typing_state"]
+    meta_key = helpers["_typing_meta_key"]("draft1")
+
+    update(
+        level="A1",
+        class_code="C1",
+        qid="q1",
+        draft_key="draft1",
+        student_code="stu",
+        student_name="Student",
+        text="Hallo",
+    )
+    assert indicator_calls and indicator_calls[0]["is_typing"] is True
+    assert st.session_state[meta_key]["is_typing"] is True
+
+    update(
+        level="A1",
+        class_code="C1",
+        qid="q1",
+        draft_key="draft1",
+        student_code="stu",
+        student_name="Student",
+        text="Hallo",
+    )
+    assert len(indicator_calls) == 1
+
+    time_stub.advance(5.0)
+    update(
+        level="A1",
+        class_code="C1",
+        qid="q1",
+        draft_key="draft1",
+        student_code="stu",
+        student_name="Student",
+        text="Hallo",
+    )
+    assert len(indicator_calls) == 2
+    assert indicator_calls[-1]["is_typing"] is True
+
+    update(
+        level="A1",
+        class_code="C1",
+        qid="q1",
+        draft_key="draft1",
+        student_code="stu",
+        student_name="Student",
+        text="",
+    )
+    assert indicator_calls[-1]["is_typing"] is False
+    assert st.session_state[meta_key]["is_typing"] is False
+
+    clear(
+        level="A1",
+        class_code="C1",
+        qid="q1",
+        draft_key="draft1",
+        student_code="stu",
+        student_name="Student",
+    )
+    assert indicator_calls[-1]["is_typing"] is False
+    assert meta_key not in st.session_state
+
+
+def test_format_typing_banner_humanises_names():
+    st = StreamlitStub()
+    time_stub = TimeStub()
+    indicators: List[Dict[str, Any]] = []
+    helpers = load_typing_helpers(st, lambda **kwargs: indicators.append(kwargs), time_stub)
+    format_banner = helpers["_format_typing_banner"]
+
+    banner_single = format_banner(
+        [{"student_code": "abc", "student_name": "Alice"}],
+        current_code="xyz",
+    )
+    assert banner_single == "Alice is typing…"
+
+    banner_multi = format_banner(
+        [
+            {"student_code": "self", "student_name": "Self"},
+            {"student_code": "b", "student_name": "Bob"},
+            {"student_code": "c", "student_name": ""},
+        ],
+        current_code="self",
+    )
+    assert banner_multi == "Bob and c are typing…"


### PR DESCRIPTION
## Summary
- add Firestore helpers to persist and read per-thread typing presence with expiry handling
- integrate typing indicators into the class board new post and reply flows with throttled updates
- cover the new helpers with unit tests and adapt existing classroom comment tests

## Testing
- pytest tests/test_firestore_typing_helpers.py tests/test_typing_ui_helpers.py tests/test_comment_box_clears.py

------
https://chatgpt.com/codex/tasks/task_e_68d6efcc12e0832184e47b4adb53c3bb