### PR TITLE
Display warning when class board replies expire in a minute

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5683,6 +5683,16 @@ if tab == "My Course":
                         "</div>"
                     )
                     st.markdown(post_html, unsafe_allow_html=True)
+
+                    show_timer_warning = (
+                        timer_info.get("status") == "open" and timer_minutes_remaining == 1
+                    )
+                    if show_timer_warning:
+                        st.info(
+                            "⏳ Time up soon—replies close in under a minute.",
+                            icon="⏳",
+                        )
+
                     clear_q_edit_flag = f"__clear_q_edit_{q_id}"
                     if st.session_state.pop(clear_q_edit_flag, False):
                         for _k in [


### PR DESCRIPTION
## Summary
- detect when a class board post has one minute remaining on its reply timer
- surface a Streamlit info callout near the post to warn that replies close soon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbda3cd05883218ba2e44cb6685880