### PR TITLE
Update Telegram onboarding instructions

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -1353,8 +1353,7 @@ def render_sidebar_published():
         with st.sidebar.expander("🔔 Telegram notifications", expanded=False):
             st.markdown(
                 """
-- [Open the Falowen bot](https://t.me/falowenbot) and tap **Start**
-- Register: `/register <student_code>` (e.g. `/register kwame202`)
+- Open the Falowen bot link or search for `@falowenbot`, tap **Start**, then type your student code (e.g. `kwame202`)
 - To deactivate: send `/stop`
                 """
             )


### PR DESCRIPTION
## Summary
- update the Telegram sidebar guidance to direct users to start the Falowen bot without using slash commands

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcdf4516d48321a72314ec68931e4b