### PR TITLE
Add brain-map prompt bank and coaching prompts

### DIFF
--- a/src/prompt_bank.py
+++ b/src/prompt_bank.py
@@ -1,0 +1,181 @@
+"""Prompt bank utilities for brain-map style scaffolds and AI coaching prompts."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from textwrap import dedent
+from typing import Dict, List, Sequence
+
+_yaml_spec = importlib.util.find_spec("yaml")
+if _yaml_spec:
+    import yaml  # type: ignore
+else:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+
+BRAIN_MAP_SCAFFOLDS: List[Dict[str, object]] = [
+    {
+        "theme": "Alltag & Termine",
+        "situation": "Einen Arzttermin kurz nach der Arbeit vereinbaren",
+        "bullet_outline": [
+            "Beschreiben Sie in einem Satz Ihr Hauptsymptom.",
+            "Bitten Sie um einen Termin nach 17:00 Uhr und schlagen Sie einen Tag vor.",
+            "Fragen Sie, ob Sie Unterlagen oder Medikamente mitbringen sollen.",
+        ],
+        "target_functions": [
+            "Terminvereinbarung", "Zeit aushandeln", "Höflich um Hinweise bitten"
+        ],
+    },
+    {
+        "theme": "Wohnen & Nachbarschaft",
+        "situation": "Lärmproblem im Mehrfamilienhaus klären",
+        "bullet_outline": [
+            "Beschreiben Sie höflich, wann und wie oft der Lärm auftritt.",
+            "Schlagen Sie eine Lösung oder ruhige Zeiten vor.",
+            "Bitten Sie um Rückmeldung und bedanken Sie sich.",
+        ],
+        "target_functions": [
+            "Beschwerden formulieren", "Vorschläge machen", "Rückmeldung einholen"
+        ],
+    },
+    {
+        "theme": "Arbeit & Projekte",
+        "situation": "Eine Kollegin um Unterstützung bei einer Präsentation bitten",
+        "bullet_outline": [
+            "Nennen Sie das Thema und das Datum der Präsentation.",
+            "Fragen Sie konkret nach Hilfe (z. B. Folien prüfen, Feedback geben).",
+            "Erklären Sie kurz, warum ihre Perspektive wichtig ist.",
+        ],
+        "target_functions": [
+            "Um Hilfe bitten", "Aufgaben beschreiben", "Begründungen geben"
+        ],
+    },
+    {
+        "theme": "Reisen & Orientierung",
+        "situation": "Eine Zugverbindung mit Umstieg planen",
+        "bullet_outline": [
+            "Sagen Sie Start- und Zielbahnhof sowie das gewünschte Datum.",
+            "Fragen Sie nach der besten Umstiegsoption und Pufferzeiten.",
+            "Klären Sie Tickettyp, Sitzplatzwunsch und eventuelle Rabatte.",
+        ],
+        "target_functions": [
+            "Informationen erfragen", "Optionen vergleichen", "Kaufentscheidungen treffen"
+        ],
+    },
+    {
+        "theme": "Studium & Kurse",
+        "situation": "Einen Kurswechsel mit der Studienberatung besprechen",
+        "bullet_outline": [
+            "Nennen Sie den aktuellen Kurs und den gewünschten Kurs.",
+            "Erklären Sie kurz, warum der Wechsel notwendig oder hilfreich ist.",
+            "Fragen Sie nach freien Plätzen und nächsten Schritten.",
+        ],
+        "target_functions": [
+            "Argumentieren", "Nach Verfügbarkeit fragen", "Verbindliche Schritte klären"
+        ],
+    },
+]
+
+DEFAULT_RUBRIC: Dict[str, str] = {
+    "Aufgabenbewältigung": "Erfüllt der Text alle Stichpunkte der Brain-Map-Situation?",
+    "Kohärenz & Organisation": "Logischer Aufbau mit klaren Übergängen und Absätzen?",
+    "Lexik": "Passender Wortschatz, Kollokationen und Register für die Situation?",
+    "Grammatik & Struktur": "Sichere Satzstrukturen, Verbzweitstellung und Nebensätze?",
+    "Fluss & Diskursmarker": "Nutzt Konnektoren (z. B. außerdem, jedoch, danach) für flüssiges Lesen?",
+}
+
+
+def brain_map_prompts_as_json(scaffolds: Sequence[Dict[str, object]] | None = None) -> str:
+    """Return the brain-map prompt bank as pretty-printed JSON."""
+
+    data = list(scaffolds) if scaffolds is not None else BRAIN_MAP_SCAFFOLDS
+    return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+def brain_map_prompts_as_yaml(scaffolds: Sequence[Dict[str, object]] | None = None) -> str:
+    """Return the brain-map prompt bank as YAML if available, else JSON fallback."""
+
+    data = list(scaffolds) if scaffolds is not None else BRAIN_MAP_SCAFFOLDS
+    if yaml is None:
+        return brain_map_prompts_as_json(data)
+    return yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
+
+
+def build_plan_prompt(scaffold: Dict[str, object]) -> str:
+    """Build a prompt that elicits a concise plan before writing."""
+
+    outline = "\n- ".join([""] + list(scaffold.get("bullet_outline", [])))
+    return dedent(
+        f"""
+        You are a German writing coach. Read the brain-map scaffold and propose a
+        brief plan (max 4 sentences) the learner will follow before drafting.
+
+        Theme: {scaffold.get('theme')}
+        Situation: {scaffold.get('situation')}
+        Bullet outline:{outline}
+        Target functions: {', '.join(scaffold.get('target_functions', []))}
+
+        Output:
+        - 1–2 guiding questions the learner should answer.
+        - A concise action plan with ordering and time-boxed steps.
+        - One tip to keep vocabulary and grammar aligned with the CEFR level.
+        """
+    ).strip()
+
+
+def build_interlocutor_prompt(scaffold: Dict[str, object]) -> str:
+    """Build a prompt that simulates an interlocutor with focused follow-ups."""
+
+    return dedent(
+        f"""
+        Act as a succinct German interlocutor for the scenario below. Ask 3–4
+        follow-up questions total, one at a time, staying within the theme and
+        target functions. Keep language at the learner's CEFR level and avoid
+        long explanations.
+
+        Theme: {scaffold.get('theme')}
+        Situation: {scaffold.get('situation')}
+        Target functions: {', '.join(scaffold.get('target_functions', []))}
+
+        Each turn:
+        - Ask exactly one question that advances the bullet outline.
+        - Offer one micro-prompt if the learner hesitates.
+        - Track which bullet points are already covered.
+        """
+    ).strip()
+
+
+def build_feedback_prompt(scaffold: Dict[str, object]) -> str:
+    """Build a rubric-driven feedback prompt with CEFR scoring and reflection."""
+
+    rubric_lines = "\n".join([f"- {k}: {v}" for k, v in DEFAULT_RUBRIC.items()])
+    return dedent(
+        f"""
+        You are an examiner providing rubric-based feedback for the writing task.
+        Use the brain-map scaffold to judge completeness, then return:
+        1) A CEFR-aligned score (A1–C2) plus a 0–100 numeric score.
+        2) A brief justification referencing the bullet outline and target functions.
+        3) A structured rubric summary using the categories below.
+        4) Reflection: suggest 2–3 concrete upgrades — one lexical, one syntactic,
+           and one with discourse markers — plus a mini-drill where the learner
+           rewrites a key sentence in two varied ways.
+
+        Theme: {scaffold.get('theme')}
+        Situation: {scaffold.get('situation')}
+        Bullet outline: {', '.join(scaffold.get('bullet_outline', []))}
+        Target functions: {', '.join(scaffold.get('target_functions', []))}
+
+        Rubric:
+        {rubric_lines}
+
+        Output format:
+        - <score>CEFR level – numeric/100</score>
+        - <justification>2–3 sentences grounded in the scaffold</justification>
+        - <rubric_notes>bulleted notes per category</rubric_notes>
+        - <reflection>
+            • Upgrade (lexical)
+            • Upgrade (syntax)
+            • Upgrade (discourse marker)
+            • Mini-drill: repeat one key sentence with two variations
+          </reflection>
+        """
+    ).strip()

--- a/static/brain_map_prompt_bank.json
+++ b/static/brain_map_prompt_bank.json
@@ -1,0 +1,72 @@
+[
+  {
+    "theme": "Alltag & Termine",
+    "situation": "Einen Arzttermin kurz nach der Arbeit vereinbaren",
+    "bullet_outline": [
+      "Beschreiben Sie in einem Satz Ihr Hauptsymptom.",
+      "Bitten Sie um einen Termin nach 17:00 Uhr und schlagen Sie einen Tag vor.",
+      "Fragen Sie, ob Sie Unterlagen oder Medikamente mitbringen sollen."
+    ],
+    "target_functions": [
+      "Terminvereinbarung",
+      "Zeit aushandeln",
+      "Höflich um Hinweise bitten"
+    ]
+  },
+  {
+    "theme": "Wohnen & Nachbarschaft",
+    "situation": "Lärmproblem im Mehrfamilienhaus klären",
+    "bullet_outline": [
+      "Beschreiben Sie höflich, wann und wie oft der Lärm auftritt.",
+      "Schlagen Sie eine Lösung oder ruhige Zeiten vor.",
+      "Bitten Sie um Rückmeldung und bedanken Sie sich."
+    ],
+    "target_functions": [
+      "Beschwerden formulieren",
+      "Vorschläge machen",
+      "Rückmeldung einholen"
+    ]
+  },
+  {
+    "theme": "Arbeit & Projekte",
+    "situation": "Eine Kollegin um Unterstützung bei einer Präsentation bitten",
+    "bullet_outline": [
+      "Nennen Sie das Thema und das Datum der Präsentation.",
+      "Fragen Sie konkret nach Hilfe (z. B. Folien prüfen, Feedback geben).",
+      "Erklären Sie kurz, warum ihre Perspektive wichtig ist."
+    ],
+    "target_functions": [
+      "Um Hilfe bitten",
+      "Aufgaben beschreiben",
+      "Begründungen geben"
+    ]
+  },
+  {
+    "theme": "Reisen & Orientierung",
+    "situation": "Eine Zugverbindung mit Umstieg planen",
+    "bullet_outline": [
+      "Sagen Sie Start- und Zielbahnhof sowie das gewünschte Datum.",
+      "Fragen Sie nach der besten Umstiegsoption und Pufferzeiten.",
+      "Klären Sie Tickettyp, Sitzplatzwunsch und eventuelle Rabatte."
+    ],
+    "target_functions": [
+      "Informationen erfragen",
+      "Optionen vergleichen",
+      "Kaufentscheidungen treffen"
+    ]
+  },
+  {
+    "theme": "Studium & Kurse",
+    "situation": "Einen Kurswechsel mit der Studienberatung besprechen",
+    "bullet_outline": [
+      "Nennen Sie den aktuellen Kurs und den gewünschten Kurs.",
+      "Erklären Sie kurz, warum der Wechsel notwendig oder hilfreich ist.",
+      "Fragen Sie nach freien Plätzen und nächsten Schritten."
+    ],
+    "target_functions": [
+      "Argumentieren",
+      "Nach Verfügbarkeit fragen",
+      "Verbindliche Schritte klären"
+    ]
+  }
+]

--- a/static/brain_map_prompt_bank.yaml
+++ b/static/brain_map_prompt_bank.yaml
@@ -1,0 +1,72 @@
+[
+  {
+    "theme": "Alltag & Termine",
+    "situation": "Einen Arzttermin kurz nach der Arbeit vereinbaren",
+    "bullet_outline": [
+      "Beschreiben Sie in einem Satz Ihr Hauptsymptom.",
+      "Bitten Sie um einen Termin nach 17:00 Uhr und schlagen Sie einen Tag vor.",
+      "Fragen Sie, ob Sie Unterlagen oder Medikamente mitbringen sollen."
+    ],
+    "target_functions": [
+      "Terminvereinbarung",
+      "Zeit aushandeln",
+      "Höflich um Hinweise bitten"
+    ]
+  },
+  {
+    "theme": "Wohnen & Nachbarschaft",
+    "situation": "Lärmproblem im Mehrfamilienhaus klären",
+    "bullet_outline": [
+      "Beschreiben Sie höflich, wann und wie oft der Lärm auftritt.",
+      "Schlagen Sie eine Lösung oder ruhige Zeiten vor.",
+      "Bitten Sie um Rückmeldung und bedanken Sie sich."
+    ],
+    "target_functions": [
+      "Beschwerden formulieren",
+      "Vorschläge machen",
+      "Rückmeldung einholen"
+    ]
+  },
+  {
+    "theme": "Arbeit & Projekte",
+    "situation": "Eine Kollegin um Unterstützung bei einer Präsentation bitten",
+    "bullet_outline": [
+      "Nennen Sie das Thema und das Datum der Präsentation.",
+      "Fragen Sie konkret nach Hilfe (z. B. Folien prüfen, Feedback geben).",
+      "Erklären Sie kurz, warum ihre Perspektive wichtig ist."
+    ],
+    "target_functions": [
+      "Um Hilfe bitten",
+      "Aufgaben beschreiben",
+      "Begründungen geben"
+    ]
+  },
+  {
+    "theme": "Reisen & Orientierung",
+    "situation": "Eine Zugverbindung mit Umstieg planen",
+    "bullet_outline": [
+      "Sagen Sie Start- und Zielbahnhof sowie das gewünschte Datum.",
+      "Fragen Sie nach der besten Umstiegsoption und Pufferzeiten.",
+      "Klären Sie Tickettyp, Sitzplatzwunsch und eventuelle Rabatte."
+    ],
+    "target_functions": [
+      "Informationen erfragen",
+      "Optionen vergleichen",
+      "Kaufentscheidungen treffen"
+    ]
+  },
+  {
+    "theme": "Studium & Kurse",
+    "situation": "Einen Kurswechsel mit der Studienberatung besprechen",
+    "bullet_outline": [
+      "Nennen Sie den aktuellen Kurs und den gewünschten Kurs.",
+      "Erklären Sie kurz, warum der Wechsel notwendig oder hilfreich ist.",
+      "Fragen Sie nach freien Plätzen und nächsten Schritten."
+    ],
+    "target_functions": [
+      "Argumentieren",
+      "Nach Verfügbarkeit fragen",
+      "Verbindliche Schritte klären"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add brain-map scaffold data and helper prompts for planning, interlocutor turns, and rubric-based feedback with reflection drills
- export the scaffold bank to JSON and YAML assets for reuse

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8fa5abb08322b9946e817999d3a8)