### PR TITLE
Show seconds in class board timestamps

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5270,7 +5270,7 @@ if tab == "My Course":
 
             def _fmt_ts(ts):
                 try:
-                    return ts.strftime("%d %b %H:%M")
+                    return ts.strftime("%d %b %H:%M:%S")
                 except Exception:
                     return ""
 


### PR DESCRIPTION
## Summary
- include seconds in the Class Notes & Q&A timestamp formatter so post and comment labels show HH:MM:SS

## Testing
- pytest *(fails: Class discussion/link tests and get_score_for_assignment expect helpers not present in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd96bce8083219fa35aff24b2264e