### PR TITLE
Trigger rerun after posting class reply

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -6165,7 +6165,7 @@ if tab == "My Course":
                                     saved_flag_key,
                                     saved_at_key,
                                 )
-                                st.session_state["need_rerun"] = True
+                                st.rerun()
 
                     with ai_col:
                         if st.button(


### PR DESCRIPTION
## Summary
- rerun the Streamlit app immediately after sending a class reply so the new comment appears without extra interaction
- remove the redundant need_rerun session flag update

## Testing
- not run (manual change)


------
https://chatgpt.com/codex/tasks/task_e_68dd010ca09083218935ee6093870e40