### PR TITLE
Restore Letter Coach draft metadata initialization

### DIFF
--- a/a1sprechen.py
+++ b/a1sprechen.py
@@ -8802,12 +8802,11 @@ if tab == "Schreiben Trainer":
                 st.session_state["need_rerun"] = True
             st.markdown("### ✏️ Enter your exam prompt or draft to start coaching")
             draft_key = ns("prompt_draft")
-            if draft_key not in st.session_state:
-                st.session_state[draft_key] = load_draft_from_db(student_code, draft_key)
+            initialize_draft_state(student_code, draft_key)
 
-            
+
             if st.session_state.pop(ns("clear_prompt"), False):
-                st.session_state[draft_key] = ""
+                reset_local_draft_state(draft_key, "")
                 save_now(draft_key, student_code)
 
             prompt = st.text_area(
@@ -8921,15 +8920,15 @@ if tab == "Schreiben Trainer":
 
 
             draft_key = ns("chat_draft")
-            if draft_key not in st.session_state:
-                st.session_state[draft_key] = load_draft_from_db(student_code, draft_key)
+            initialize_draft_state(student_code, draft_key)
 
-            
+
             if st.session_state.pop(ns("clear_chat_draft"), False):
-                st.session_state[draft_key] = ""
+                reset_local_draft_state(draft_key, "")
+                save_now(draft_key, student_code, show_toast=False)
 
             if st.session_state.pop(ns("clear_chat"), False):
-                st.session_state[draft_key] = ""
+                reset_local_draft_state(draft_key, "")
                 save_now(draft_key, student_code, show_toast=False)
 
             st.text_area(


### PR DESCRIPTION
## Summary
- use `initialize_draft_state` for Letter Coach prompt and chat drafts so saved text metadata is restored from Firestore
- reset local draft metadata when clearing prompt or chat drafts to keep saved timestamps aligned with the cleared content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2a96982588321b66a8cfadcee5f68