### PR TITLE
Display forum timer near reply composer

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -50,7 +50,11 @@ from src.topic_coach_persistence import (
     load_topic_coach_state,
     persist_topic_coach_state,
 )
-from src.forum_timer import _to_datetime_any, build_forum_timer_indicator
+from src.forum_timer import (
+    _to_datetime_any,
+    build_forum_reply_indicator_text,
+    build_forum_timer_indicator,
+)
 from src.level_sync import sync_level_state
 
 from flask import Flask
@@ -6044,6 +6048,17 @@ if tab == "My Course":
                     )
                     if banner:
                         st.caption(banner)
+                    reply_timer_label = build_forum_reply_indicator_text(timer_info)
+                    if reply_timer_label:
+                        reply_color = "#dc2626" if timer_info.get("status") == "open" else "#64748b"
+                        st.markdown(
+                            "<div style='font-size:0.95rem;font-weight:600;color:%s;margin:6px 0 -4px;'>%s</div>"
+                            % (
+                                reply_color,
+                                html.escape(str(reply_timer_label)),
+                            ),
+                            unsafe_allow_html=True,
+                        )
                     st.text_area(
                         "Reply to this thread…",
                         key=draft_key,

--- a/src/forum_timer.py
+++ b/src/forum_timer.py
@@ -89,7 +89,24 @@ def build_forum_timer_indicator(
     }
 
 
+def build_forum_reply_indicator_text(timer_info: Optional[Dict[str, Any]]) -> str:
+    """Return the countdown/closed label to display near the reply composer."""
+    if not timer_info:
+        return ""
+
+    status = timer_info.get("status")
+    label = timer_info.get("label") or ""
+    if status in {"open", "closed"} and label:
+        return str(label)
+    return ""
+
+
 # Backwards-compatible private aliases for modules expecting these helpers
 _to_datetime_any = to_datetime_any
 
-__all__ = ["to_datetime_any", "_to_datetime_any", "build_forum_timer_indicator"]
+__all__ = [
+    "to_datetime_any",
+    "_to_datetime_any",
+    "build_forum_timer_indicator",
+    "build_forum_reply_indicator_text",
+]

--- a/tests/test_forum_timer_indicator.py
+++ b/tests/test_forum_timer_indicator.py
@@ -1,6 +1,10 @@
 from datetime import datetime, timedelta, timezone
 
-from src.forum_timer import build_forum_timer_indicator, to_datetime_any
+from src.forum_timer import (
+    build_forum_reply_indicator_text,
+    build_forum_timer_indicator,
+    to_datetime_any,
+)
 
 
 def test_to_datetime_any_handles_naive_datetime():
@@ -27,3 +31,25 @@ def test_build_forum_timer_indicator_closed():
     assert info["status"] == "closed"
     assert info["minutes"] == 0
     assert info["label"] == "Forum closed"
+
+
+def test_build_forum_reply_indicator_text_mirrors_open_label():
+    info = {
+        "status": "open",
+        "label": "⏳ 7 minutes left",
+        "minutes": 7,
+    }
+    assert build_forum_reply_indicator_text(info) == "⏳ 7 minutes left"
+
+
+def test_build_forum_reply_indicator_text_handles_closed_state():
+    info = {
+        "status": "closed",
+        "label": "Forum closed",
+        "minutes": 0,
+    }
+    assert build_forum_reply_indicator_text(info) == "Forum closed"
+
+
+def test_build_forum_reply_indicator_text_empty_when_no_timer():
+    assert build_forum_reply_indicator_text({"status": "none", "label": ""}) == ""


### PR DESCRIPTION
## Summary
- render the forum timer status directly above the reply composer so countdowns and closures are visible while typing
- share label-selection logic through a helper that is covered by automated tests

## Testing
- pytest tests/test_forum_timer_indicator.py
- streamlit run a1sprechen.py --server.headless true --browser.gatherUsageStats false

------
https://chatgpt.com/codex/tasks/task_e_68daee8fc1648321b894cd20e428f496