### PR TITLE
Fix forum timer reset handling for class board posts

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5501,7 +5501,6 @@ if tab == "My Course":
                     )
                     clear_draft_after_post(student_code, draft_key)
                     st.session_state["__clear_q_form"] = True
-                    st.session_state["q_forum_timer_minutes"] = 0
                     st.success("Post published!")
                     refresh_with_toast()
 


### PR DESCRIPTION
## Summary
- remove the redundant q_forum_timer_minutes reset in the post handler so the timer is cleared via the existing __clear_q_form flow

## Testing
- not run (Streamlit UI manual verification requested but not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbbeaa42e88321a9a99b7513605918