### PR TITLE
Relocate forum timer warning next to reply composer

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -5697,11 +5697,6 @@ if tab == "My Course":
                     show_timer_warning = (
                         timer_info.get("status") == "open" and timer_minutes_remaining == 1
                     )
-                    if show_timer_warning:
-                        st.info(
-                            "⏳ Time up soon—replies close in under a minute.",
-                            icon="⏳",
-                        )
 
                     clear_q_edit_flag = f"__clear_q_edit_{q_id}"
                     if st.session_state.pop(clear_q_edit_flag, False):
@@ -6077,6 +6072,11 @@ if tab == "My Course":
                                 html.escape(str(reply_timer_label)),
                             ),
                             unsafe_allow_html=True,
+                        )
+                    if show_timer_warning:
+                        st.info(
+                            "⏳ Time up soon—replies close in under a minute.",
+                            icon="⏳",
                         )
                     st.text_area(
                         "Reply to this thread…",


### PR DESCRIPTION
## Summary
- move the one-minute timer warning from the post header into the reply composer area
- ensure the warning appears only when a single minute remains for replies to avoid duplicate notices

## Testing
- not run (Streamlit app not launched in CI)


------
https://chatgpt.com/codex/tasks/task_e_68dc2af6868c8321b36d3a40be46533f