### PR TITLE
Adjust blog footer spacing

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1070,7 +1070,7 @@ def login_page():
         height = globals().get("calc_blog_height", lambda n: 380)(len(blog_posts))
         render_blog_cards(blog_posts, height=height)
         st.markdown(
-            '<div style="text-align:center;margin-top:8px;">'
+            '<div style="text-align:center;margin:4px 0 0;">'
             '<a href="https://blog.falowen.app/" target="_blank" rel="noopener">Read more</a>'
             '</div>',
             unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- tighten the margin around the blog widget footer link so it sits closer to the cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe918d1788321a3df1afb9393c3e9