### PR TITLE
Adjust draft clearing to avoid rehydrating widget immediately

### DIFF
--- a/src/draft_management.py
+++ b/src/draft_management.py
@@ -107,7 +107,15 @@ def clear_draft_after_post(code: str, draft_key: str) -> None:
     """Persist an empty draft and clear local state after publishing."""
 
     save_draft_to_db(code, draft_key, "")
-    reset_local_draft_state(draft_key, text="", saved=False, saved_at=None)
+    st.session_state.pop(draft_key, None)
+
+    last_val_key, last_ts_key, saved_flag_key, saved_at_key = _draft_state_keys(
+        draft_key
+    )
+    st.session_state[last_val_key] = ""
+    st.session_state[last_ts_key] = time.time()
+    st.session_state[saved_flag_key] = False
+    st.session_state[saved_at_key] = None
 
 
 def save_now(draft_key: str, code: str, show_toast: bool = True) -> None:

--- a/tests/test_classnotes_draft_lifecycle.py
+++ b/tests/test_classnotes_draft_lifecycle.py
@@ -57,7 +57,7 @@ def test_clear_draft_after_post_resets_local_state(monkeypatch):
         "q_text"
     )
 
-    assert session_state["q_text"] == ""
+    assert "q_text" not in session_state
     assert session_state[last_val_key] == ""
     assert session_state[saved_flag_key] is False
     assert session_state[saved_at_key] is None


### PR DESCRIPTION
## Summary
- update draft clearing to remove the live widget entry while keeping metadata in sync
- update draft lifecycle tests to assert the widget key is removed and metadata reset

## Testing
- pytest tests/test_classnotes_draft_lifecycle.py tests/test_draft_management.py

------
https://chatgpt.com/codex/tasks/task_e_68dae0e2fc9c8321b3e419c91f607afd