### PR TITLE
Handle pending dictionary query updates

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -7775,6 +7775,9 @@ if tab == "Vocab Trainer":
             st.markdown('<div class="sticky-search">', unsafe_allow_html=True)
             cols = st.columns([6, 3, 3])
             with cols[0]:
+                pending_dict_q = st.session_state.pop("dict_q_pending", None)
+                if pending_dict_q is not None:
+                    st.session_state["dict_q"] = pending_dict_q
                 q = st.text_input("🔎 Search (German or English)", key="dict_q", placeholder="e.g., Wochenende, bakery, spielen")
             with cols[1]:
                 search_in = st.selectbox("Field", ["Both", "German", "English"], 0, key="dict_field")
@@ -7864,7 +7867,7 @@ if tab == "Vocab Trainer":
             for i, s in enumerate(suggestions[:5]):
                 with bcols[i]:
                     if st.button(s, key=f"sugg_{i}"):
-                        st.session_state["dict_q"] = s
+                        st.session_state["dict_q_pending"] = s
                         refresh_with_toast()
 
         levels_label = ", ".join(levels) if levels else "none"

--- a/src/vocab/dictionary.py
+++ b/src/vocab/dictionary.py
@@ -141,6 +141,9 @@ def render_vocab_dictionary(student_level_locked: str) -> None:
         st.markdown('<div class="sticky-search">', unsafe_allow_html=True)
         cols = st.columns([6, 3, 3])
         with cols[0]:
+            pending_dict_q = st.session_state.pop("dict_q_pending", None)
+            if pending_dict_q is not None:
+                st.session_state["dict_q"] = pending_dict_q
             query = st.text_input(
                 "🔎 Search (German or English)",
                 key="dict_q",
@@ -265,7 +268,7 @@ def render_vocab_dictionary(student_level_locked: str) -> None:
         for idx, suggestion in enumerate(suggestions[:5]):
             with button_cols[idx]:
                 if st.button(suggestion, key=f"sugg_{idx}"):
-                    st.session_state["dict_q"] = suggestion
+                    st.session_state["dict_q_pending"] = suggestion
                     refresh_with_toast()
 
     levels_label = ", ".join(levels) if levels else "none"


### PR DESCRIPTION
## Summary
- load any pending dictionary query before rendering the search input
- queue suggestion button clicks through a pending query field and refresh the page
- mirror the pending query behavior in the standalone dictionary view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf42db87c832186cb99d96c495c8e