### PR TITLE
Add caption clarifying resubmit email workflow

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -3867,6 +3867,11 @@ if tab == "My Course":
                         )
                         with st.container(border=True):
                             st.markdown("**Need to resubmit?**")
+                            st.caption(
+                                "The button opens a pre-filled email to learngermanghana@gmail.com. "
+                                "If your device doesn't launch an email app, copy the address and "
+                                "send your resubmission manually using the template above."
+                            )
                             st.link_button(
                                 "Resubmit via email",
                                 resubmit_link,


### PR DESCRIPTION
## Summary
- add a caption below the resubmit heading to clarify the pre-filled email button and provide fallback steps

## Testing
- streamlit run a1sprechen.py --server.port 8501 --server.address 0.0.0.0 *(fails: Missing OpenAI API key / external proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f5b7042c8321a4fd0d40b35cb672