### PR TITLE
Persist classroom comment drafts on logout

### DIFF
--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,0 +1,52 @@
+import logging
+
+import pytest
+
+from src import logout
+
+
+class DummySt:
+    def __init__(self):
+        self.session_state = {
+            "session_token": "token-123",
+            "student_code": "STUDENT42",
+            "classroom_comment_draft_week1": "Remember to review.",
+        }
+        self.query_params = {}
+        self.messages = []
+
+    def success(self, message):
+        self.messages.append(message)
+
+
+@pytest.fixture(autouse=True)
+def clear_log_handlers():
+    # Ensure logger errors do not propagate between tests
+    logger = logging.getLogger()
+    handlers = list(logger.handlers)
+    for handler in handlers:
+        logger.removeHandler(handler)
+    try:
+        yield
+    finally:
+        for handler in handlers:
+            logger.addHandler(handler)
+
+
+def test_do_logout_persists_classroom_comment_drafts(monkeypatch):
+    saved = []
+
+    def fake_save(code, key, value):
+        saved.append((code, key, value))
+
+    monkeypatch.setattr(logout, "save_draft_to_db", fake_save)
+
+    st_module = DummySt()
+
+    logout.do_logout(
+        st_module=st_module,
+        destroy_token=lambda token: None,
+        logger=logging,
+    )
+
+    assert ("STUDENT42", "classroom_comment_draft_week1", "Remember to review.") in saved


### PR DESCRIPTION
## Summary
- capture the active student code at logout and persist classroom comment drafts before clearing session state
- import Firestore draft helper and guard draft persistence with error logging
- add a regression test to ensure logout saves classroom comment drafts

## Testing
- pytest tests/test_logout.py

------
https://chatgpt.com/codex/tasks/task_e_68dae2e7e1948321b6d0f3f1d766fdda