### PR TITLE
Fix connector mode reset on session clear

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -7318,7 +7318,7 @@ if tab == "Chat • Grammar • Exams":
                 st.session_state.pop(KEY_CONN_TEXT, None)
                 st.session_state.pop(KEY_CONN_SCENARIO, None)
                 st.session_state.pop(KEY_CONN_RESPONSE, None)
-                st.session_state[KEY_CONN_MODE] = "I'll choose connectors"
+                st.session_state.pop(KEY_CONN_MODE, None)
                 suggestion_placeholder.empty()
                 coach_response_placeholder.empty()
                 rerun_fn = getattr(st, "experimental_rerun", None) or getattr(st, "rerun", None)


### PR DESCRIPTION
## Summary
- clear the connector mode radio session key when resetting the connectors tab
- ensure the radio falls back to its default option after clearing the session

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e25db717788321a485ab935ff57fb5