### PR TITLE
Sanitize blog card hrefs

### DIFF
--- a/src/blog_cards_widget.py
+++ b/src/blog_cards_widget.py
@@ -43,6 +43,7 @@ def render_blog_cards(
     for it in items:
         title_txt = it.get("title", "") or ""
         href_txt = it.get("href", "") or "#"
+        safe_href = safe_http_url(href_txt) or "#"
 
         # Body: strip HTML to plain text; provide a readable fallback if empty
         raw_body = it.get("body", "") or ""
@@ -53,7 +54,7 @@ def render_blog_cards(
         img_url = safe_http_url(it.get("image") or "")
 
         title = esc(title_txt)
-        href = esc(href_txt)
+        href = esc(safe_href)
         body = esc(snippet)
 
         img_html = (

--- a/tests/test_blog_cards_widget.py
+++ b/tests/test_blog_cards_widget.py
@@ -1,0 +1,30 @@
+from src.blog_cards_widget import render_blog_cards
+
+
+def test_render_blog_cards_sanitizes_links(monkeypatch):
+    captured = {}
+
+    def fake_html(html_block, height=None, scrolling=False):
+        captured["html"] = html_block
+
+    monkeypatch.setattr("src.blog_cards_widget.components.html", fake_html)
+
+    items = [
+        {
+            "title": "Unsafe Link",
+            "href": "javascript:alert('oops')",
+            "body": "<p>Body</p>",
+        },
+        {
+            "title": "Data Link",
+            "href": "data:text/html;base64,PHNjcmlwdD4=",
+            "body": "<p>Another Body</p>",
+        },
+    ]
+
+    render_blog_cards(items, height=200)
+
+    html = captured.get("html", "")
+    assert "javascript:" not in html
+    assert "data:" not in html
+    assert 'href="#"' in html


### PR DESCRIPTION
## Summary
- sanitize blog card hrefs by enforcing http(s) schemes and defaulting to '#'
- add a regression test covering javascript and data scheme inputs

## Testing
- pytest tests/test_blog_cards_widget.py

------
https://chatgpt.com/codex/tasks/task_e_68dae7a536c88321b8a80691252b01c5