### PR TITLE
Add spaced repetition scheduling for vocab practice

### DIFF
--- a/src/stats.py
+++ b/src/stats.py
@@ -7,7 +7,7 @@ been extracted so they can be imported independently and tested.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Dict, Any
 from collections import Counter
 
 import os
@@ -134,6 +134,57 @@ def vocab_attempt_exists(student_code: str, session_id: str) -> bool:
     return any(h.get("session_id") == session_id for h in history)
 
 
+def _merge_schedule_updates(
+    existing: Dict[str, Any],
+    updates: Optional[Dict[str, Optional[Dict[str, Any]]]],
+) -> Dict[str, Any]:
+    """Merge per-word schedule *updates* into *existing* data."""
+
+    merged: Dict[str, Any] = {str(k): dict(v) for k, v in (existing or {}).items()}
+    if not updates:
+        return merged
+
+    for raw_word, payload in updates.items():
+        word = str(raw_word).strip()
+        if not word:
+            continue
+        if payload is None:
+            merged.pop(word, None)
+            continue
+        cleaned = {k: v for k, v in payload.items() if v is not None}
+        merged[word] = cleaned
+    return merged
+
+
+def update_vocab_schedule(
+    student_code: str, updates: Dict[str, Optional[Dict[str, Any]]]
+) -> None:
+    """Apply *updates* to a student's stored vocabulary schedule."""
+
+    if not updates:
+        return
+
+    _db = _get_db()
+    if _db is None:
+        st.warning("Firestore not initialized; skipping schedule update.")
+        return
+
+    doc_ref = _db.collection("vocab_stats").document(student_code)
+    try:
+        doc = doc_ref.get()
+    except Exception as e:  # pragma: no cover - firestore failure
+        st.warning(f"Could not load existing schedule ({e}); skipping update.")
+        return
+
+    data = doc.to_dict() if doc.exists else {}
+    schedule = _merge_schedule_updates(data.get("schedule", {}), updates)
+
+    try:
+        doc_ref.set({"schedule": schedule}, merge=True)
+    except Exception as e:  # pragma: no cover - firestore failure
+        st.warning(f"Could not update schedule ({e}).")
+
+
 def save_vocab_attempt(
     student_code: str,
     level: str,
@@ -142,6 +193,7 @@ def save_vocab_attempt(
     practiced_words: Iterable[str],
     session_id: Optional[str] = None,
     incorrect_words: Optional[Iterable[str]] = None,
+    schedule_updates: Optional[Dict[str, Optional[Dict[str, Any]]]] = None,
 ) -> None:
     """Persist one vocab practice attempt to Firestore."""
 
@@ -167,6 +219,7 @@ def save_vocab_attempt(
     data = doc.to_dict() if doc.exists else {}
     history = data.get("history", [])
     total_sessions = data.get("total_sessions", len(history))
+    schedule = _merge_schedule_updates(data.get("schedule", {}), schedule_updates)
 
     
     raw_total = int(total) if total is not None else 0
@@ -191,19 +244,27 @@ def save_vocab_attempt(
             if text and text not in seen_incorrect:
                 seen_incorrect.append(text)
 
-    attempt = {
-        "level": level,
-        "total": total_int,
-        "correct": correct_int,
-        "practiced_words": list(practiced_words or []),
-        "timestamp": datetime.now(tz=timezone.utc).isoformat(timespec="minutes"),
-        "session_id": session_id,
-        "incorrect_words": seen_incorrect,
-    }
+    words_list = list(practiced_words or [])
+    should_record = bool(words_list) or total_int or correct_int
+    timestamp = datetime.now(tz=timezone.utc).isoformat(timespec="minutes")
+    if should_record:
+        attempt = {
+            "level": level,
+            "total": total_int,
+            "correct": correct_int,
+            "practiced_words": words_list,
+            "timestamp": timestamp,
+            "session_id": session_id,
+            "incorrect_words": seen_incorrect,
+        }
 
-    history.append(attempt)
-    total_sessions += 1
-    history = history[-MAX_HISTORY:]
+        history.append(attempt)
+        total_sessions += 1
+        history = history[-MAX_HISTORY:]
+    else:
+        attempt = None
+        timestamp = data.get("last_practiced") or timestamp
+
     completed = {w for a in history for w in a.get("practiced_words", [])}
 
     incorrect_counter: Counter[str] = Counter()
@@ -215,16 +276,15 @@ def save_vocab_attempt(
     aggregated_incorrect = [word for word, _ in incorrect_counter.most_common(50)]
 
     try:
-        doc_ref.set(
-            {
-                "history": history,
-                "last_practiced": attempt["timestamp"],
-                "completed_words": sorted(completed),
-                "total_sessions": total_sessions,
-                "incorrect_words": aggregated_incorrect,
-            },
-            merge=True,
-        )
+        payload = {
+            "history": history,
+            "last_practiced": attempt["timestamp"] if attempt else timestamp,
+            "completed_words": sorted(completed),
+            "total_sessions": total_sessions,
+            "incorrect_words": aggregated_incorrect,
+            "schedule": schedule,
+        }
+        doc_ref.set(payload, merge=True)
     except Exception as e:  # pragma: no cover - firestore failure
         st.warning(f"Could not save stats ({e}).")
 
@@ -240,6 +300,7 @@ def get_vocab_stats(student_code: str):
             "completed_words": [],
             "total_sessions": 0,
             "incorrect_words": [],
+            "schedule": {},
         }
 
     doc_ref = _db.collection("vocab_stats").document(student_code)
@@ -266,6 +327,7 @@ def get_vocab_stats(student_code: str):
             "completed_words": data.get("completed_words", []),
             "total_sessions": total_sessions,
             "incorrect_words": data.get("incorrect_words", []),
+            "schedule": data.get("schedule", {}),
         }
 
     return {
@@ -274,4 +336,5 @@ def get_vocab_stats(student_code: str):
         "completed_words": [],
         "total_sessions": 0,
         "incorrect_words": [],
+        "schedule": {},
     }

--- a/src/vocab/practice.py
+++ b/src/vocab/practice.py
@@ -12,6 +12,7 @@ from src.services.vocab import VOCAB_LISTS, get_audio_url
 from src.stats import save_vocab_attempt, vocab_attempt_exists
 from src.stats_ui import render_vocab_stats
 from src.utils.toasts import refresh_with_toast
+from src.vocab.scheduler import VocabScheduleManager
 
 if TYPE_CHECKING:  # pragma: no cover - runtime import to avoid circular dependency
     from typing import Callable
@@ -68,7 +69,7 @@ def render_vocab_practice(student_code: str, level: str) -> None:
         "vt_total": None,
         "vt_saved": False,
         "vt_session_id": None,
-        "vt_mode": "Only new words",
+        "vt_mode": "Due today",
         "vt_incorrect": [],
     }
     for key, value in defaults.items():
@@ -82,7 +83,71 @@ def render_vocab_practice(student_code: str, level: str) -> None:
     items = VOCAB_LISTS.get(level, [])
     completed = set(stats["completed_words"])
     not_done = [pair for pair in items if pair[0] not in completed]
+    schedule_manager = VocabScheduleManager(
+        student_code, stats.get("schedule", {})
+    )
+    due_items = schedule_manager.due_items(items)
+    due_count = len(due_items)
+    next_due = schedule_manager.next_due_after_now()
+    new_count = len(not_done)
+
+    col_due, col_next, col_new = st.columns(3)
+    col_due.metric("Due today", due_count)
+    next_display = (
+        next_due.replace("T", " ")[:16] if next_due else "🎉 All clear!"
+    )
+    col_next.metric("Next review", next_display)
+    col_new.metric("New words available", new_count)
     st.info(f"{len(not_done)} words NOT yet done at {level}.")
+
+    if schedule_manager.known_words:
+        due_labels = {
+            item.pair[0]: f"{item.pair[0]} · due {item.due_at.date()}"
+            for item in due_items
+        }
+        with st.expander("🔧 Manage review schedule", expanded=False):
+            st.caption(
+                "Snooze cards if you need more time or reset them to relearn from scratch."
+            )
+            snooze_options = list(due_labels.keys()) or list(schedule_manager.known_words)
+            snooze_selection = st.multiselect(
+                "Cards to snooze",
+                options=snooze_options,
+                format_func=lambda word: due_labels.get(word, word),
+                key="vt_snooze_selection",
+            )
+            snooze_days = st.slider(
+                "Snooze for how many days?",
+                1,
+                14,
+                value=1,
+                key="vt_snooze_days",
+            )
+            if st.button("Snooze selected", key="vt_snooze_button"):
+                updates = schedule_manager.snooze_cards(
+                    snooze_selection, days=snooze_days
+                )
+                if updates:
+                    schedule_manager.persist_updates(updates)
+                    st.success("Snoozed selected cards.")
+                    refresh_with_toast()
+                else:
+                    st.info("Select at least one card to snooze.")
+
+            reset_selection = st.multiselect(
+                "Cards to reset",
+                options=list(schedule_manager.known_words),
+                key="vt_reset_selection",
+                help="Resetting clears the schedule so the word returns as new.",
+            )
+            if st.button("Reset selected cards", key="vt_reset_button"):
+                updates = schedule_manager.reset_cards(reset_selection)
+                if updates:
+                    schedule_manager.persist_updates(updates)
+                    st.success("Reset schedule for selected cards.")
+                    refresh_with_toast()
+                else:
+                    st.info("Select at least one card to reset.")
 
     if st.button("🔁 Start New Practice", key="vt_reset"):
         for key in defaults:
@@ -94,11 +159,14 @@ def render_vocab_practice(student_code: str, level: str) -> None:
             st.subheader("Daily Practice Setup")
             mode = st.radio(
                 "Select words:",
-                ["Only new words", "All words", "Review my mistakes"],
+                ["Due today", "Only new words", "All words", "Review my mistakes"],
                 horizontal=True,
                 key="vt_mode",
             )
-            if mode == "Only new words":
+            due_pairs = [item.pair for item in due_items]
+            if mode == "Due today":
+                session_vocab = due_pairs.copy()
+            elif mode == "Only new words":
                 session_vocab = not_done.copy()
             elif mode == "Review my mistakes":
                 session_vocab = [
@@ -109,7 +177,9 @@ def render_vocab_practice(student_code: str, level: str) -> None:
                 session_vocab = items.copy()
             max_count = len(session_vocab)
             if max_count == 0:
-                if mode == "Review my mistakes":
+                if mode == "Due today":
+                    st.success("🎉 Nothing due today! Try another mode.")
+                elif mode == "Review my mistakes":
                     st.success("🎉 No recorded mistakes to review. Try another mode.")
                 elif mode == "Only new words":
                     st.success("🎉 All done! Switch to 'All words' to repeat.")
@@ -125,7 +195,8 @@ def render_vocab_practice(student_code: str, level: str) -> None:
             )
             submitted = st.form_submit_button("Start")
         if submitted:
-            random.shuffle(session_vocab)
+            if mode != "Due today":
+                random.shuffle(session_vocab)
             st.session_state.vt_list = session_vocab[:count]
             st.session_state.vt_total = count
             st.session_state.vt_index = 0
@@ -227,6 +298,10 @@ def render_vocab_practice(student_code: str, level: str) -> None:
             if not st.session_state.get("vt_session_id"):
                 st.session_state.vt_session_id = str(uuid4())
             if not vocab_attempt_exists(student_code, st.session_state.vt_session_id):
+                schedule_updates = schedule_manager.record_session(
+                    practiced_words=words,
+                    incorrect_words=st.session_state.get("vt_incorrect", []),
+                )
                 save_vocab_attempt(
                     student_code=student_code,
                     level=level,
@@ -235,6 +310,7 @@ def render_vocab_practice(student_code: str, level: str) -> None:
                     practiced_words=words,
                     session_id=st.session_state.vt_session_id,
                     incorrect_words=st.session_state.get("vt_incorrect", []),
+                    schedule_updates=schedule_updates,
                 )
             st.session_state.vt_saved = True
             refresh_with_toast()

--- a/src/vocab/scheduler.py
+++ b/src/vocab/scheduler.py
@@ -1,0 +1,222 @@
+"""Helpers for spaced-repetition style vocabulary scheduling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from src.stats import update_vocab_schedule
+
+DEFAULT_EASE = 2.5
+MIN_EASE = 1.3
+EASE_INCREMENT = 0.1
+EASE_PENALTY = 0.2
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat(timespec="seconds")
+
+
+def _default_state() -> Dict[str, object]:
+    return {
+        "ease": DEFAULT_EASE,
+        "interval": 0,
+        "repetitions": 0,
+        "last_review": None,
+        "next_due": None,
+        "last_result": None,
+    }
+
+
+def _normalise_state(raw: Optional[Dict[str, object]]) -> Dict[str, object]:
+    state = _default_state()
+    if not raw:
+        return state
+    for key in state:
+        if key in raw:
+            state[key] = raw[key]
+    return state
+
+
+def _compute_next_state(
+    state: Dict[str, object],
+    *,
+    correct: bool,
+    now: datetime,
+) -> Dict[str, object]:
+    ease = float(state.get("ease", DEFAULT_EASE) or DEFAULT_EASE)
+    interval = int(state.get("interval", 0) or 0)
+    repetitions = int(state.get("repetitions", 0) or 0)
+
+    if correct:
+        repetitions += 1
+        ease = max(MIN_EASE, ease + EASE_INCREMENT)
+        if interval == 0:
+            interval = 1
+        elif interval == 1:
+            interval = 3
+        else:
+            interval = max(1, int(round(interval * ease)))
+    else:
+        repetitions = 0
+        ease = max(MIN_EASE, ease - EASE_PENALTY)
+        interval = 1
+
+    next_due = now + timedelta(days=interval)
+
+    return {
+        "ease": round(ease, 3),
+        "interval": int(interval),
+        "repetitions": int(repetitions),
+        "last_review": _format_datetime(now),
+        "next_due": _format_datetime(next_due),
+        "last_result": "correct" if correct else "incorrect",
+    }
+
+
+@dataclass
+class DueItem:
+    pair: Tuple[str, str]
+    due_at: datetime
+
+
+class VocabScheduleManager:
+    """Manage spaced-repetition scheduling for vocab practice."""
+
+    def __init__(
+        self,
+        student_code: str,
+        schedule: Optional[Dict[str, Dict[str, object]]] = None,
+        *,
+        now: Optional[datetime] = None,
+    ) -> None:
+        self.student_code = student_code
+        self.now = (now or _utc_now()).astimezone(timezone.utc)
+        raw = schedule or {}
+        self.schedule: Dict[str, Dict[str, object]] = {
+            str(word): _normalise_state(payload)
+            for word, payload in raw.items()
+            if str(word).strip()
+        }
+
+    # ------------------------------------------------------------------
+    # Derived properties
+    # ------------------------------------------------------------------
+    @property
+    def known_words(self) -> Sequence[str]:
+        return tuple(sorted(self.schedule.keys()))
+
+    def due_items(self, items: Iterable[Tuple[str, str]]) -> List[DueItem]:
+        results: List[DueItem] = []
+        for pair in items:
+            word = str(pair[0])
+            state = self.schedule.get(word)
+            if not state:
+                continue
+            due_at = _parse_datetime(state.get("next_due"))
+            if due_at and due_at <= self.now:
+                results.append(DueItem(pair=pair, due_at=due_at))
+        results.sort(key=lambda item: item.due_at)
+        return results
+
+    def next_due_after_now(self) -> Optional[str]:
+        upcoming: List[datetime] = []
+        for state in self.schedule.values():
+            due_at = _parse_datetime(state.get("next_due"))
+            if due_at and due_at > self.now:
+                upcoming.append(due_at)
+        if not upcoming:
+            return None
+        upcoming.sort()
+        return _format_datetime(upcoming[0])
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+    def record_session(
+        self,
+        practiced_words: Iterable[str],
+        incorrect_words: Iterable[str],
+    ) -> Dict[str, Dict[str, object]]:
+        updates: Dict[str, Dict[str, object]] = {}
+        incorrect_set = {str(word) for word in incorrect_words}
+        for word in practiced_words:
+            key = str(word)
+            if not key:
+                continue
+            state = self.schedule.get(key, _default_state())
+            updated = _compute_next_state(
+                state,
+                correct=key not in incorrect_set,
+                now=self.now,
+            )
+            updates[key] = updated
+            self.schedule[key] = updated
+        return updates
+
+    def snooze_cards(
+        self,
+        words: Sequence[str],
+        *,
+        days: int = 1,
+    ) -> Dict[str, Dict[str, object]]:
+        if days < 1:
+            days = 1
+        updates: Dict[str, Dict[str, object]] = {}
+        delta = timedelta(days=days)
+        for raw_word in words:
+            word = str(raw_word)
+            if not word:
+                continue
+            state = self.schedule.get(word, _default_state()).copy()
+            base_due = _parse_datetime(state.get("next_due")) or self.now
+            new_due = base_due + delta
+            state.setdefault("ease", DEFAULT_EASE)
+            state.setdefault("interval", max(int(state.get("interval", 1) or 1), 1))
+            state.setdefault("repetitions", int(state.get("repetitions", 0) or 0))
+            state["next_due"] = _format_datetime(new_due)
+            updates[word] = state
+            self.schedule[word] = state
+        return updates
+
+    def reset_cards(self, words: Sequence[str]) -> Dict[str, Optional[Dict[str, object]]]:
+        updates: Dict[str, Optional[Dict[str, object]]] = {}
+        for raw_word in words:
+            word = str(raw_word)
+            if not word:
+                continue
+            updates[word] = None
+            self.schedule.pop(word, None)
+        return updates
+
+    def persist_updates(
+        self, updates: Dict[str, Optional[Dict[str, object]]]
+    ) -> None:
+        if not updates:
+            return
+        update_vocab_schedule(self.student_code, updates)
+
+
+__all__ = [
+    "DEFAULT_EASE",
+    "MIN_EASE",
+    "VocabScheduleManager",
+    "DueItem",
+]

--- a/tests/test_vocab_scheduler.py
+++ b/tests/test_vocab_scheduler.py
@@ -1,0 +1,156 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src import stats
+from src.vocab.scheduler import VocabScheduleManager
+
+
+class StubDoc:
+    def __init__(self, store, student):
+        self._store = store
+        self._student = student
+        self.exists = student in store
+
+    def to_dict(self):
+        if self._student not in self._store:
+            return {}
+        return dict(self._store[self._student])
+
+
+class StubDocRef:
+    def __init__(self, store, student):
+        self._store = store
+        self._student = student
+        self.saved_payloads = []
+
+    def get(self):
+        return StubDoc(self._store, self._student)
+
+    def set(self, payload, merge=True):
+        self.saved_payloads.append(payload)
+        existing = self._store.get(self._student, {}) if merge else {}
+        updated = _deep_merge(existing, payload) if merge else dict(payload)
+        self._store[self._student] = updated
+
+
+class StubCollection:
+    def __init__(self, store):
+        self._store = store
+
+    def document(self, student):
+        return StubDocRef(self._store, student)
+
+
+class StubDB:
+    def __init__(self):
+        self._collections = {}
+
+    def collection(self, name):
+        coll_store = self._collections.setdefault(name, {})
+        return StubCollection(coll_store)
+
+
+def _deep_merge(target, update):
+    result = dict(target)
+    for key, value in update.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+@pytest.fixture
+def fixed_now():
+    return datetime(2024, 1, 1, 9, 0, tzinfo=timezone.utc)
+
+
+def test_record_session_updates_intervals(fixed_now):
+    manager = VocabScheduleManager("stu", schedule={}, now=fixed_now)
+
+    first = manager.record_session(["Hund"], [])
+    hund_state = first["Hund"]
+    assert hund_state["interval"] == 1
+    assert hund_state["repetitions"] == 1
+    assert hund_state["last_result"] == "correct"
+    next_due = datetime.fromisoformat(hund_state["next_due"])
+    assert next_due.date() == (fixed_now + timedelta(days=1)).date()
+
+    manager2 = VocabScheduleManager(
+        "stu",
+        schedule={"Hund": hund_state},
+        now=fixed_now + timedelta(days=2),
+    )
+    second = manager2.record_session(["Hund"], [])
+    hund_state2 = second["Hund"]
+    assert hund_state2["interval"] >= 3
+    assert hund_state2["repetitions"] == 2
+
+    manager3 = VocabScheduleManager(
+        "stu",
+        schedule={"Hund": hund_state2},
+        now=fixed_now + timedelta(days=5),
+    )
+    third = manager3.record_session(["Hund"], ["Hund"])
+    hund_state3 = third["Hund"]
+    assert hund_state3["interval"] == 1
+    assert hund_state3["repetitions"] == 0
+    assert hund_state3["last_result"] == "incorrect"
+
+
+def test_snooze_and_reset_cards(fixed_now):
+    existing = {
+        "Hund": {
+            "ease": 2.5,
+            "interval": 2,
+            "repetitions": 1,
+            "last_review": fixed_now.isoformat(),
+            "next_due": (fixed_now + timedelta(days=1)).isoformat(),
+            "last_result": "correct",
+        }
+    }
+    manager = VocabScheduleManager("stu", schedule=existing, now=fixed_now)
+
+    snoozed = manager.snooze_cards(["Hund"], days=3)
+    new_due = datetime.fromisoformat(snoozed["Hund"]["next_due"])
+    assert new_due.date() == (fixed_now + timedelta(days=4)).date()
+
+    resets = manager.reset_cards(["Hund"])
+    assert resets["Hund"] is None
+    assert "Hund" not in manager.known_words
+
+
+def test_save_vocab_attempt_persists_schedule(fixed_now):
+    stub_db = StubDB()
+    stats.db = stub_db  # type: ignore[attr-defined]
+
+    student = "stu"
+    schedule_update = {
+        "Hund": {
+            "ease": 2.6,
+            "interval": 3,
+            "repetitions": 2,
+            "last_review": fixed_now.isoformat(),
+            "next_due": (fixed_now + timedelta(days=3)).isoformat(),
+            "last_result": "correct",
+        }
+    }
+
+    stats.save_vocab_attempt(
+        student_code=student,
+        level="A1",
+        total=2,
+        correct=1,
+        practiced_words=["Hund", "Katze"],
+        session_id="sess-1",
+        incorrect_words=["Katze"],
+        schedule_updates=schedule_update,
+    )
+
+    stored = stub_db.collection("vocab_stats")._store[student]
+    assert stored["history"]
+    assert stored["schedule"]["Hund"]["interval"] == 3
+    assert stored["incorrect_words"] == ["Katze"]
+
+    stats.db = None  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- persist per-word scheduling metadata in vocab stats including schedule updates
- add a scheduler helper and wire the practice flow to the due queue with snooze/reset controls
- cover scheduling calculations with dedicated tests

## Testing
- pytest tests/test_vocab_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68de949c8a9c8321b2457e11f80831a8